### PR TITLE
Scale down feature

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = "6b6c93f799633df46ba180c110abe0af8aa3efb9cde3e1882883a9b12987c1ec"
+memo = "5547c5a3065909c909fa68c6328351cfc088a2736fe847b054955245972fb8c9"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = "1107a1891bd511e31de4f230e9a48603699278ca925067076cdebee28b8d877a"
+memo = "6b6c93f799633df46ba180c110abe0af8aa3efb9cde3e1882883a9b12987c1ec"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1,4 +1,4 @@
-memo = "5547c5a3065909c909fa68c6328351cfc088a2736fe847b054955245972fb8c9"
+memo = "486eea1fb4752688896c1920e7b3e1c3ac99f1b87fca7b39a65316bc8882513b"
 
 [[projects]]
   branch = "master"
@@ -285,8 +285,8 @@ memo = "5547c5a3065909c909fa68c6328351cfc088a2736fe847b054955245972fb8c9"
 [[projects]]
   name = "github.com/topfreegames/extensions"
   packages = ["pg","pg/interfaces","pg/mocks","redis","redis/interfaces","redis/mocks"]
-  revision = "f22266dd30886af073db9c84fefd1188bf2f8e3b"
-  version = "v2.5.2"
+  revision = "a52da04dfd4528d888efae8562ffe76d6d98facb"
+  version = "v2.5.3"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -85,7 +85,7 @@
 
 [[dependencies]]
   name = "github.com/topfreegames/extensions"
-  version = "v2.5.2"
+  version = "v2.5.3"
 
 [[dependencies]]
   name = "github.com/go-redis/redis"

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -20,6 +20,7 @@ worker:
   syncPeriod: 10
   gracefulShutdownTimeout: 300
 scaleUpTimeoutSeconds: 300
+scaleDownTimeoutSeconds: 300
 deleteTimeoutSeconds: 150
 pingTimeout: 30
 sentry:

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -135,8 +135,11 @@ func GetSchedulerScalingInfo(logger logrus.FieldLogger, mr *models.MixedMetricsR
 	err := mr.WithSegment(models.SegmentSelect, func() error {
 		return scheduler.Load(db)
 	})
+
 	if err != nil {
 		return nil, nil, nil, err
+	} else if scheduler.YAML == "" {
+		return nil, nil, nil, fmt.Errorf("scheduler \"%s\" not found", schedulerName)
 	}
 	scalingPolicy := scheduler.GetAutoScalingPolicy()
 	var roomCountByStatus *models.RoomsStatusCount
@@ -258,6 +261,80 @@ func ScaleUp(logger logrus.FieldLogger, mr *models.MixedMetricsReporter, db pgin
 	return creationErr
 }
 
+func ScaleDown(logger logrus.FieldLogger, mr *models.MixedMetricsReporter, db pginterfaces.DB, redisClient redisinterfaces.RedisClient, clientset kubernetes.Interface, scheduler *models.Scheduler, amount, timeoutSec int) error {
+	l := logger.WithFields(logrus.Fields{
+		"source":    "scaleDown",
+		"scheduler": scheduler.Name,
+		"amount":    amount,
+	})
+	timeout := make(chan bool, 1)
+	go func() {
+		time.Sleep(time.Duration(timeoutSec) * time.Second)
+		timeout <- true
+	}()
+
+	l.Debug("accessing redis")
+	pipe := redisClient.TxPipeline()
+	sReady := pipe.SPopN(models.GetRoomStatusSetRedisKey(scheduler.Name, models.StatusReady), int64(amount))
+	_, err := pipe.Exec()
+	if err != nil {
+		l.WithError(err).Error("scale down error")
+		return err
+	}
+
+	idleRooms, err := sReady.Result()
+	if err != nil {
+		l.WithError(err).Error("scale down error")
+		return err
+	}
+
+	for i, key := range idleRooms {
+		pieces := strings.Split(key, ":")
+		name := pieces[len(pieces)-1]
+		idleRooms[i] = name
+	}
+
+	var deletionErr error
+
+	for _, roomName := range idleRooms {
+		err := deleteServiceAndPod(logger, mr, clientset, scheduler.Name, roomName)
+		if err != nil {
+			logger.WithField("roomName", roomName).WithError(err).Error("error deleting room")
+			deletionErr = err
+		} else {
+			room := models.NewRoom(roomName, scheduler.Name)
+			err := room.ClearAll(redisClient)
+			if err != nil {
+				logger.WithField("roomName", roomName).WithError(err).Error("error removing room info from redis")
+				return err
+			}
+		}
+	}
+
+	for {
+		exit := true
+		select {
+		case <-timeout:
+			return errors.New("timeout scaling down scheduler")
+		default:
+			for _, name := range idleRooms {
+				_, err := clientset.CoreV1().Pods(scheduler.Name).Get(name, metav1.GetOptions{})
+				if err == nil || !strings.Contains(err.Error(), "not found") {
+					exit = false
+				} else {
+					l.WithError(err).Error("scale down pod error")
+				}
+			}
+		}
+		if exit {
+			l.Info("finished scaling down scheduler")
+			break
+		}
+	}
+
+	return deletionErr
+}
+
 func deleteSchedulerHelper(logger logrus.FieldLogger, mr *models.MixedMetricsReporter, db pginterfaces.DB, clientset kubernetes.Interface, scheduler *models.Scheduler, namespace *models.Namespace, timeoutSec int) error {
 	var err error
 	if scheduler.ID != "" {
@@ -270,6 +347,14 @@ func deleteSchedulerHelper(logger logrus.FieldLogger, mr *models.MixedMetricsRep
 			logger.WithError(err).Error("failed to update scheduler state")
 			return err
 		}
+	}
+
+	err = mr.WithSegment(models.SegmentDelete, func() error {
+		return scheduler.Delete(db)
+	})
+	if err != nil {
+		logger.WithError(err).Error("failed to delete scheduler from database while deleting scheduler")
+		return err
 	}
 
 	configYAML, _ := models.NewConfigYAML(scheduler.YAML)
@@ -330,14 +415,6 @@ func deleteSchedulerHelper(logger logrus.FieldLogger, mr *models.MixedMetricsRep
 			logger.Debug("deleting scheduler pods")
 			time.Sleep(time.Duration(1) * time.Second)
 		}
-	}
-
-	err = mr.WithSegment(models.SegmentDelete, func() error {
-		return scheduler.Delete(db)
-	})
-	if err != nil {
-		logger.WithError(err).Error("failed to delete scheduler from database while deleting scheduler")
-		return err
 	}
 	return nil
 }

--- a/controller/controller_suite_test.go
+++ b/controller/controller_suite_test.go
@@ -33,6 +33,8 @@ var (
 	mr              *models.MixedMetricsReporter
 )
 
+var allStatus = []string{models.StatusCreating, models.StatusReady, models.StatusOccupied, models.StatusTerminating, models.StatusTerminated}
+
 func TestController(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Suite")

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -417,6 +417,16 @@ var _ = Describe("Controller", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("some error in redis"))
 		})
+
+		It("should return error if no scheduler found", func() {
+			var configYaml1 models.ConfigYAML
+			err := yaml.Unmarshal([]byte(yaml1), &configYaml1)
+			Expect(err).NotTo(HaveOccurred())
+			mockDb.EXPECT().Query(gomock.Any(), "SELECT * FROM schedulers WHERE name = ?", configYaml1.Name)
+			_, _, _, err = controller.GetSchedulerScalingInfo(logger, mr, mockDb, mockRedisClient, configYaml1.Name)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("scheduler \"controller-name\" not found"))
+		})
 	})
 
 	Describe("UpdateScheduler", func() {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -24,8 +24,8 @@ import (
 	"gopkg.in/pg.v5/types"
 	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/pkg/fields"
 )
 
 const (

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -25,6 +25,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/fields"
 )
 
 const (
@@ -709,6 +710,256 @@ var _ = Describe("Controller", func() {
 			err = controller.ScaleUp(logger, mr, mockDb, mockRedisClient, clientset, scheduler, amount, timeoutSec, true)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("timeout scaling up scheduler"))
+		})
+	})
+
+	Describe("ScaleDown", func() {
+		It("should succeed in scaling down", func() {
+			var configYaml1 models.ConfigYAML
+			err := yaml.Unmarshal([]byte(yaml1), &configYaml1)
+			Expect(err).NotTo(HaveOccurred())
+			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, yaml1)
+
+			// ScaleUp
+			scaleUpAmount := 5
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline).Times(scaleUpAmount)
+			mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(
+				func(schedulerName string, statusInfo map[string]interface{}) {
+					Expect(statusInfo["status"]).To(Equal(models.StatusCreating))
+					Expect(statusInfo["lastPing"]).To(BeNumerically("~", time.Now().Unix(), 1))
+				},
+			).Times(scaleUpAmount)
+			mockPipeline.EXPECT().ZAdd(models.GetRoomPingRedisKey(configYaml1.Name), gomock.Any()).Times(scaleUpAmount)
+			mockPipeline.EXPECT().SAdd(models.GetRoomStatusSetRedisKey(configYaml1.Name, "creating"), gomock.Any()).Times(scaleUpAmount)
+			mockPipeline.EXPECT().Exec().Times(scaleUpAmount)
+			err = controller.ScaleUp(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleUpAmount, timeoutSec, true)
+
+			// ScaleDown
+			scaleDownAmount := 2
+			names, err := controller.GetServiceNames(scaleDownAmount, scheduler.Name, clientset)
+			Expect(err).NotTo(HaveOccurred())
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().
+				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
+				Return(redis.NewStringSliceResult(names, nil))
+			mockPipeline.EXPECT().Exec()
+
+			for _, name := range names {
+				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+				room := models.NewRoom(name, scheduler.Name)
+				for _, status := range allStatus {
+					mockPipeline.EXPECT().
+						SRem(models.GetRoomStatusSetRedisKey(room.SchedulerName, status), room.GetRoomRedisKey())
+				}
+				mockPipeline.EXPECT().ZRem(models.GetRoomPingRedisKey(scheduler.Name), room.ID)
+				mockPipeline.EXPECT().Del(room.GetRoomRedisKey())
+				mockPipeline.EXPECT().Exec()
+			}
+
+			timeoutSec = 300
+			err = controller.ScaleDown(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleDownAmount, timeoutSec)
+			Expect(err).NotTo(HaveOccurred())
+			services, err := clientset.CoreV1().Services(scheduler.Name).List(metav1.ListOptions{
+				FieldSelector: fields.Everything().String(),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(services.Items).To(HaveLen(scaleUpAmount - scaleDownAmount))
+		})
+
+		It("should return error if redis fails to clear room statuses", func() {
+			var configYaml1 models.ConfigYAML
+			err := yaml.Unmarshal([]byte(yaml1), &configYaml1)
+			Expect(err).NotTo(HaveOccurred())
+			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, yaml1)
+
+			// ScaleUp
+			scaleUpAmount := 5
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline).Times(scaleUpAmount)
+			mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(
+				func(schedulerName string, statusInfo map[string]interface{}) {
+					Expect(statusInfo["status"]).To(Equal(models.StatusCreating))
+					Expect(statusInfo["lastPing"]).To(BeNumerically("~", time.Now().Unix(), 1))
+				},
+			).Times(scaleUpAmount)
+			mockPipeline.EXPECT().ZAdd(models.GetRoomPingRedisKey(configYaml1.Name), gomock.Any()).Times(scaleUpAmount)
+			mockPipeline.EXPECT().SAdd(models.GetRoomStatusSetRedisKey(configYaml1.Name, "creating"), gomock.Any()).Times(scaleUpAmount)
+			mockPipeline.EXPECT().Exec().Times(scaleUpAmount)
+			err = controller.ScaleUp(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleUpAmount, timeoutSec, true)
+
+			// ScaleDown
+			scaleDownAmount := 2
+			names, err := controller.GetServiceNames(scaleDownAmount, scheduler.Name, clientset)
+			Expect(err).NotTo(HaveOccurred())
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().
+				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
+				Return(redis.NewStringSliceResult(names, nil))
+			mockPipeline.EXPECT().Exec()
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			room := models.NewRoom(names[0], scheduler.Name)
+			for _, status := range allStatus {
+				mockPipeline.EXPECT().
+					SRem(models.GetRoomStatusSetRedisKey(room.SchedulerName, status), room.GetRoomRedisKey())
+			}
+			mockPipeline.EXPECT().ZRem(models.GetRoomPingRedisKey(scheduler.Name), room.ID)
+			mockPipeline.EXPECT().Del(room.GetRoomRedisKey())
+			mockPipeline.EXPECT().Exec().Return([]redis.Cmder{}, errors.New("some error in redis"))
+
+			timeoutSec = 0
+			err = controller.ScaleDown(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleDownAmount, timeoutSec)
+			Expect(err).To(HaveOccurred())
+			services, err := clientset.CoreV1().Services(scheduler.Name).List(metav1.ListOptions{
+				FieldSelector: fields.Everything().String(),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(services.Items).To(HaveLen(scaleUpAmount - 1))
+		})
+
+		It("should return error if redis fails to get N ready rooms", func() {
+			var configYaml1 models.ConfigYAML
+			err := yaml.Unmarshal([]byte(yaml1), &configYaml1)
+			Expect(err).NotTo(HaveOccurred())
+			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, yaml1)
+
+			// ScaleUp
+			scaleUpAmount := 5
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline).Times(scaleUpAmount)
+			mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(
+				func(schedulerName string, statusInfo map[string]interface{}) {
+					Expect(statusInfo["status"]).To(Equal(models.StatusCreating))
+					Expect(statusInfo["lastPing"]).To(BeNumerically("~", time.Now().Unix(), 1))
+				},
+			).Times(scaleUpAmount)
+			mockPipeline.EXPECT().ZAdd(models.GetRoomPingRedisKey(configYaml1.Name), gomock.Any()).Times(scaleUpAmount)
+			mockPipeline.EXPECT().SAdd(models.GetRoomStatusSetRedisKey(configYaml1.Name, "creating"), gomock.Any()).Times(scaleUpAmount)
+			mockPipeline.EXPECT().Exec().Times(scaleUpAmount)
+			err = controller.ScaleUp(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleUpAmount, timeoutSec, true)
+
+			// ScaleDown
+			scaleDownAmount := 2
+			names, err := controller.GetServiceNames(scaleDownAmount, scheduler.Name, clientset)
+			Expect(err).NotTo(HaveOccurred())
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().
+				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
+				Return(redis.NewStringSliceResult(names, nil))
+			mockPipeline.EXPECT().Exec().Return([]redis.Cmder{}, errors.New("some error in redis"))
+
+			timeoutSec = 0
+			err = controller.ScaleDown(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleDownAmount, timeoutSec)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("some error in redis"))
+		})
+
+		It("should return error if redis fails to get string slice", func() {
+			var configYaml1 models.ConfigYAML
+			err := yaml.Unmarshal([]byte(yaml1), &configYaml1)
+			Expect(err).NotTo(HaveOccurred())
+			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, yaml1)
+
+			// ScaleUp
+			scaleUpAmount := 5
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline).Times(scaleUpAmount)
+			mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(
+				func(schedulerName string, statusInfo map[string]interface{}) {
+					Expect(statusInfo["status"]).To(Equal(models.StatusCreating))
+					Expect(statusInfo["lastPing"]).To(BeNumerically("~", time.Now().Unix(), 1))
+				},
+			).Times(scaleUpAmount)
+			mockPipeline.EXPECT().ZAdd(models.GetRoomPingRedisKey(configYaml1.Name), gomock.Any()).Times(scaleUpAmount)
+			mockPipeline.EXPECT().SAdd(models.GetRoomStatusSetRedisKey(configYaml1.Name, "creating"), gomock.Any()).Times(scaleUpAmount)
+			mockPipeline.EXPECT().Exec().Times(scaleUpAmount)
+			err = controller.ScaleUp(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleUpAmount, timeoutSec, true)
+
+			// ScaleDown
+			scaleDownAmount := 2
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().
+				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
+				Return(redis.NewStringSliceResult(nil, errors.New("some error in redis")))
+			mockPipeline.EXPECT().Exec()
+
+			timeoutSec = 0
+			err = controller.ScaleDown(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleDownAmount, timeoutSec)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("some error in redis"))
+		})
+
+		It("should return error if delete non existing service and pod", func() {
+			var configYaml1 models.ConfigYAML
+			err := yaml.Unmarshal([]byte(yaml1), &configYaml1)
+			Expect(err).NotTo(HaveOccurred())
+			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, yaml1)
+
+			// ScaleDown
+			scaleDownAmount := 1
+			names := []string{"non-existing-service"}
+			Expect(err).NotTo(HaveOccurred())
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().
+				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
+				Return(redis.NewStringSliceResult(names, nil))
+			mockPipeline.EXPECT().Exec()
+
+			timeoutSec = 300
+			err = controller.ScaleDown(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleDownAmount, timeoutSec)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Service \"non-existing-service\" not found"))
+		})
+
+		It("should return timeout error", func() {
+			var configYaml1 models.ConfigYAML
+			err := yaml.Unmarshal([]byte(yaml1), &configYaml1)
+			Expect(err).NotTo(HaveOccurred())
+			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, yaml1)
+
+			// ScaleUp
+			scaleUpAmount := 5
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline).Times(scaleUpAmount)
+			mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(
+				func(schedulerName string, statusInfo map[string]interface{}) {
+					Expect(statusInfo["status"]).To(Equal(models.StatusCreating))
+					Expect(statusInfo["lastPing"]).To(BeNumerically("~", time.Now().Unix(), 1))
+				},
+			).Times(scaleUpAmount)
+			mockPipeline.EXPECT().ZAdd(models.GetRoomPingRedisKey(configYaml1.Name), gomock.Any()).Times(scaleUpAmount)
+			mockPipeline.EXPECT().SAdd(models.GetRoomStatusSetRedisKey(configYaml1.Name, "creating"), gomock.Any()).Times(scaleUpAmount)
+			mockPipeline.EXPECT().Exec().Times(scaleUpAmount)
+			err = controller.ScaleUp(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleUpAmount, timeoutSec, true)
+
+			// ScaleDown
+			scaleDownAmount := 2
+			names, err := controller.GetServiceNames(scaleDownAmount, scheduler.Name, clientset)
+			Expect(err).NotTo(HaveOccurred())
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().
+				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
+				Return(redis.NewStringSliceResult(names, nil))
+			mockPipeline.EXPECT().Exec()
+
+			for _, name := range names {
+				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+				room := models.NewRoom(name, scheduler.Name)
+				for _, status := range allStatus {
+					mockPipeline.EXPECT().
+						SRem(models.GetRoomStatusSetRedisKey(room.SchedulerName, status), room.GetRoomRedisKey())
+				}
+				mockPipeline.EXPECT().ZRem(models.GetRoomPingRedisKey(scheduler.Name), room.ID)
+				mockPipeline.EXPECT().Del(room.GetRoomRedisKey())
+				mockPipeline.EXPECT().Exec()
+			}
+
+			timeoutSec = 0
+			err = controller.ScaleDown(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleDownAmount, timeoutSec)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("timeout scaling down scheduler"))
 		})
 	})
 })

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -739,11 +739,9 @@ var _ = Describe("Controller", func() {
 			names, err := controller.GetServiceNames(scaleDownAmount, scheduler.Name, clientset)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-			mockPipeline.EXPECT().
+			mockRedisClient.EXPECT().
 				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
 				Return(redis.NewStringSliceResult(names, nil))
-			mockPipeline.EXPECT().Exec()
 
 			for _, name := range names {
 				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
@@ -792,11 +790,9 @@ var _ = Describe("Controller", func() {
 			names, err := controller.GetServiceNames(scaleDownAmount, scheduler.Name, clientset)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-			mockPipeline.EXPECT().
+			mockRedisClient.EXPECT().
 				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
 				Return(redis.NewStringSliceResult(names, nil))
-			mockPipeline.EXPECT().Exec()
 
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
 			room := models.NewRoom(names[0], scheduler.Name)
@@ -843,11 +839,9 @@ var _ = Describe("Controller", func() {
 			names, err := controller.GetServiceNames(scaleDownAmount, scheduler.Name, clientset)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-			mockPipeline.EXPECT().
+			mockRedisClient.EXPECT().
 				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
-				Return(redis.NewStringSliceResult(names, nil))
-			mockPipeline.EXPECT().Exec().Return([]redis.Cmder{}, errors.New("some error in redis"))
+				Return(redis.NewStringSliceResult(names, errors.New("some error in redis")))
 
 			timeoutSec = 0
 			err = controller.ScaleDown(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleDownAmount, timeoutSec)
@@ -878,11 +872,9 @@ var _ = Describe("Controller", func() {
 			// ScaleDown
 			scaleDownAmount := 2
 
-			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-			mockPipeline.EXPECT().
+			mockRedisClient.EXPECT().
 				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
 				Return(redis.NewStringSliceResult(nil, errors.New("some error in redis")))
-			mockPipeline.EXPECT().Exec()
 
 			timeoutSec = 0
 			err = controller.ScaleDown(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleDownAmount, timeoutSec)
@@ -901,11 +893,9 @@ var _ = Describe("Controller", func() {
 			names := []string{"non-existing-service"}
 			Expect(err).NotTo(HaveOccurred())
 
-			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-			mockPipeline.EXPECT().
+			mockRedisClient.EXPECT().
 				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
 				Return(redis.NewStringSliceResult(names, nil))
-			mockPipeline.EXPECT().Exec()
 
 			timeoutSec = 300
 			err = controller.ScaleDown(logger, mr, mockDb, mockRedisClient, clientset, scheduler, scaleDownAmount, timeoutSec)
@@ -938,11 +928,9 @@ var _ = Describe("Controller", func() {
 			names, err := controller.GetServiceNames(scaleDownAmount, scheduler.Name, clientset)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-			mockPipeline.EXPECT().
+			mockRedisClient.EXPECT().
 				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
 				Return(redis.NewStringSliceResult(names, nil))
-			mockPipeline.EXPECT().Exec()
 
 			for _, name := range names {
 				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)

--- a/controller/test_helper.go
+++ b/controller/test_helper.go
@@ -9,8 +9,8 @@ package controller
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/fields"
 )
 
 // GetServiceNames return n services that are currently running

--- a/controller/test_helper.go
+++ b/controller/test_helper.go
@@ -1,0 +1,29 @@
+// maestro
+// https://github.com/topfreegames/maestro
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/fields"
+)
+
+// GetServiceNames return n services that are currently running
+func GetServiceNames(n int, namespace string, clientset kubernetes.Interface) ([]string, error) {
+	services, err := clientset.CoreV1().Services(namespace).List(metav1.ListOptions{
+		FieldSelector: fields.Everything().String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	serviceNames := []string{}
+	for _, service := range services.Items {
+		serviceNames = append(serviceNames, service.Name)
+	}
+	return serviceNames[:n], nil
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -83,7 +83,7 @@ func migrations0001CreateschedulertableSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "migrations/0001-CreateSchedulerTable.sql", size: 716, mode: os.FileMode(420), modTime: time.Unix(1494349030, 0)}
+	info := bindataFileInfo{name: "migrations/0001-CreateSchedulerTable.sql", size: 716, mode: os.FileMode(420), modTime: time.Unix(1495042893, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/watcher/watcher_suite_test.go
+++ b/watcher/watcher_suite_test.go
@@ -36,6 +36,7 @@ var (
 	mockRedisClient *redismocks.MockRedisClient
 	mr              *models.MixedMetricsReporter
 	redisClient     *redis.Client
+	allStatus       = []string{models.StatusCreating, models.StatusReady, models.StatusOccupied, models.StatusTerminating, models.StatusTerminated}
 )
 
 func TestWatcher(t *testing.T) {

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -515,11 +515,9 @@ var _ = Describe("Watcher", func() {
 			scaleDownAmount := 2
 			names, err := controller.GetServiceNames(scaleDownAmount, scheduler.Name, clientset)
 			Expect(err).NotTo(HaveOccurred())
-			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-			mockPipeline.EXPECT().
+			mockRedisClient.EXPECT().
 				SPopN(models.GetRoomStatusSetRedisKey(configYaml1.Name, models.StatusReady), int64(scaleDownAmount)).
 				Return(redis.NewStringSliceResult(names, nil))
-			mockPipeline.EXPECT().Exec()
 			for _, name := range names {
 				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
 				room := models.NewRoom(name, scheduler.Name)

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/pg.v5/types"
 	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/pkg/fields"
+	"k8s.io/apimachinery/pkg/fields"
 
 	"github.com/go-redis/redis"
 	"github.com/golang/mock/gomock"


### PR DESCRIPTION
## Scale Down

### How it's done
- Get from config/local.yaml how many room to remove per scale down
- Using this amount N, it access redis and get N random rooms that have status ready
- Remove their pods and services
- Remove their keys from Redis
- In GetSchedulerScalingInfo function, when a scheduler doesn't exist on DB it doesn't return error. Instead it just don't set any value on scheduler variable. So I am checking if YAML property is empty.