### PR TITLE
Threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,15 @@ autoscaling:
     delta: 10               # how many GRUs will be created every time the scaling policy is triggered
     trigger:
       usage: 70             # minimum usage (percentage) that can trigger the scaling policy
-      time: 600             # duration in seconds to wait before scaling policy takes place
+      window: 600             # duration in seconds to wait before scaling policy takes place
+      threshold: 80        # percentage of the points that are above 'usage' needed to trigger scale up
     cooldown: 300           # duration in seconds to wait before consecutive scaling
   down:
     delta: 2                # how many GRUs will be terminated every time the scaling policy is triggered
     trigger:
       usage: 50             # maximum usage (percentage) the can trigger the scaling policy
-      time: 900            
+      window: 900            
+      threshold: 80        # percentage of the points that are above 'usage' needed to trigger scale down
     cooldown: 300          
 env:                        # environment variable to be passed on to the container
   - name: EXAMPLE_ENV_VAR

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -7,7 +7,10 @@
 
 package api
 
-import "net/http"
+import (
+	"net/http"
+	"strconv"
+)
 
 type responseWriter struct {
 	http.ResponseWriter
@@ -48,4 +51,16 @@ func getStatusFromResponseWriter(w http.ResponseWriter) int {
 		return rw.statusCode
 	}
 	return -1
+}
+
+func getMaxSurge(app *App, r *http.Request) (int, error) {
+	var maxSurge int
+	var err error
+	maxSurgeStr := r.URL.Query().Get("maxsurge")
+	if maxSurgeStr == "" {
+		maxSurge = app.Config.GetInt("watcher.maxSurge")
+	} else {
+		maxSurge, err = strconv.Atoi(maxSurgeStr)
+	}
+	return maxSurge, err
 }

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -16,6 +16,7 @@ watcher:
   lockKey: "maestro-lock-key"
   lockTimeoutMs: 180000
   gracefulShutdownTimeout: 300
+  maxSurge: 25
 worker:
   syncPeriod: 30
   gracefulShutdownTimeout: 300

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -12,13 +12,13 @@ extensions:
     url: redis://localhost:6363
     connectionTimeout: 200
 watcher:
-  autoScalingPeriod: 30
+  autoScalingPeriod: 10
   lockKey: "maestro-lock-key"
   lockTimeoutMs: 180000
   gracefulShutdownTimeout: 300
   maxSurge: 25
 worker:
-  syncPeriod: 30
+  syncPeriod: 5
   gracefulShutdownTimeout: 300
 scaleUpTimeoutSeconds: 600
 scaleDownTimeoutSeconds: 600

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -16,6 +16,7 @@ watcher:
   lockKey: "maestro-lock-key"
   lockTimeoutMs: 180000
   gracefulShutdownTimeout: 300
+  maxSurge: 25
 worker:
   syncPeriod: 10
   gracefulShutdownTimeout: 300

--- a/docs/api.md
+++ b/docs/api.md
@@ -333,7 +333,8 @@ All API responses include a `X-Maestro-Version` header with the current Maestro 
           "delta": 10,
           "trigger": {
             "usage": 70,
-            "time": 600
+            "window": 600,
+            "threshold": 80
           },
           "cooldown": 300
         },
@@ -341,7 +342,8 @@ All API responses include a `X-Maestro-Version` header with the current Maestro 
           "delta": 2,
           "trigger": {
             "usage": 50,
-            "time": 900
+            "window": 900,
+            "threshold": 80
           },
           "cooldown": 300
         }
@@ -473,7 +475,8 @@ All API responses include a `X-Maestro-Version` header with the current Maestro 
           "delta": 10,
           "trigger": {
             "usage": 70,
-            "time": 600
+            "window": 600,
+            "threshold": 80
           },
           "cooldown": 300
         },
@@ -481,7 +484,8 @@ All API responses include a `X-Maestro-Version` header with the current Maestro 
           "delta": 2,
           "trigger": {
             "usage": 50,
-            "time": 900
+            "window": 900,
+            "threshold": 80
           },
           "cooldown": 300
         }

--- a/manifests/scheduler-config-1.yaml
+++ b/manifests/scheduler-config-1.yaml
@@ -11,14 +11,16 @@ shutdownTimeout: 10
 autoscaling:
   min: 2
   up:
+    cooldown: 30
     delta: 1
     trigger:
       usage: 70
-      time: 10
-    cooldown: 30
+      window: 60
+      threshold: 80
   down:
+    cooldown: 30
     delta: 1
     trigger:
       usage: 50
-      time: 10
-    cooldown: 30
+      window: 60
+      threshold: 80

--- a/manifests/scheduler-config-2.json
+++ b/manifests/scheduler-config-2.json
@@ -25,7 +25,8 @@
          "delta": 1,
          "trigger": {
             "usage": 70,
-            "time": 1
+            "window": 1,
+            "threshold": 80
          },
          "cooldown": 1
       },
@@ -33,7 +34,8 @@
          "delta": 1,
          "trigger": {
             "usage": 50,
-            "time": 1
+            "window": 1,
+            "threshold": 80
          },
          "cooldown": 1
       }

--- a/models/pod.go
+++ b/models/pod.go
@@ -229,3 +229,20 @@ func (p *Pod) configureHostPorts(clientset kubernetes.Interface, redisClient red
 	p.Ports = podPorts
 	return nil
 }
+
+//PodExists returns true if a pod exists on namespace
+// returns false if it doesn't
+// returns false and a error if an error occurs
+func PodExists(
+	name, namespace string,
+	clientset kubernetes.Interface,
+) (bool, error) {
+	_, err := clientset.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+	if err == nil {
+		return true, nil
+	}
+	if strings.Contains(err.Error(), "not found") {
+		return false, nil
+	}
+	return false, err
+}

--- a/models/pod_test.go
+++ b/models/pod_test.go
@@ -78,16 +78,18 @@ var _ = Describe("Pod", func() {
 			Memory: "64487424",
 		}
 		shutdownTimeout = 180
-
-		mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-		mockPipeline.EXPECT().SPop(models.FreePortsRedisKey()).
-			Return(goredis.NewStringResult("5000", nil))
-		mockPipeline.EXPECT().SPop(models.FreePortsRedisKey()).
-			Return(goredis.NewStringResult("5001", nil))
-		mockPipeline.EXPECT().Exec()
 	})
 
 	Describe("NewPod", func() {
+		BeforeEach(func() {
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().SPop(models.FreePortsRedisKey()).
+				Return(goredis.NewStringResult("5000", nil))
+			mockPipeline.EXPECT().SPop(models.FreePortsRedisKey()).
+				Return(goredis.NewStringResult("5001", nil))
+			mockPipeline.EXPECT().Exec()
+		})
+
 		It("should build correct pod struct", func() {
 			pod, err := models.NewPod(
 				game,
@@ -120,6 +122,15 @@ var _ = Describe("Pod", func() {
 	})
 
 	Describe("Create", func() {
+		BeforeEach(func() {
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().SPop(models.FreePortsRedisKey()).
+				Return(goredis.NewStringResult("5000", nil))
+			mockPipeline.EXPECT().SPop(models.FreePortsRedisKey()).
+				Return(goredis.NewStringResult("5001", nil))
+			mockPipeline.EXPECT().Exec()
+		})
+
 		It("should create a pod in kubernetes", func() {
 			pod, err := models.NewPod(
 				game,
@@ -287,6 +298,15 @@ var _ = Describe("Pod", func() {
 	})
 
 	Describe("Delete", func() {
+		BeforeEach(func() {
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().SPop(models.FreePortsRedisKey()).
+				Return(goredis.NewStringResult("5000", nil))
+			mockPipeline.EXPECT().SPop(models.FreePortsRedisKey()).
+				Return(goredis.NewStringResult("5001", nil))
+			mockPipeline.EXPECT().Exec()
+		})
+
 		It("should delete a pod from kubernetes", func() {
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
 			mockPipeline.EXPECT().SAdd(models.FreePortsRedisKey(), 5000)
@@ -334,6 +354,30 @@ var _ = Describe("Pod", func() {
 			err = pod.Delete(clientset, mockRedisClient)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Pod \"pong-free-for-all-0\" not found"))
+		})
+	})
+
+	Describe("PodExists", func() {
+		It("should return true if pod exists", func() {
+			name := "pod-name"
+			namespace := "pod-ns"
+			pod := &v1.Pod{}
+			pod.SetName(name)
+			_, err := clientset.CoreV1().Pods(namespace).Create(pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			exists, err := models.PodExists(name, namespace, clientset)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+		})
+
+		It("should return false if pod does not exist", func() {
+			name := "pod-name"
+			namespace := "pod-ns"
+
+			exists, err := models.PodExists(name, namespace, clientset)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
 		})
 	})
 })

--- a/models/scale_info.go
+++ b/models/scale_info.go
@@ -1,0 +1,61 @@
+// maestro
+// https://github.com/topfreegames/maestro
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package models
+
+//ScaleInfo holds information about last time scheduler was verified if it needed to be scaled
+// and how many time it was above or below threshold
+type ScaleInfo struct {
+	pointsAboveUsage int
+	points           []float32
+	pointer          int
+	threshold        int
+	usage            float32
+	length           int
+}
+
+// NewScaleInfo returns a new ScaleInfo
+func NewScaleInfo(cap, threshold, usage int) *ScaleInfo {
+	return &ScaleInfo{
+		points:    make([]float32, cap),
+		threshold: threshold,
+		usage:     float32(usage) / 100,
+	}
+}
+
+// AddPoint inserts a new point on a circular list and updates pointsAboveUsage
+func (s *ScaleInfo) AddPoint(point, total int) {
+	if s.length >= len(s.points) {
+		s.length = len(s.points) - 1
+		if s.points[s.pointer] >= s.usage {
+			s.pointsAboveUsage = s.pointsAboveUsage - 1
+		}
+	}
+
+	currentUsage := float32(point) / float32(total)
+	s.points[s.pointer] = currentUsage
+	s.length = s.length + 1
+	s.pointer = (s.pointer + 1) % cap(s.points)
+	if currentUsage >= s.usage {
+		s.pointsAboveUsage = s.pointsAboveUsage + 1
+	}
+}
+
+// IsAboveThreshold returns true if the percentage of points above usage is greater than threshold
+func (s *ScaleInfo) IsAboveThreshold() bool {
+	return 100*s.pointsAboveUsage >= s.threshold*s.length
+}
+
+// GetPoints returns the array of points, where each point is the usage at that time
+func (s *ScaleInfo) GetPoints() []float32 {
+	return s.points
+}
+
+// GetPointsAboveUsage returns the total number of points that were above usage
+func (s *ScaleInfo) GetPointsAboveUsage() int {
+	return s.pointsAboveUsage
+}

--- a/models/scale_info_test.go
+++ b/models/scale_info_test.go
@@ -1,0 +1,79 @@
+// maestro
+// +build unit
+// https://github.com/topfreegames/maestro
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package models_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/topfreegames/maestro/models"
+)
+
+var _ = Describe("ScaleInfo", func() {
+	It("should add point at position 0", func() {
+		var cap, threshold, usage int = 4, 50, 50
+		scaleInfo := models.NewScaleInfo(cap, threshold, usage)
+		scaleInfo.AddPoint(6, 10)
+		points := scaleInfo.GetPoints()
+		Expect(points).To(HaveCap(cap))
+		Expect(points[0]).To(BeNumerically("~", 0.6, 1e-6))
+		Expect(scaleInfo.IsAboveThreshold()).To(BeTrue())
+	})
+
+	It("should add point at position 1", func() {
+		var cap, threshold, usage int = 4, 50, 50
+		scaleInfo := models.NewScaleInfo(cap, threshold, usage)
+		scaleInfo.AddPoint(6, 10)
+		scaleInfo.AddPoint(4, 10)
+		points := scaleInfo.GetPoints()
+		Expect(points).To(HaveCap(cap))
+		Expect(points[0]).To(BeNumerically("~", 0.6, 1e-6))
+		Expect(points[1]).To(BeNumerically("~", 0.4, 1e-6))
+		Expect(scaleInfo.IsAboveThreshold()).To(BeTrue())
+	})
+
+	It("should add point at position 2", func() {
+		var cap, threshold, usage int = 4, 50, 50
+		scaleInfo := models.NewScaleInfo(cap, threshold, usage)
+		scaleInfo.AddPoint(6, 10)
+		scaleInfo.AddPoint(4, 10)
+		scaleInfo.AddPoint(3, 10)
+		points := scaleInfo.GetPoints()
+		Expect(points).To(HaveCap(cap))
+		Expect(points[0]).To(BeNumerically("~", 0.6, 1e-6))
+		Expect(points[1]).To(BeNumerically("~", 0.4, 1e-6))
+		Expect(points[2]).To(BeNumerically("~", 0.3, 1e-6))
+		Expect(scaleInfo.IsAboveThreshold()).To(BeFalse())
+	})
+
+	It("should ovewrite at position 0", func() {
+		var cap, threshold, usage int = 2, 50, 50
+		scaleInfo := models.NewScaleInfo(cap, threshold, usage)
+		scaleInfo.AddPoint(6, 10)
+		scaleInfo.AddPoint(4, 10)
+		scaleInfo.AddPoint(3, 10)
+		points := scaleInfo.GetPoints()
+		Expect(points).To(HaveCap(cap))
+		Expect(points[0]).To(BeNumerically("~", 0.3, 1e-6))
+		Expect(points[1]).To(BeNumerically("~", 0.4, 1e-6))
+		Expect(scaleInfo.IsAboveThreshold()).To(BeFalse())
+	})
+
+	It("should ovewrite at position 0", func() {
+		var cap, threshold, usage int = 2, 50, 50
+		scaleInfo := models.NewScaleInfo(cap, threshold, usage)
+		scaleInfo.AddPoint(6, 10)
+		scaleInfo.AddPoint(8, 10)
+		scaleInfo.AddPoint(7, 10)
+		points := scaleInfo.GetPoints()
+		Expect(points).To(HaveCap(cap))
+		Expect(points[0]).To(BeNumerically("~", 0.7, 1e-6))
+		Expect(points[1]).To(BeNumerically("~", 0.8, 1e-6))
+		Expect(scaleInfo.IsAboveThreshold()).To(BeTrue())
+	})
+})

--- a/models/scheduler.go
+++ b/models/scheduler.go
@@ -42,9 +42,13 @@ type EnvVar struct {
 }
 
 // ScalingPolicyTrigger has the configuration for a scaling policy trigger
+// During 'Window' seconds with n measures, 'Usage'% of the machines needs
+// to be occupied on 'Threshold'% of these n points.
+// This will trigger a scale up or scale down.
 type ScalingPolicyTrigger struct {
-	Time  int `yaml:"time" json:"time" valid:"int64"`
-	Usage int `yaml:"usage" json:"usage" valid:"int64"`
+	Window    int `yaml:"window" json:"window" valid:"int64"`
+	Usage     int `yaml:"usage" json:"usage" valid:"int64"`
+	Threshold int `yaml:"threshold" json:"threshold" valid:"int64"`
 }
 
 // ScalingPolicy has the configuration for a scaling policy

--- a/models/scheduler_test.go
+++ b/models/scheduler_test.go
@@ -42,13 +42,15 @@ autoscaling:
     delta: 10
     trigger:
       usage: 70
-      time: 600
+      window: 600
+      threshold: 80
     cooldown: 300
   down:
     delta: 2
     trigger:
       usage: 50
-      time: 900
+      window: 900
+      threshold: 80
     cooldown: 300
 env:
   - name: EXAMPLE_ENV_VAR
@@ -84,11 +86,11 @@ var _ = Describe("Scheduler", func() {
 			Expect(configYAML.AutoScaling.Min).To(Equal(100))
 			Expect(configYAML.AutoScaling.Up.Cooldown).To(Equal(300))
 			Expect(configYAML.AutoScaling.Up.Delta).To(Equal(10))
-			Expect(configYAML.AutoScaling.Up.Trigger.Time).To(Equal(600))
+			Expect(configYAML.AutoScaling.Up.Trigger.Window).To(Equal(600))
 			Expect(configYAML.AutoScaling.Up.Trigger.Usage).To(Equal(70))
 			Expect(configYAML.AutoScaling.Down.Cooldown).To(Equal(300))
 			Expect(configYAML.AutoScaling.Down.Delta).To(Equal(2))
-			Expect(configYAML.AutoScaling.Down.Trigger.Time).To(Equal(900))
+			Expect(configYAML.AutoScaling.Down.Trigger.Window).To(Equal(900))
 			Expect(configYAML.AutoScaling.Down.Trigger.Usage).To(Equal(50))
 			Expect(configYAML.Env).To(HaveLen(2))
 			Expect(configYAML.Env[0].Name).To(Equal("EXAMPLE_ENV_VAR"))
@@ -232,12 +234,14 @@ var _ = Describe("Scheduler", func() {
 			Expect(autoScalingPolicy.Min).To(Equal(100))
 			Expect(autoScalingPolicy.Up.Cooldown).To(Equal(300))
 			Expect(autoScalingPolicy.Up.Delta).To(Equal(10))
-			Expect(autoScalingPolicy.Up.Trigger.Time).To(Equal(600))
+			Expect(autoScalingPolicy.Up.Trigger.Window).To(Equal(600))
 			Expect(autoScalingPolicy.Up.Trigger.Usage).To(Equal(70))
+			Expect(autoScalingPolicy.Up.Trigger.Threshold).To(Equal(80))
 			Expect(autoScalingPolicy.Down.Cooldown).To(Equal(300))
 			Expect(autoScalingPolicy.Down.Delta).To(Equal(2))
-			Expect(autoScalingPolicy.Down.Trigger.Time).To(Equal(900))
+			Expect(autoScalingPolicy.Down.Trigger.Window).To(Equal(900))
 			Expect(autoScalingPolicy.Down.Trigger.Usage).To(Equal(50))
+			Expect(autoScalingPolicy.Down.Trigger.Threshold).To(Equal(80))
 		})
 	})
 

--- a/testing/minikube.go
+++ b/testing/minikube.go
@@ -89,7 +89,8 @@ func NextJsonStr() (string, error) {
       "delta": 1,
       "trigger": {
         "usage": 70,
-        "time": 1
+        "window": 3,
+        "threshold": 80
       },
       "cooldown": 1
     },
@@ -97,7 +98,8 @@ func NextJsonStr() (string, error) {
       "delta": 1,
       "trigger": {
         "usage": 50,
-        "time": 1
+        "window": 3,
+        "threshold": 80
       },
       "cooldown": 1
     }

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -50,6 +50,8 @@ type Watcher struct {
 	gracefulShutdown  *gracefulShutdown
 	OccupiedTimeout   int64
 	EventForwarders   []eventforwarder.EventForwarder
+	ScaleUpInfo       *models.ScaleInfo
+	ScaleDownInfo     *models.ScaleInfo
 }
 
 // NewWatcher is the watcher constructor
@@ -77,8 +79,6 @@ func NewWatcher(
 	}
 	w.loadConfigurationDefaults()
 	w.configure()
-	w.configureLogger()
-	w.configureTimeout()
 	return w
 }
 
@@ -92,7 +92,7 @@ func (w *Watcher) loadConfigurationDefaults() {
 	w.Config.SetDefault("occupiedTimeout", 60*60)
 }
 
-func (w *Watcher) configure() {
+func (w *Watcher) configure() error {
 	w.AutoScalingPeriod = w.Config.GetInt("watcher.autoScalingPeriod")
 	w.LockKey = fmt.Sprintf("%s-%s", w.Config.GetString("watcher.lockKey"), w.SchedulerName)
 	w.LockTimeoutMS = w.Config.GetInt("watcher.lockTimeoutMs")
@@ -101,16 +101,7 @@ func (w *Watcher) configure() {
 		wg:      &wg,
 		timeout: time.Duration(w.Config.GetInt("watcher.gracefulShutdownTimeout")) * time.Second,
 	}
-}
 
-func (w *Watcher) configureLogger() {
-	w.Logger = w.Logger.WithFields(logrus.Fields{
-		"source":  "maestro-watcher",
-		"version": metadata.Version,
-	})
-}
-
-func (w *Watcher) configureTimeout() error {
 	scheduler := models.NewScheduler(w.SchedulerName, "", "")
 	err := w.MetricsReporter.WithSegment(models.SegmentSelect, func() error {
 		return scheduler.Load(w.DB)
@@ -122,8 +113,41 @@ func (w *Watcher) configureTimeout() error {
 	if err != nil {
 		return err
 	}
-	w.OccupiedTimeout = configYaml.OccupiedTimeout
+	w.configureLogger()
+	w.configureTimeout(configYaml)
+	w.configureAutoScale(configYaml)
 	return nil
+}
+
+func (w *Watcher) configureLogger() {
+	w.Logger = w.Logger.WithFields(logrus.Fields{
+		"source":  "maestro-watcher",
+		"version": metadata.Version,
+	})
+}
+
+func (w *Watcher) configureTimeout(configYaml *models.ConfigYAML) {
+	w.OccupiedTimeout = configYaml.OccupiedTimeout
+}
+
+func (w *Watcher) configureAutoScale(configYaml *models.ConfigYAML) {
+	var capacity, usage, threshold int
+
+	capacity = configYaml.AutoScaling.Up.Trigger.Window / w.AutoScalingPeriod
+	if capacity <= 0 {
+		capacity = 1
+	}
+	threshold = configYaml.AutoScaling.Up.Trigger.Threshold
+	usage = configYaml.AutoScaling.Up.Trigger.Usage
+	w.ScaleUpInfo = models.NewScaleInfo(capacity, threshold, usage)
+
+	capacity = configYaml.AutoScaling.Down.Trigger.Window / w.AutoScalingPeriod
+	if capacity <= 0 {
+		capacity = 1
+	}
+	threshold = configYaml.AutoScaling.Down.Trigger.Threshold
+	usage = 100 - configYaml.AutoScaling.Down.Trigger.Usage
+	w.ScaleDownInfo = models.NewScaleInfo(capacity, threshold, usage)
 }
 
 // Start starts the watcher
@@ -385,49 +409,46 @@ func (w *Watcher) checkState(
 	roomCount *models.RoomsStatusCount,
 	scheduler *models.Scheduler,
 	nowTimestamp int64,
-) (bool, bool, bool) {
-	inCooldownPeriod := false
+) (bool, bool, bool) { //shouldScaleUp, shouldScaleDown, changedState
+	var shouldScaleUp, shouldScaleDown, changedState bool
+	inSync := true
 
 	if scheduler.State == models.StateCreating || scheduler.State == models.StateTerminating {
-		return false, false, false
+		return false, false, changedState
 	}
-
 	if roomCount.Total() < autoScalingInfo.Min {
-		return true, false, false
+		return true, false, changedState
 	}
 
-	if 100*roomCount.Ready < (100-autoScalingInfo.Up.Trigger.Usage)*roomCount.Total() {
+	w.ScaleUpInfo.AddPoint(roomCount.Occupied, roomCount.Total())
+	if w.ScaleUpInfo.IsAboveThreshold() {
+		inSync = false
 		if scheduler.State != models.StateSubdimensioned {
 			scheduler.State = models.StateSubdimensioned
 			scheduler.StateLastChangedAt = nowTimestamp
-			return false, false, true
+			changedState = true
+		} else if nowTimestamp-scheduler.LastScaleOpAt > int64(autoScalingInfo.Up.Cooldown) {
+			shouldScaleUp = true
 		}
-		if nowTimestamp-scheduler.LastScaleOpAt > int64(autoScalingInfo.Up.Cooldown) &&
-			nowTimestamp-scheduler.StateLastChangedAt > int64(autoScalingInfo.Up.Trigger.Time) {
-			return true, false, false
-		}
-		inCooldownPeriod = true
 	}
 
-	if 100*roomCount.Ready > (100-autoScalingInfo.Down.Trigger.Usage)*roomCount.Total() &&
-		roomCount.Total()-autoScalingInfo.Down.Delta >= autoScalingInfo.Min {
+	w.ScaleDownInfo.AddPoint(roomCount.Ready, roomCount.Total())
+	if w.ScaleDownInfo.IsAboveThreshold() && roomCount.Total()-autoScalingInfo.Down.Delta >= autoScalingInfo.Min {
+		inSync = false
 		if scheduler.State != models.StateOverdimensioned {
 			scheduler.State = models.StateOverdimensioned
 			scheduler.StateLastChangedAt = nowTimestamp
-			return false, false, true
+			changedState = true
+		} else if nowTimestamp-scheduler.LastScaleOpAt > int64(autoScalingInfo.Down.Cooldown) {
+			shouldScaleDown = true
 		}
-		if nowTimestamp-scheduler.LastScaleOpAt > int64(autoScalingInfo.Down.Cooldown) &&
-			nowTimestamp-scheduler.StateLastChangedAt > int64(autoScalingInfo.Down.Trigger.Time) {
-			return false, true, false
-		}
-		inCooldownPeriod = true
 	}
 
-	if !inCooldownPeriod && scheduler.State != models.StateInSync {
+	if inSync && scheduler.State != models.StateInSync {
 		scheduler.State = models.StateInSync
 		scheduler.StateLastChangedAt = nowTimestamp
-		return false, false, true
+		changedState = true
 	}
 
-	return false, false, false
+	return shouldScaleUp, shouldScaleDown, changedState
 }

--- a/worker/worker_int_test.go
+++ b/worker/worker_int_test.go
@@ -230,6 +230,8 @@ var _ = Describe("Worker", func() {
 
 				recorder = httptest.NewRecorder()
 				app.Router.ServeHTTP(recorder, request)
+
+				Expect(recorder.Code).To(Equal(http.StatusOK))
 				Expect(recorder.Body.String()).To(Equal(`{"success": true}`))
 				Expect(recorder.Code).To(Equal(http.StatusOK))
 			}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -119,10 +119,11 @@ cmd:
 				Eval(gomock.Any(), gomock.Any(), startPortRange, endPortRange).
 				Return(goredis.NewCmdResult(nil, nil))
 
-			w.Start(startPortRange, endPortRange)
+			err := w.Start(startPortRange, endPortRange)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("some error in pg"))
 			Expect(hook.LastEntry().Message).To(Equal("error listing schedulers"))
 		})
-
 	})
 
 	Describe("EnsureRunningWatchers", func() {


### PR DESCRIPTION
# Threshold

A new way to scale GRUs in Maestro

Watcher gets a window of time that is the scheduler's _autoscaling.up.trigger.time_. At each cycle (every _watcher.autoScalingPeriod_ seconds) if the usage is above _autoscaling.up.trigger.usage_, a counter is incremented. 

At the end of the window, if the counter over the number of points in this window is above _autoscaling.up.trigger.percentage_, the GRUs are scaled up. 

The same works for scale down.