### PR TITLE
Generic room events.

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -225,6 +225,17 @@ func (a *App) getRouter() *mux.Router {
 		NewValidationMiddleware(func() interface{} { return &models.RoomStatusPayload{} }),
 	).ServeHTTP).Methods("PUT").Name("status")
 
+	r.HandleFunc("/scheduler/{schedulerName}/rooms/{roomName}/roomevent", Chain(
+		NewRoomEventHandler(a),
+		NewMetricsReporterMiddleware(a),
+		NewSentryMiddleware(),
+		NewNewRelicMiddleware(a),
+		NewLoggingMiddleware(a),
+		NewVersionMiddleware(),
+		NewParamMiddleware(func() interface{} { return &models.RoomParams{} }),
+		NewValidationMiddleware(func() interface{} { return &models.RoomEventPayload{} }),
+	).ServeHTTP).Methods("POST").Name("roomEvent")
+
 	r.HandleFunc("/scheduler/{schedulerName}/rooms/{roomName}/playerevent", Chain(
 		NewPlayerEventHandler(a),
 		NewMetricsReporterMiddleware(a),

--- a/api/validation_middleware.go
+++ b/api/validation_middleware.go
@@ -54,6 +54,18 @@ func playerEventPayloadFromCtx(ctx context.Context) *models.PlayerEventPayload {
 	return arr[0].(*models.PlayerEventPayload)
 }
 
+func roomEventPayloadFromCtx(ctx context.Context) *models.RoomEventPayload {
+	payload := ctx.Value(payloadString)
+	if payload == nil {
+		return nil
+	}
+	arr := payload.([]interface{})
+	if len(arr) == 0 || arr[0] == nil {
+		return nil
+	}
+	return arr[0].(*models.RoomEventPayload)
+}
+
 func statusPayloadFromCtx(ctx context.Context) *models.RoomStatusPayload {
 	payload := ctx.Value(payloadString)
 	if payload == nil {

--- a/models/payloads.go
+++ b/models/payloads.go
@@ -20,3 +20,10 @@ type PlayerEventPayload struct {
 	Event     string                 `json:"status" valid:"matches(playerLeft|playerJoin),required"`
 	Timestamp int64                  `json:"timestamp" valid:"int64,required"`
 }
+
+// RoomEventPayload is the struct that defines the payload for the roomEvent route
+type RoomEventPayload struct {
+	Metadata  map[string]interface{} `json:"metadata"`
+	Event     string                 `json:"status" valid:"required"`
+	Timestamp int64                  `json:"timestamp" valid:"int64,required"`
+}


### PR DESCRIPTION
This commit adds a route for forwarding generic room events.

Please review this after reviewing PR #23, as I'll rebase it to keep only the relevant changes.