### PR TITLE
 Forward ping room events

### DIFF
--- a/api/room_handler.go
+++ b/api/room_handler.go
@@ -63,6 +63,16 @@ func (g *RoomPingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO: consider sampling requests by scheduler name and only forwarding a few pings
+	eventforwarder.ForwardRoomEvent(
+		g.App.Forwarders,
+		g.App.DB,
+		g.App.KubernetesClient,
+		room, payload.Status,
+		payload.Metadata,
+		g.App.SchedulerCache,
+	)
+
 	mr.WithSegment(models.SegmentSerialization, func() error {
 		Write(w, http.StatusOK, `{"success": true}`)
 		return nil


### PR DESCRIPTION
This PR adds a call to eventforwarder.ForwardRoomEvent whenever a ping request is received.

Please review this after PRs #23 and #24 as I'll rebase their changes once they are accepted.