### PR TITLE
Feature/scheduler info endpoint

### DIFF
--- a/api/scheduler_handler.go
+++ b/api/scheduler_handler.go
@@ -440,7 +440,6 @@ func (g *SchedulerListHandler) returnInfo(
 		g.App.HandleError(w, http.StatusInternalServerError, errStr, err)
 		return
 	}
-	println("huahusahduhaushd")
 	roomsCounts, err := models.GetRoomsCountByStatusForSchedulers(redisClient.Client, schedulersNames)
 	if err != nil {
 		errStr := "failed to get rooms counts for schedulers"
@@ -449,7 +448,7 @@ func (g *SchedulerListHandler) returnInfo(
 		return
 	}
 
-	resp := []map[string]interface{}{}
+	resp := make([]map[string]interface{}, len(schedulersNames))
 	for i, s := range schedulers {
 		configYaml := models.ConfigYAML{}
 		err = yaml.Unmarshal([]byte(s.YAML), &configYaml)
@@ -460,7 +459,7 @@ func (g *SchedulerListHandler) returnInfo(
 			return
 		}
 
-		resp = append(resp, map[string]interface{}{
+		resp[i] = map[string]interface{}{
 			"name":             s.Name,
 			"game":             s.Game,
 			"roomsReady":       roomsCounts[i].Ready,
@@ -468,7 +467,7 @@ func (g *SchedulerListHandler) returnInfo(
 			"roomsCreating":    roomsCounts[i].Creating,
 			"roomsTerminating": roomsCounts[i].Terminating,
 			"autoscalingMin":   configYaml.AutoScaling.Min,
-		})
+		}
 	}
 
 	bts, err := json.Marshal(resp)

--- a/api/scheduler_handler.go
+++ b/api/scheduler_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/topfreegames/extensions/clock"
 	"github.com/topfreegames/extensions/redis"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/topfreegames/maestro/controller"
 	maestroErrors "github.com/topfreegames/maestro/errors"
@@ -260,9 +261,17 @@ func (g *SchedulerListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		g.App.HandleError(w, status, "List scheduler failed", err)
 		return
 	}
+
+	_, getInfo := r.URL.Query()["info"]
+	if getInfo {
+		g.returnInfo(w, r, l, mr, names)
+		return
+	}
+
 	resp := map[string]interface{}{
 		"schedulers": names,
 	}
+
 	bts, err := json.Marshal(resp)
 	if err != nil {
 		logger.WithError(err).Error("List scheduler failed.")
@@ -395,6 +404,86 @@ func (g *SchedulerStatusHandler) returnConfig(
 		return nil
 	})
 	logger.Debug("config scheduler succeeded.")
+}
+
+func (g *SchedulerListHandler) returnInfo(
+	w http.ResponseWriter,
+	r *http.Request,
+	l logrus.FieldLogger,
+	mr *models.MixedMetricsReporter,
+	schedulersNames []string,
+) {
+	logger := l.WithFields(logrus.Fields{
+		"source":    "schedulerHandler",
+		"operation": "get infos",
+	})
+
+	logger.Debugf("Getting schedulers infos")
+
+	var schedulers []models.Scheduler
+	err := mr.WithSegment(models.SegmentSelect, func() error {
+		var err error
+		schedulers, err = models.LoadSchedulers(g.App.DB, schedulersNames)
+		return err
+	})
+	if err != nil {
+		errStr := "failed to get schedulers from DB"
+		logger.WithError(err).Error(errStr)
+		g.App.HandleError(w, http.StatusInternalServerError, errStr, err)
+		return
+	}
+
+	redisClient, err := redis.NewClient("extensions.redis", g.App.Config, g.App.RedisClient)
+	if err != nil {
+		errStr := "failed to create redis client"
+		logger.WithError(err).Error(errStr)
+		g.App.HandleError(w, http.StatusInternalServerError, errStr, err)
+		return
+	}
+	println("huahusahduhaushd")
+	roomsCounts, err := models.GetRoomsCountByStatusForSchedulers(redisClient.Client, schedulersNames)
+	if err != nil {
+		errStr := "failed to get rooms counts for schedulers"
+		logger.WithError(err).Error(errStr)
+		g.App.HandleError(w, http.StatusInternalServerError, errStr, err)
+		return
+	}
+
+	resp := []map[string]interface{}{}
+	for i, s := range schedulers {
+		configYaml := models.ConfigYAML{}
+		err = yaml.Unmarshal([]byte(s.YAML), &configYaml)
+		if err != nil {
+			errStr := fmt.Sprintf("parse yaml error for scheduler %s", s.Name)
+			logger.WithError(err).Error(errStr)
+			g.App.HandleError(w, http.StatusInternalServerError, errStr, err)
+			return
+		}
+
+		resp = append(resp, map[string]interface{}{
+			"name":             s.Name,
+			"game":             s.Game,
+			"roomsReady":       roomsCounts[i].Ready,
+			"roomsOccupied":    roomsCounts[i].Occupied,
+			"roomsCreating":    roomsCounts[i].Creating,
+			"roomsTerminating": roomsCounts[i].Terminating,
+			"autoscalingMin":   configYaml.AutoScaling.Min,
+		})
+	}
+
+	bts, err := json.Marshal(resp)
+	if err != nil {
+		errStr := "failed to marshal schedulers infos"
+		logger.WithError(err).Error(errStr)
+		g.App.HandleError(w, http.StatusInternalServerError, errStr, err)
+		return
+	}
+
+	mr.WithSegment(models.SegmentSerialization, func() error {
+		WriteBytes(w, http.StatusOK, bts)
+		return nil
+	})
+	logger.Debug("get schedulers infos succeeded")
 }
 
 // SchedulerScaleHandler handler

--- a/api/scheduler_handler_test.go
+++ b/api/scheduler_handler_test.go
@@ -253,7 +253,7 @@ var _ = Describe("Scheduler Handler", func() {
 				mockPipeline.EXPECT().Exec()
 			}
 
-			FIt("should list schedulers with infos", func() {
+			It("should list schedulers with infos", func() {
 				expectedNames := []string{"scheduler1"}
 				expectationsGivenNames(expectedNames)
 
@@ -273,7 +273,7 @@ var _ = Describe("Scheduler Handler", func() {
 				Expect(recorder.Body.String()).To(Equal(`[{"autoscalingMin":100,"game":"game-name","name":"scheduler1","roomsCreating":2,"roomsOccupied":1,"roomsReady":1,"roomsTerminating":0}]`))
 			})
 
-			FIt("should list empty array when there aren't schedulers", func() {
+			It("should list empty array when there aren't schedulers", func() {
 				expectedNames := []string{}
 				expectationsGivenNames(expectedNames)
 

--- a/models/room_status.go
+++ b/models/room_status.go
@@ -51,17 +51,17 @@ func GetRoomsCountByStatusForSchedulers(
 	schedulersNames []string,
 ) ([]RoomsStatusCount, error) {
 	pipe := redisClient.TxPipeline()
-	var results []map[string]*redis.IntCmd
-	for _, name := range schedulersNames {
-		results = append(results, GetRoomsCountByStatusWithPipe(name, pipe))
+	results := make([]map[string]*redis.IntCmd, len(schedulersNames))
+	for i, name := range schedulersNames {
+		results[i] = GetRoomsCountByStatusWithPipe(name, pipe)
 	}
 	_, err := pipe.Exec()
 	if err != nil {
 		return nil, err
 	}
-	var convertedResults []RoomsStatusCount
-	for _, r := range results {
-		convertedResults = append(convertedResults, *RedisResultToRoomsCount(r))
+	convertedResults := make([]RoomsStatusCount, len(results))
+	for i, r := range results {
+		convertedResults[i] = *RedisResultToRoomsCount(r)
 	}
 	return convertedResults, nil
 }

--- a/models/scheduler.go
+++ b/models/scheduler.go
@@ -131,6 +131,17 @@ func (c *Scheduler) Load(db interfaces.DB) error {
 	return err
 }
 
+// LoadSchedulers loads a slice of schedulers from database by names
+func LoadSchedulers(db interfaces.DB, names []string) ([]Scheduler, error) {
+	var schedulers []Scheduler
+	_, err := db.Query(
+		&schedulers,
+		"SELECT * FROM schedulers WHERE name IN (?)",
+		pg.In(names),
+	)
+	return schedulers, err
+}
+
 // Create creates a scheduler in the database
 func (c *Scheduler) Create(db interfaces.DB) error {
 	_, err := db.Query(c, "INSERT INTO schedulers (name, game, yaml, state, state_last_changed_at) VALUES (?name, ?game, ?yaml, ?state, ?state_last_changed_at) RETURNING id", c)

--- a/models/scheduler_test.go
+++ b/models/scheduler_test.go
@@ -192,6 +192,31 @@ var _ = Describe("Scheduler", func() {
 		})
 	})
 
+	Describe("LoadSchedulers", func() {
+		It("should load schedulers from the database", func() {
+			mockDb.EXPECT().Query(
+				gomock.Any(),
+				"SELECT * FROM schedulers WHERE name IN (?)",
+				gomock.Any(),
+			)
+			names := []string{"s1", "s2"}
+			_, err := models.LoadSchedulers(mockDb, names)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return an error if db returns an error", func() {
+			mockDb.EXPECT().Query(
+				gomock.Any(),
+				"SELECT * FROM schedulers WHERE name IN (?)",
+				gomock.Any(),
+			).Return(&types.Result{}, errors.New("some error in pg"))
+			names := []string{"s1", "s2"}
+			_, err := models.LoadSchedulers(mockDb, names)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("some error in pg"))
+		})
+	})
+
 	Describe("Update Scheduler", func() {
 		It("should update scheduler in the database", func() {
 			scheduler := models.NewScheduler(name, game, yaml1)


### PR DESCRIPTION
GET /scheduler?info now returns an [{}] of schedulers infos, mainly for maestro-dashboard