### PR TITLE
Status/Cancel routes for current operation in schedulers

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -271,6 +271,16 @@ func (a *App) getRouter(showProfile bool) *mux.Router {
 		NewValidationMiddleware(func() interface{} { return &models.SchedulerMinParams{} }),
 	).ServeHTTP).Methods("PUT").Name("schedulerMin")
 
+	r.HandleFunc("/scheduler/{schedulerName}/operations/current/status", Chain(
+		NewSchedulerOperationCurrentStatusHandler(a),
+		NewBasicAuthMiddleware(a),
+		NewAuthMiddleware(a),
+		NewMetricsReporterMiddleware(a),
+		NewSentryMiddleware(),
+		NewNewRelicMiddleware(a),
+		NewDogStatsdMiddleware(a),
+	).ServeHTTP).Methods("GET").Name("schedulersOperationCurrentStatus")
+
 	r.HandleFunc("/scheduler/{schedulerName}/operations/{operationKey}/status", Chain(
 		NewSchedulerOperationHandler(a),
 		NewBasicAuthMiddleware(a),

--- a/api/app.go
+++ b/api/app.go
@@ -538,7 +538,9 @@ func (a *App) configureLogin() {
 }
 
 //HandleError writes an error response with message and status
-func (a *App) HandleError(w http.ResponseWriter, status int, msg string, err interface{}) {
+func (a *App) HandleError(
+	w http.ResponseWriter, status int, msg string, err interface{},
+) {
 	w.WriteHeader(status)
 	var sErr errors.SerializableError
 	val, ok := err.(errors.SerializableError)

--- a/api/app.go
+++ b/api/app.go
@@ -291,6 +291,16 @@ func (a *App) getRouter(showProfile bool) *mux.Router {
 		NewDogStatsdMiddleware(a),
 	).ServeHTTP).Methods("GET").Name("schedulersOperationStatus")
 
+	r.HandleFunc("/scheduler/{schedulerName}/operations/current/cancel", Chain(
+		NewSchedulerOperationCancelCurrentHandler(a),
+		NewBasicAuthMiddleware(a),
+		NewAuthMiddleware(a),
+		NewMetricsReporterMiddleware(a),
+		NewSentryMiddleware(),
+		NewNewRelicMiddleware(a),
+		NewDogStatsdMiddleware(a),
+	).ServeHTTP).Methods("PUT").Name("schedulersOperationCancelCurrent")
+
 	r.HandleFunc("/scheduler/{schedulerName}/operations/{operationKey}/cancel", Chain(
 		NewSchedulerOperationCancelHandler(a),
 		NewBasicAuthMiddleware(a),
@@ -299,7 +309,7 @@ func (a *App) getRouter(showProfile bool) *mux.Router {
 		NewSentryMiddleware(),
 		NewNewRelicMiddleware(a),
 		NewDogStatsdMiddleware(a),
-	).ServeHTTP).Methods("PUT").Name("schedulersOperationStatus")
+	).ServeHTTP).Methods("PUT").Name("schedulersOperationCancel")
 
 	r.HandleFunc("/scheduler/{schedulerName}/rooms/{roomName}/ping", Chain(
 		NewRoomPingHandler(a),

--- a/api/basicauth_middleware.go
+++ b/api/basicauth_middleware.go
@@ -71,10 +71,12 @@ func (m *BasicAuthMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	ctx := NewContextWithBasicAuthOK(r.Context())
+	email := r.Header.Get("x-forwarded-user-email")
+	ctxWithEmail := NewContextWithEmail(r.Context(), email)
+	ctxWithBasicAuth := NewContextWithBasicAuthOK(ctxWithEmail)
 
 	// Call the next middleware/handler in chain
-	m.next.ServeHTTP(w, r.WithContext(ctx))
+	m.next.ServeHTTP(w, r.WithContext(ctxWithBasicAuth))
 }
 
 //SetNext middleware

--- a/api/scheduler_operation_cancel_handler.go
+++ b/api/scheduler_operation_cancel_handler.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -8,6 +10,24 @@ import (
 	"github.com/topfreegames/extensions/middleware"
 	"github.com/topfreegames/maestro/models"
 )
+
+func cancelOperation(
+	ctx context.Context, app *App, logger logrus.FieldLogger,
+	schedulerName, operationKey string,
+) (string, error) {
+	operationManager := models.NewOperationManager(
+		schedulerName, app.RedisClient.Trace(ctx), logger,
+	)
+	mr := metricsReporterFromCtx(ctx)
+	err := mr.WithSegment(models.SegmentPipeExec, func() error {
+		return operationManager.Cancel(operationKey)
+	})
+	if err != nil {
+		return "error deleting operation key on redis", err
+	}
+
+	return "", nil
+}
 
 // SchedulerOperationCancelHandler returns the current status on scheduler operation
 type SchedulerOperationCancelHandler struct {
@@ -20,11 +40,12 @@ func NewSchedulerOperationCancelHandler(a *App) *SchedulerOperationCancelHandler
 	return m
 }
 
-func (g *SchedulerOperationCancelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (g *SchedulerOperationCancelHandler) ServeHTTP(
+	w http.ResponseWriter, r *http.Request,
+) {
 	vars := mux.Vars(r)
 	schedulerName := vars["schedulerName"]
 	operationKey := vars["operationKey"]
-	mr := metricsReporterFromCtx(r.Context())
 
 	l := middleware.GetLogger(r.Context())
 	logger := l.WithFields(logrus.Fields{
@@ -36,13 +57,80 @@ func (g *SchedulerOperationCancelHandler) ServeHTTP(w http.ResponseWriter, r *ht
 
 	logger.Info("Starting scheduler operation cancel")
 
-	operationManager := models.NewOperationManager(schedulerName, g.App.RedisClient.Trace(r.Context()), logger)
-	err := mr.WithSegment(models.SegmentPipeExec, func() error {
-		return operationManager.Cancel(operationKey)
-	})
+	errorMsg, err := cancelOperation(
+		r.Context(), g.App, logger, schedulerName, operationKey,
+	)
 	if err != nil {
-		logger.WithError(err).Error("error deleting operation key on redis")
-		g.App.HandleError(w, http.StatusInternalServerError, "error deleting operation key on redis", err)
+		logger.WithError(err).Error(errorMsg)
+		g.App.HandleError(
+			w, http.StatusInternalServerError, errorMsg, err,
+		)
+		return
+	}
+
+	WriteJSON(w, http.StatusOK, map[string]interface{}{
+		"success": true,
+	})
+	logger.Info("Successfully canceled operation")
+}
+
+// SchedulerOperationCancelCurrentHandler returns the current status on
+// scheduler operation
+type SchedulerOperationCancelCurrentHandler struct {
+	App *App
+}
+
+// NewSchedulerOperationCancelCurrentHandler returns an instance of
+// SchedulerConfigHandler
+func NewSchedulerOperationCancelCurrentHandler(
+	a *App,
+) *SchedulerOperationCancelCurrentHandler {
+	m := &SchedulerOperationCancelCurrentHandler{App: a}
+	return m
+}
+
+func (g *SchedulerOperationCancelCurrentHandler) ServeHTTP(
+	w http.ResponseWriter, r *http.Request,
+) {
+	vars := mux.Vars(r)
+	schedulerName := vars["schedulerName"]
+
+	l := middleware.GetLogger(r.Context())
+	logger := l.WithFields(logrus.Fields{
+		"source":    "SchedulerOperationCancelCurrentHandler",
+		"operation": "scheduler operation cancel",
+		"scheduler": schedulerName,
+	})
+
+	logger.Info("Starting scheduler operation cancel current")
+
+	operationManager := models.NewOperationManager(
+		schedulerName, g.App.RedisClient.Trace(r.Context()), logger,
+	)
+	currOperation, err := operationManager.CurrentOperation()
+	if err != nil {
+		logger.WithError(err).Error("error getting current operation")
+		g.App.HandleError(
+			w, http.StatusInternalServerError, "error getting current operation", err,
+		)
+		return
+	}
+	if currOperation == "" {
+		logger.Info(fmt.Sprintf("No current operation over %s", schedulerName))
+		WriteJSON(w, http.StatusOK, map[string]interface{}{
+			"operating": "false",
+		})
+		return
+	}
+
+	errorMsg, err := cancelOperation(
+		r.Context(), g.App, logger, schedulerName, currOperation,
+	)
+	if err != nil {
+		logger.WithError(err).Error(errorMsg)
+		g.App.HandleError(
+			w, http.StatusInternalServerError, errorMsg, err,
+		)
 		return
 	}
 

--- a/api/scheduler_operation_cancel_handler_test.go
+++ b/api/scheduler_operation_cancel_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	goredis "github.com/go-redis/redis"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,12 +25,12 @@ import (
 )
 
 var _ = Describe("SchedulerOperationCancelHandler", func() {
-	Describe("PUT /scheduler/{schedulerName}/operations/{operationKey}/cancel", func() {
-		var request *http.Request
-		var recorder *httptest.ResponseRecorder
-		var opManager *models.OperationManager
-		var name = "scheduler-name"
+	var request *http.Request
+	var recorder *httptest.ResponseRecorder
+	var opManager *models.OperationManager
+	var name = "scheduler-name"
 
+	Describe("PUT /scheduler/{schedulerName}/operations/{operationKey}/cancel", func() {
 		BeforeEach(func() {
 			recorder = httptest.NewRecorder()
 			opManager = models.NewOperationManager(name, mockRedisClient, logger)
@@ -42,7 +43,9 @@ var _ = Describe("SchedulerOperationCancelHandler", func() {
 		})
 
 		It("should cancel operation", func() {
-			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
 			MockDeleteRedisKey(opManager, mockRedisClient, mockPipeline, nil)
 
 			app.Router.ServeHTTP(recorder, request)
@@ -54,15 +57,21 @@ var _ = Describe("SchedulerOperationCancelHandler", func() {
 		})
 
 		It("should return error if redis fails", func() {
-			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
-			MockDeleteRedisKey(opManager, mockRedisClient, mockPipeline, errors.New("redis error"))
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
+			MockDeleteRedisKey(
+				opManager, mockRedisClient, mockPipeline, errors.New("redis error"),
+			)
 
 			app.Router.ServeHTTP(recorder, request)
 
 			var response map[string]interface{}
 			json.Unmarshal(recorder.Body.Bytes(), &response)
 			Expect(response).To(HaveKeyWithValue("success", false))
-			Expect(response).To(HaveKeyWithValue("error", "error deleting operation key on redis"))
+			Expect(response).To(HaveKeyWithValue(
+				"error", "error deleting operation key on redis",
+			))
 			Expect(response).To(HaveKeyWithValue("description", "redis error"))
 			Expect(response).To(HaveKeyWithValue("code", "MAE-000"))
 
@@ -70,7 +79,9 @@ var _ = Describe("SchedulerOperationCancelHandler", func() {
 		})
 
 		It("should return error if operation key is invalid", func() {
-			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
 			key := "invalid key"
 			url := fmt.Sprintf("http://%s/scheduler/%s/operations/%s/cancel",
 				app.Address, name, key)
@@ -83,9 +94,82 @@ var _ = Describe("SchedulerOperationCancelHandler", func() {
 			var response map[string]interface{}
 			json.Unmarshal(recorder.Body.Bytes(), &response)
 			Expect(response).To(HaveKeyWithValue("success", false))
-			Expect(response).To(HaveKeyWithValue("error", "error deleting operation key on redis"))
-			Expect(response).To(HaveKeyWithValue("description", "operationKey is not valid: invalid key"))
+			Expect(response).To(HaveKeyWithValue(
+				"error", "error deleting operation key on redis",
+			))
+			Expect(response).To(HaveKeyWithValue(
+				"description", "operationKey is not valid: invalid key",
+			))
 			Expect(response).To(HaveKeyWithValue("code", "MAE-000"))
+		})
+	})
+
+	Describe("PUT /scheduler/{schedulerName}/operations/current/cancel", func() {
+		var opKey string
+
+		BeforeEach(func() {
+			opKey = "opmanager:scheduler-name:some-random-token"
+			recorder = httptest.NewRecorder()
+			opManager = models.NewOperationManager(name, mockRedisClient, logger)
+
+			url := fmt.Sprintf(
+				"http://%s/scheduler/%s/operations/current/cancel", app.Address, name,
+			)
+
+			request, _ = http.NewRequest("PUT", url, nil)
+			request.SetBasicAuth("user", "pass")
+		})
+
+		It("should cancel current operation", func() {
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
+			mockRedisClient.EXPECT().
+				Get(opManager.BuildCurrOpKey()).
+				Return(goredis.NewStringResult(opKey, nil))
+
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().Del(opKey)
+			mockPipeline.EXPECT().Exec().Return(nil, nil)
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Code).To(Equal(http.StatusOK))
+
+			var response map[string]interface{}
+			json.Unmarshal(recorder.Body.Bytes(), &response)
+			Expect(response).To(HaveKeyWithValue("success", true))
+		})
+
+		It("should return error if redis fails", func() {
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
+			mockRedisClient.EXPECT().
+				Get(opManager.BuildCurrOpKey()).
+				Return(goredis.NewStringResult(opKey, nil))
+
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().Del(opKey)
+			mockPipeline.EXPECT().Exec().Return(nil, errors.New("redis error"))
+
+			app.Router.ServeHTTP(recorder, request)
+
+			var response map[string]interface{}
+			json.Unmarshal(recorder.Body.Bytes(), &response)
+			Expect(response).To(HaveKeyWithValue("success", false))
+			Expect(response).To(HaveKeyWithValue(
+				"error", "error deleting operation key on redis",
+			))
+			Expect(response).To(HaveKeyWithValue("description", "redis error"))
+			Expect(response).To(HaveKeyWithValue("code", "MAE-000"))
+
+			Expect(recorder.Code).To(Equal(http.StatusInternalServerError))
 		})
 	})
 })

--- a/api/scheduler_operation_handler.go
+++ b/api/scheduler_operation_handler.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func getRollingProgress(
+func getOperationRollingProgress(
 	ctx context.Context, app *App, schedulerName string,
 ) (float64, string, error) {
 	scheduler := models.NewScheduler(schedulerName, "", "")
@@ -105,7 +105,7 @@ func getOperationStatus(
 		return status, "", nil
 	}
 
-	progress, errorMsg, err := getRollingProgress(ctx, app, schedulerName)
+	progress, errorMsg, err := getOperationRollingProgress(ctx, app, schedulerName)
 	if err != nil {
 		return empty, errorMsg, err
 	}

--- a/api/scheduler_operation_handler.go
+++ b/api/scheduler_operation_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,6 +13,61 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
+
+func getRollingProgress(
+	ctx context.Context, app *App, schedulerName string,
+) (float64, string, error) {
+	scheduler := models.NewScheduler(schedulerName, "", "")
+	err := scheduler.Load(app.DBClient.WithContext(ctx))
+	if err != nil {
+		return 0, "error getting scheduler for getting progress", err
+	}
+
+	scheduler.NextMinorVersion()
+	minor := scheduler.Version
+	scheduler.NextMajorVersion()
+	major := scheduler.Version
+
+	totalPods, err := app.KubernetesClient.CoreV1().Pods(schedulerName).List(
+		metav1.ListOptions{},
+	)
+	if err != nil {
+		return 0, "error getting getting pods from kubernetes", err
+	}
+	total := float64(len(totalPods.Items))
+
+	var new float64
+
+	podsMinorVersion, err := app.KubernetesClient.CoreV1().Pods(
+		schedulerName,
+	).List(metav1.ListOptions{
+		LabelSelector: labels.Set{"version": minor}.String(),
+	})
+	if err != nil {
+		return 0, "error getting getting pods from kubernetes", err
+	}
+	for _, pod := range podsMinorVersion.Items {
+		if models.IsPodReady(&pod) {
+			new = new + 1.0
+		}
+	}
+
+	podsMajorVersion, err := app.KubernetesClient.CoreV1().Pods(
+		schedulerName,
+	).List(metav1.ListOptions{
+		LabelSelector: labels.Set{"version": major}.String(),
+	})
+	if err != nil {
+		return 0, "error getting getting pods from kubernetes", err
+	}
+	for _, pod := range podsMajorVersion.Items {
+		if models.IsPodReady(&pod) {
+			new = new + 1.0
+		}
+	}
+
+	return 100.0 * new / total, "", nil
+}
 
 // SchedulerOperationHandler returns the current status on scheduler operation
 type SchedulerOperationHandler struct {
@@ -39,11 +95,16 @@ func (g *SchedulerOperationHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	logger.Info("Starting scheduler operation status")
 
-	operationManager := models.NewOperationManager(schedulerName, g.App.RedisClient.Trace(r.Context()), logger)
+	operationManager := models.NewOperationManager(
+		schedulerName, g.App.RedisClient.Trace(r.Context()), logger,
+	)
 	status, err := operationManager.Get(operationKey)
 	if err != nil {
 		logger.WithError(err).Error("error accesssing operation key on redis")
-		g.App.HandleError(w, http.StatusInternalServerError, "error accesssing operation key on redis", err)
+		g.App.HandleError(
+			w, http.StatusInternalServerError,
+			"error accesssing operation key on redis", err,
+		)
 		return
 	}
 
@@ -63,56 +124,92 @@ func (g *SchedulerOperationHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	scheduler := models.NewScheduler(schedulerName, "", "")
-	err = scheduler.Load(g.App.DBClient.WithContext(r.Context()))
+	progress, errorMsg, err := getRollingProgress(r.Context(), g.App, schedulerName)
 	if err != nil {
-		g.App.HandleError(w, http.StatusInternalServerError, "error getting scheduler for getting progress", err)
+		g.App.HandleError(w, http.StatusInternalServerError, errorMsg, err)
 		return
 	}
-
-	scheduler.NextMinorVersion()
-	minor := scheduler.Version
-	scheduler.NextMajorVersion()
-	major := scheduler.Version
-
-	totalPods, err := g.App.KubernetesClient.CoreV1().Pods(schedulerName).List(metav1.ListOptions{})
-	if err != nil {
-		g.App.HandleError(w, http.StatusInternalServerError, "error getting getting pods from kubernetes", err)
-		return
-	}
-	total := float64(len(totalPods.Items))
-
-	var news float64
-
-	podsMinorVersion, err := g.App.KubernetesClient.CoreV1().Pods(schedulerName).List(metav1.ListOptions{
-		LabelSelector: labels.Set{"version": minor}.String(),
-	})
-	if err != nil {
-		g.App.HandleError(w, http.StatusInternalServerError, "error getting getting pods from kubernetes", err)
-		return
-	}
-	for _, pod := range podsMinorVersion.Items {
-		if models.IsPodReady(&pod) {
-			news = news + 1.0
-		}
-	}
-
-	podsMajorVersion, err := g.App.KubernetesClient.CoreV1().Pods(schedulerName).List(metav1.ListOptions{
-		LabelSelector: labels.Set{"version": major}.String(),
-	})
-	if err != nil {
-		g.App.HandleError(w, http.StatusInternalServerError, "error getting getting pods from kubernetes", err)
-		return
-	}
-	for _, pod := range podsMajorVersion.Items {
-		if models.IsPodReady(&pod) {
-			news = news + 1.0
-		}
-	}
-
-	status["progress"] = fmt.Sprintf("%.2f%%", 100.0*news/total)
+	status["progress"] = fmt.Sprintf("%.2f%%", progress)
 
 	bts, _ := json.Marshal(status)
 	WriteBytes(w, http.StatusOK, bts)
 	logger.Info("Successfully wrote status response")
+}
+
+// SchedulerOperationCurrentStatusHandler returns the current status
+// on scheduler operation
+type SchedulerOperationCurrentStatusHandler struct {
+	App *App
+}
+
+// NewSchedulerOperationCurrentStatusHandler returns an instance of
+// SchedulerConfigHandler
+func NewSchedulerOperationCurrentStatusHandler(
+	a *App,
+) *SchedulerOperationCurrentStatusHandler {
+	m := &SchedulerOperationCurrentStatusHandler{App: a}
+	return m
+}
+
+func (g *SchedulerOperationCurrentStatusHandler) ServeHTTP(
+	w http.ResponseWriter, r *http.Request,
+) {
+	vars := mux.Vars(r)
+	schedulerName := vars["schedulerName"]
+
+	l := middleware.GetLogger(r.Context())
+	logger := l.WithFields(logrus.Fields{
+		"source":    "SchedulerOperationCurrentStatusHandler",
+		"operation": "scheduler operation current status",
+		"scheduler": schedulerName,
+	})
+
+	logger.Info("Starting scheduler operation status")
+
+	operationManager := models.NewOperationManager(
+		schedulerName, g.App.RedisClient.Trace(r.Context()), logger,
+	)
+	currOperation, err := operationManager.CurrentOperation()
+	if err != nil {
+		logger.WithError(err).Error("error getting current operation")
+		g.App.HandleError(
+			w, http.StatusInternalServerError, "error getting current operation", err,
+		)
+		return
+	}
+	if currOperation == "" {
+		logger.Info(fmt.Sprintf("No current operation over %s", schedulerName))
+		WriteJSON(w, http.StatusOK, map[string]interface{}{
+			"operating": "false",
+		})
+		return
+	}
+
+	status, err := operationManager.Get(currOperation)
+	if err != nil {
+		logger.WithError(err).Error("error accesssing operation key on redis")
+		g.App.HandleError(
+			w, http.StatusInternalServerError,
+			"error accesssing operation key on redis", err,
+		)
+		return
+	}
+
+	// finished
+	if _, ok := status["status"]; ok {
+		bts, _ := json.Marshal(status)
+		WriteBytes(w, http.StatusOK, bts)
+		return
+	}
+
+	// in progress
+	progress, errorMsg, err := getRollingProgress(r.Context(), g.App, schedulerName)
+	if err != nil {
+		g.App.HandleError(w, http.StatusInternalServerError, errorMsg, err)
+		return
+	}
+	status["progress"] = fmt.Sprintf("%.2f%%", progress)
+
+	bts, _ := json.Marshal(status)
+	WriteBytes(w, http.StatusOK, bts)
 }

--- a/api/scheduler_operation_handler_test.go
+++ b/api/scheduler_operation_handler_test.go
@@ -148,6 +148,10 @@ var _ = Describe("SchedulerOperationHandler", func() {
 				Get(opManager.BuildCurrOpKey()).
 				Return(goredis.NewStringResult(opKey, nil))
 
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
+
 			status := map[string]string{
 				"status":   "200",
 				"success":  "true",
@@ -173,6 +177,10 @@ var _ = Describe("SchedulerOperationHandler", func() {
 			mockRedisClient.EXPECT().
 				Get(opManager.BuildCurrOpKey()).
 				Return(goredis.NewStringResult(opKey, nil))
+
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
 
 			status := map[string]string{
 				"progress": "running",

--- a/api/scheduler_operation_handler_test.go
+++ b/api/scheduler_operation_handler_test.go
@@ -52,18 +52,18 @@ var _ = Describe("SchedulerOperationHandler", func() {
 		clientset.CoreV1().Pods(schedulerName).Create(pod)
 	}
 
-	BeforeEach(func() {
-		opManager = models.NewOperationManager(schedulerName, mockRedisClient, logger)
-
-		recorder = httptest.NewRecorder()
-
-		url = fmt.Sprintf("http://%s/scheduler/%s/operations/%s/status",
-			app.Address, schedulerName, opManager.GetOperationKey())
-		request, _ = http.NewRequest("GET", url, nil)
-		request.SetBasicAuth("user", "pass")
-	})
-
 	Describe("GET /scheduler/{schedulerName}/operations/{operationKey}/status", func() {
+		BeforeEach(func() {
+			opManager = models.NewOperationManager(schedulerName, mockRedisClient, logger)
+
+			recorder = httptest.NewRecorder()
+
+			url = fmt.Sprintf("http://%s/scheduler/%s/operations/%s/status",
+				app.Address, schedulerName, opManager.GetOperationKey())
+			request, _ = http.NewRequest("GET", url, nil)
+			request.SetBasicAuth("user", "pass")
+		})
+
 		It("should return status completed if so", func() {
 			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 			status := map[string]string{
@@ -89,6 +89,101 @@ var _ = Describe("SchedulerOperationHandler", func() {
 			mockGetStatusFromRedis(status, nil)
 
 			mockCtxWrapper.EXPECT().WithContext(gomock.Any(), app.DBClient.DB).Return(app.DBClient.DB)
+
+			// Select current scheduler
+			MockSelectScheduler(yamlString, mockDb, nil)
+
+			// Create half of the pods in version v1.0 and half in v2.0
+			createPod("pod1", schedulerName, "v1.0")
+			createPod("pod2", schedulerName, "v2.0")
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Code).To(Equal(http.StatusOK))
+
+			var response map[string]interface{}
+			json.Unmarshal(recorder.Body.Bytes(), &response)
+			Expect(response).To(HaveKeyWithValue("progress", "50.00%"))
+		})
+	})
+
+	Describe("GET /scheduler/{schedulerName}/operations/status", func() {
+		var opKey string
+
+		BeforeEach(func() {
+			opKey = "opmanager:scheduler-name:some-random-token"
+			opManager = models.NewOperationManager(schedulerName, mockRedisClient, logger)
+
+			recorder = httptest.NewRecorder()
+
+			url = fmt.Sprintf("http://%s/scheduler/%s/operations/current/status",
+				app.Address, schedulerName)
+			request, _ = http.NewRequest("GET", url, nil)
+			request.SetBasicAuth("user", "pass")
+		})
+
+		It("should return operating: false when there isn't current operation", func() {
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
+			var err error
+			MockGetCurrentOperationKey(opManager, mockRedisClient, err)
+			status := map[string]string{
+				"operating": "false",
+			}
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Code).To(Equal(http.StatusOK))
+
+			var response map[string]string
+			json.Unmarshal(recorder.Body.Bytes(), &response)
+			Expect(response).To(Equal(status))
+		})
+
+		It("should return status completed if so, for current operation", func() {
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
+
+			mockRedisClient.EXPECT().
+				Get(opManager.BuildCurrOpKey()).
+				Return(goredis.NewStringResult(opKey, nil))
+
+			status := map[string]string{
+				"status":   "200",
+				"success":  "true",
+				"progress": "100%",
+			}
+			mockRedisClient.EXPECT().
+				HGetAll(opKey).
+				Return(goredis.NewStringStringMapResult(status, nil))
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Code).To(Equal(http.StatusOK))
+
+			var response map[string]string
+			json.Unmarshal(recorder.Body.Bytes(), &response)
+			Expect(response).To(Equal(status))
+		})
+
+		It("should return progress when not completed", func() {
+			mockRedisTraceWrapper.EXPECT().WithContext(
+				gomock.Any(), mockRedisClient,
+			).Return(mockRedisClient)
+
+			mockRedisClient.EXPECT().
+				Get(opManager.BuildCurrOpKey()).
+				Return(goredis.NewStringResult(opKey, nil))
+
+			status := map[string]string{
+				"progress": "running",
+			}
+			mockRedisClient.EXPECT().
+				HGetAll(opKey).
+				Return(goredis.NewStringStringMapResult(status, nil))
+
+			mockCtxWrapper.EXPECT().WithContext(
+				gomock.Any(), app.DBClient.DB,
+			).Return(app.DBClient.DB)
 
 			// Select current scheduler
 			MockSelectScheduler(yamlString, mockDb, nil)


### PR DESCRIPTION
Currently, there are status/cancel routes for a specified operationKey, returned in an async update scheduler call. These new routes affect the on going operation, if any.

When there isn't a running operation, the response is

```{ "operating": "false" }```

BasicAuth middleware was adapted to pass x-forwarded-user-email down the context.