### PR TITLE
Fix python requests security alert for versions <=2.19.9.

### DIFF
--- a/dev-room/requirements.txt
+++ b/dev-room/requirements.txt
@@ -9,7 +9,7 @@ lazy-object-proxy==1.3.1
 mccabe==0.6.1
 pylint==2.1.0
 python-mimeparse==1.6.0
-requests==2.19.1
+requests==2.20.0
 six==1.11.0
 typed-ast==1.1.0
 typing==3.6.4


### PR DESCRIPTION
An automatic alert was issue by github with the following info:


CVE-2018-18074 More information
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.
