### PR TITLE
Feature/servers by metric

### DIFF
--- a/api/api_suite_int_test.go
+++ b/api/api_suite_int_test.go
@@ -28,19 +28,21 @@ import (
 
 	mTest "github.com/topfreegames/maestro/testing"
 	"k8s.io/client-go/kubernetes"
+	metricsClient "k8s.io/metrics/pkg/client/clientset_generated/clientset"
 )
 
 var (
-	clientset kubernetes.Interface
-	app       *api.App
-	hook      *test.Hook
-	logger    *logrus.Logger
-	config    *viper.Viper
-	mockDb    *pgmocks.MockDB
-	mockLogin *mocks.MockLogin
-	mockCtrl  *gomock.Controller
-	mmr       *models.MixedMetricsReporter
-	token     = "token"
+	clientset        kubernetes.Interface
+	metricsClientset metricsClient.Interface
+	app              *api.App
+	hook             *test.Hook
+	logger           *logrus.Logger
+	config           *viper.Viper
+	mockDb           *pgmocks.MockDB
+	mockLogin        *mocks.MockLogin
+	mockCtrl         *gomock.Controller
+	mmr              *models.MixedMetricsReporter
+	token            = "token"
 )
 
 func TestIntModels(t *testing.T) {
@@ -56,13 +58,16 @@ var _ = BeforeSuite(func() {
 	clientset, err = kubernetes.NewForConfig(minikubeConfig)
 	Expect(err).NotTo(HaveOccurred())
 
+	metricsClientset, err = metricsClient.NewForConfig(minikubeConfig)
+	Expect(err).NotTo(HaveOccurred())
+
 	logger, hook = test.NewNullLogger()
 	logger.Level = logrus.DebugLevel
 
 	config, err = mTest.GetDefaultConfig()
 	Expect(err).NotTo(HaveOccurred())
 
-	app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", nil, nil, nil, nil, clientset)
+	app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", nil, nil, nil, nil, clientset, metricsClientset)
 	Expect(err).NotTo(HaveOccurred())
 
 	user := &login.User{

--- a/api/app.go
+++ b/api/app.go
@@ -336,6 +336,16 @@ func (a *App) getRouter(showProfile bool) *mux.Router {
 		NewParamMiddleware(func() interface{} { return &models.RoomParams{} }),
 	).ServeHTTP).Methods("GET").Name("address")
 
+	r.HandleFunc("/scheduler/{schedulerName}/rooms", Chain(
+		NewRoomListByMetricHandler(a),
+		NewResponseTimeMiddleware(a),
+		NewMetricsReporterMiddleware(a),
+		NewSentryMiddleware(),
+		NewNewRelicMiddleware(a),
+		NewDogStatsdMiddleware(a),
+		NewParamMiddleware(func() interface{} { return &models.SchedulerParams{} }),
+	).ServeHTTP).Methods("GET").Name("roomsByMetric")
+
 	r.HandleFunc("/scheduler/{schedulerName}/rooms/{roomName}/status", Chain(
 		NewRoomStatusHandler(a),
 		NewResponseTimeMiddleware(a),

--- a/api/app_int_test.go
+++ b/api/app_int_test.go
@@ -244,7 +244,7 @@ var _ = Describe("App", func() {
 		})
 
 		It("should return code 500 if postgres is down", func() {
-			app, err := api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", nil, nil, nil, nil, clientset)
+			app, err := api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", nil, nil, nil, nil, clientset, metricsClientset)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = app.DBClient.DB.Close()

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("App", func() {
 	Describe("NewApp", func() {
 		It("should return new app", func() {
-			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset)
+			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(application).NotTo(BeNil())
 			Expect(application.Address).NotTo(Equal(""))
@@ -36,14 +36,14 @@ var _ = Describe("App", func() {
 
 			// should use development environment
 			config.Set(api.EnvironmentConfig, api.DevEnvironment)
-			application, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset)
+			application, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(application.RoomAddrGetter).To(BeAssignableToTypeOf(&models.RoomAddressesFromNodePort{}))
 		})
 
 		It("should fail if some error occurred", func() {
 			config.Set("newrelic.key", 12345)
-			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset)
+			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("license length is not 40"))
 			Expect(application).To(BeNil())
@@ -51,7 +51,7 @@ var _ = Describe("App", func() {
 
 		It("should not fail if no newrelic key is provided", func() {
 			config.Set("newrelic.key", "")
-			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset)
+			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(application).NotTo(BeNil())
 		})

--- a/api/room_handler_test.go
+++ b/api/room_handler_test.go
@@ -259,7 +259,7 @@ forwarders:
 				createNamespace(namespace, clientset)
 				err := createPod(roomName, namespace, clientset)
 				Expect(err).NotTo(HaveOccurred())
-				app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset)
+				app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
 				Expect(err).NotTo(HaveOccurred())
 				app.Forwarders = []*eventforwarder.Info{
 					&eventforwarder.Info{
@@ -478,7 +478,7 @@ forwarders:
 					createNamespace(namespace, clientset)
 					err := createPod(roomName, namespace, clientset)
 					Expect(err).NotTo(HaveOccurred())
-					app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset)
+					app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
 					Expect(err).NotTo(HaveOccurred())
 					app.Forwarders = []*eventforwarder.Info{
 						&eventforwarder.Info{
@@ -643,7 +643,7 @@ forwarders:
 		var app *api.App
 		BeforeEach(func() {
 			var err error
-			app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset)
+			app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
 			Expect(err).NotTo(HaveOccurred())
 			app.Forwarders = []*eventforwarder.Info{
 				&eventforwarder.Info{
@@ -794,7 +794,7 @@ forwarders:
 			createNamespace(namespace, clientset)
 			err := createPod("roomName", namespace, clientset)
 			Expect(err).NotTo(HaveOccurred())
-			app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset)
+			app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
 			Expect(err).NotTo(HaveOccurred())
 			app.Forwarders = []*eventforwarder.Info{
 				&eventforwarder.Info{

--- a/api/room_handler_test.go
+++ b/api/room_handler_test.go
@@ -1026,7 +1026,7 @@ forwarders:
 					expectedRet[idx] = r.GetRoomRedisKey()
 				}
 				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-				mockPipeline.EXPECT().SScan(pKey, uint64(0), "", int64(5)).Return(redis.NewScanCmdResult(expectedRet, 0, nil))
+				mockPipeline.EXPECT().SRandMemberN(pKey, int64(5)).Return(redis.NewStringSliceResult(expectedRet, nil))
 				mockPipeline.EXPECT().Exec()
 
 				url := fmt.Sprintf("/scheduler/%s/rooms", namespace)
@@ -1103,8 +1103,8 @@ forwarders:
 			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 			pKey := models.GetRoomStatusSetRedisKey(namespace, models.StatusReady)
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-			mockPipeline.EXPECT().SScan(pKey, uint64(0), "", int64(5)).Return(
-				redis.NewScanCmdResult([]string{}, 0, errors.New("something went wrong")))
+			mockPipeline.EXPECT().SRandMemberN(pKey, int64(5)).Return(
+				redis.NewStringSliceResult([]string{}, errors.New("something went wrong")))
 			mockPipeline.EXPECT().Exec()
 
 			url := fmt.Sprintf("/scheduler/%s/rooms", namespace)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -54,7 +54,7 @@ var startCmd = &cobra.Command{
 
 		cmdL.Info("starting maestro")
 
-		app, err := api.NewApp(bind, port, config, log, incluster, showProfile, kubeconfig, nil, nil, nil, nil, nil)
+		app, err := api.NewApp(bind, port, config, log, incluster, showProfile, kubeconfig, nil, nil, nil, nil, nil, nil)
 		if err != nil {
 			cmdL.Fatal(err)
 		}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -586,6 +586,12 @@ func UpdateSchedulerConfig(
 		return errors.New("invalid parameter: autoscaling max must be greater than min")
 	}
 
+	// if using resource scaling (cpu, mem) requests must be set
+	err := validateMetricsTrigger(configYAML, logger)
+	if err != nil {
+		return err
+	}
+
 	// Lock watchers so they don't scale up or down and the scheduler is not
 	//  overwritten with older version on database
 	var lock *redisLock.Lock
@@ -595,8 +601,6 @@ func UpdateSchedulerConfig(
 	defer ticker.Stop()
 	timeout := time.NewTimer(timeoutDur)
 	defer timeout.Stop()
-
-	var err error
 
 waitForLock:
 	for {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -27,6 +27,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metricsClient "k8s.io/metrics/pkg/client/clientset_generated/clientset"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -1196,6 +1197,7 @@ func SetRoomStatus(
 	db pginterfaces.DB,
 	mr *models.MixedMetricsReporter,
 	clientset kubernetes.Interface,
+	metricsClientset metricsClient.Interface,
 	status string,
 	config *viper.Viper,
 	room *models.Room,
@@ -1209,7 +1211,15 @@ func SetRoomStatus(
 	if err != nil {
 		return err
 	}
-	roomsCountByStatus, err := room.SetStatus(redisClient, db, mr, status, cachedScheduler.ConfigYAML, status == models.StatusOccupied)
+	roomsCountByStatus, err := room.SetStatus(
+		redisClient,
+		db,
+		metricsClientset,
+		mr,
+		status,
+		cachedScheduler.Scheduler,
+		status == models.StatusOccupied,
+	)
 	if err != nil {
 		return err
 	}

--- a/controller/controller_suite_test.go
+++ b/controller/controller_suite_test.go
@@ -27,11 +27,13 @@ import (
 	"github.com/topfreegames/extensions/redis"
 	"github.com/topfreegames/maestro/mocks"
 	"github.com/topfreegames/maestro/models"
+	metricsFake "k8s.io/metrics/pkg/client/clientset_generated/clientset/fake"
 )
 
 var (
 	hook                  *test.Hook
 	logger                *logrus.Logger
+	metricsClientset      *metricsFake.Clientset
 	mockCtrl              *gomock.Controller
 	config                *viper.Viper
 	mockDb                *pgmocks.MockDB
@@ -50,6 +52,10 @@ var (
 		models.StatusOccupied,
 		models.StatusTerminating,
 		models.StatusTerminated,
+	}
+	allMetrics = []string{
+		string(models.CPUAutoScalingPolicyType),
+		string(models.MemAutoScalingPolicyType),
 	}
 )
 
@@ -71,6 +77,7 @@ var _ = BeforeEach(func() {
 	mr := models.NewMixedMetricsReporter()
 	mr.AddReporter(fakeReporter)
 
+	metricsClientset = metricsFake.NewSimpleClientset()
 	mockCtrl = gomock.NewController(GinkgoT())
 
 	mockDb = pgmocks.NewMockDB(mockCtrl)

--- a/docs/api.md
+++ b/docs/api.md
@@ -294,6 +294,56 @@ All API responses include a `X-Maestro-Version` header with the current Maestro 
       }
     ```
 
+  ### List Rooms Ordered By Metric
+
+  `GET  /scheduler/:schedulerName/rooms`
+
+  This route returns an array of room ids ordered by metric in ascending order. If metric is "legacy" or "room" it will return available rooms (status ready).
+
+  * Optional query parameters
+    * *metric*: valid values are "cpu", "mem", "room" and "legacy". Default: "room".
+    * *limit*: number of rooms to be returned, must be an int greater than 0. Default: 5.
+
+  * Success Response
+    * Code: `200`
+    * Content:
+
+      ```
+        {
+          "rooms":  [roomID1, roomID2, roomID3]
+        }
+      ```
+
+  * Error Response
+
+    It will return an error if some error occurred.
+
+    * Code: `500`
+    * Content:
+
+    ```
+      {
+        "code":        [string]<error-code>,
+        "error":       [string]<error-message>,
+        "description": [string]<error-description>,
+        "success":     [bool]false
+      }
+    ```
+
+    It will return an error if invalid metric or limit is sent.
+
+    * Code: `400`
+    * Content:
+
+    ```
+      {
+        "code":        [string]<error-code>,
+        "error":       [string]<error-message>,
+        "description": [string]<error-description>,
+        "success":     [bool]false
+      }
+    ```
+
 ## Scheduler Management:
 
   ### Create
@@ -602,7 +652,7 @@ All API responses include a `X-Maestro-Version` header with the current Maestro 
       }
     ```
 
-    It will return an error if image was not sent on body 
+    It will return an error if image was not sent on body
 
     * Code: `422`
     * Content:
@@ -670,7 +720,7 @@ All API responses include a `X-Maestro-Version` header with the current Maestro 
       }
     ```
 
-    It will return an error if min was not sent on body 
+    It will return an error if min was not sent on body
 
     * Code: `422`
     * Content:
@@ -922,7 +972,7 @@ All API responses include a `X-Maestro-Version` header with the current Maestro 
       }
     ```
 
-  ### Scale 
+  ### Scale
 
   `POST /scheduler/:schedulerName`
 
@@ -980,7 +1030,7 @@ All API responses include a `X-Maestro-Version` header with the current Maestro 
 
   `GET /scheduler/:schedulerName/releases`
 
-  Returns the releases (versions) of the scheduler. 
+  Returns the releases (versions) of the scheduler.
   A minor release means that the scheduler changed but the pods didn't need to be recreated. Every attribute related only to Maestro and not to the pods does that, e.g.: autoscaling values, forwarder configurations, etc. This means that the pod can have as label version=v1.0 and the scheduler is in version v1.1.
   A major relese means that the pods needed to be recreated in order to respect the new scheduler configuration, e.g.: new image, new ports, new env var, new command. In this case, the scheduler will go, for example, from v1.0 to v2.0 and all new pods must have label verion=v2.0.
 

--- a/metadata/version.go
+++ b/metadata/version.go
@@ -11,4 +11,4 @@ package metadata
 var Version = "7.2.2"
 
 //KubeVersion is the desired Kubernetes version
-var KubeVersion = "v1.7.5"
+var KubeVersion = "v1.10.0"

--- a/models/autoscaler.go
+++ b/models/autoscaler.go
@@ -7,6 +7,8 @@
 
 package models
 
+import "k8s.io/api/core/v1"
+
 // AutoScalingPolicyType defines all types of autoscaling policies available
 type AutoScalingPolicyType string
 
@@ -20,3 +22,47 @@ const (
 	// MemAutoScalingPolicyType defines memory usage autoscaling policy type
 	MemAutoScalingPolicyType AutoScalingPolicyType = "mem"
 )
+
+// GetAvailablePolicyTypes returns an array of available policy types
+func GetAvailablePolicyTypes() []AutoScalingPolicyType {
+	return []AutoScalingPolicyType{
+		LegacyAutoScalingPolicyType,
+		RoomAutoScalingPolicyType,
+		CPUAutoScalingPolicyType,
+		MemAutoScalingPolicyType,
+	}
+}
+
+// ValidPolicyType checks if a given string is a valid autoscaling policy type
+func ValidPolicyType(s string) bool {
+	for _, p := range GetAvailablePolicyTypes() {
+		if s == string(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// ResourcePolicyType returns a bool indicating if a given policy type has resourcess associated to it or not
+func ResourcePolicyType(policyType AutoScalingPolicyType) bool {
+	switch policyType {
+	case CPUAutoScalingPolicyType:
+		return true
+	case MemAutoScalingPolicyType:
+		return true
+	default:
+		return false
+	}
+}
+
+// GetResourceUsage returns the resource usage given a kubernetes resource and a policy type
+func GetResourceUsage(usage v1.ResourceList, policyType AutoScalingPolicyType) int64 {
+	switch policyType {
+	case CPUAutoScalingPolicyType:
+		return usage.Cpu().ScaledValue(-3)
+	case MemAutoScalingPolicyType:
+		return usage.Memory().ScaledValue(0)
+	default:
+		return 0
+	}
+}

--- a/models/autoscaler_test.go
+++ b/models/autoscaler_test.go
@@ -1,0 +1,83 @@
+// maestro
+// +build unit
+// https://github.com/topfreegames/maestro
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package models_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/topfreegames/maestro/models"
+)
+
+var _ = Describe("Autoscaler", func() {
+	Describe("ValidPolicyType", func() {
+		It("should return true for legacy policy type", func() {
+			Expect(models.ValidPolicyType("legacy")).To(BeTrue())
+		})
+
+		It("should return true for room policy type", func() {
+			Expect(models.ValidPolicyType("room")).To(BeTrue())
+		})
+
+		It("should return true for cpu policy type", func() {
+			Expect(models.ValidPolicyType("cpu")).To(BeTrue())
+		})
+
+		It("should return true for mem policy type", func() {
+			Expect(models.ValidPolicyType("mem")).To(BeTrue())
+		})
+
+		It("should return false if invalid policy type", func() {
+			Expect(models.ValidPolicyType("asjbkdhjs")).To(BeFalse())
+		})
+	})
+
+	Describe("ResourcePolicyType", func() {
+		It("should return false for legacy policy type", func() {
+			Expect(models.ResourcePolicyType(models.LegacyAutoScalingPolicyType)).To(BeFalse())
+		})
+
+		It("should return false for room policy type", func() {
+			Expect(models.ResourcePolicyType(models.RoomAutoScalingPolicyType)).To(BeFalse())
+		})
+
+		It("should return true for cpu policy type", func() {
+			Expect(models.ResourcePolicyType(models.CPUAutoScalingPolicyType)).To(BeTrue())
+		})
+
+		It("should return true for mem policy type", func() {
+			Expect(models.ResourcePolicyType(models.MemAutoScalingPolicyType)).To(BeTrue())
+		})
+	})
+
+	Describe("GetResourceUsage", func() {
+		resourceList := v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("500m"),
+			v1.ResourceMemory: resource.MustParse("100M"),
+		}
+
+		It("should return 0 for legacy policy type", func() {
+			Expect(models.GetResourceUsage(resourceList, models.LegacyAutoScalingPolicyType)).To(Equal(int64(0)))
+		})
+
+		It("should return 0 for room policy type", func() {
+			Expect(models.GetResourceUsage(resourceList, models.RoomAutoScalingPolicyType)).To(Equal(int64(0)))
+		})
+
+		It("should return true for cpu policy type", func() {
+			Expect(models.GetResourceUsage(resourceList, models.CPUAutoScalingPolicyType)).To(Equal(int64(500)))
+		})
+
+		It("should return true for mem policy type", func() {
+			Expect(models.GetResourceUsage(resourceList, models.MemAutoScalingPolicyType)).To(Equal(int64(100000000)))
+		})
+	})
+})

--- a/models/constants.go
+++ b/models/constants.go
@@ -43,6 +43,9 @@ const SegmentHMSet = "Redis/HMSet"
 //SegmentZRangeBy represents a segment
 const SegmentZRangeBy = "Redis/ZRangeBy"
 
+//SegmentSScan represents a segment
+const SegmentSScan = "Redis/SegmentSScan"
+
 //SegmentPipeExec represents a segment
 const SegmentPipeExec = "Redis/Exec"
 

--- a/models/constants.go
+++ b/models/constants.go
@@ -43,8 +43,8 @@ const SegmentHMSet = "Redis/HMSet"
 //SegmentZRangeBy represents a segment
 const SegmentZRangeBy = "Redis/ZRangeBy"
 
-//SegmentSScan represents a segment
-const SegmentSScan = "Redis/SegmentSScan"
+//SegmentSRandMember represents a segment
+const SegmentSRandMember = "Redis/SegmentSRandMember"
 
 //SegmentPipeExec represents a segment
 const SegmentPipeExec = "Redis/Exec"

--- a/models/game_room.go
+++ b/models/game_room.go
@@ -145,7 +145,7 @@ func createPod(
 	name := fmt.Sprintf("%s-%s", configYAML.Name, randID)
 	room := NewRoom(name, configYAML.Name)
 	err := mr.WithSegment(SegmentInsert, func() error {
-		return room.Create(redisClient, db, mr, configYAML)
+		return room.Create(redisClient, db, mr, scheduler)
 	})
 	if err != nil {
 		return nil, err

--- a/models/game_room_test.go
+++ b/models/game_room_test.go
@@ -133,6 +133,8 @@ var _ = Describe("GameRoomManagement", func() {
 		err := yaml.Unmarshal([]byte(schedulerYaml_game_room_test), &configYaml1)
 		Expect(err).NotTo(HaveOccurred())
 		scheduler = models.NewScheduler(configYaml1.Name, configYaml1.Game, yaml1)
+		scheduler.Name = namespace
+		scheduler.Game = game
 	})
 
 	Context("GameRoom", func() {

--- a/models/room.go
+++ b/models/room.go
@@ -390,9 +390,8 @@ func GetRoomsOccupiedTimeout(redisClient interfaces.RedisClient, schedulerName s
 	return result, err
 }
 
-func getReadyRooms(redisClient interfaces.RedisClient, schedulerName string, size int, mr *MixedMetricsReporter) ([]string, error) {
+func getReadyRooms(tx redis.Pipeliner, schedulerName string, size int, mr *MixedMetricsReporter) ([]string, error) {
 	var result []string
-	tx := redisClient.TxPipeline()
 	rooms := tx.SScan(
 		GetRoomStatusSetRedisKey(schedulerName, StatusReady),
 		uint64(0),
@@ -425,7 +424,7 @@ func GetRoomsByMetric(redisClient interfaces.RedisClient, schedulerName string, 
 	// TODO hacky, one day add ZRange and SScan to redis interface
 	tx := redisClient.TxPipeline()
 	if metricName == string(RoomAutoScalingPolicyType) || metricName == string(LegacyAutoScalingPolicyType) {
-		return getReadyRooms(redisClient, schedulerName, size, mr)
+		return getReadyRooms(tx, schedulerName, size, mr)
 	}
 	rooms := tx.ZRange(
 		GetRoomMetricsRedisKey(schedulerName, metricName),

--- a/models/room_test.go
+++ b/models/room_test.go
@@ -10,6 +10,7 @@ package models_test
 
 import (
 	"fmt"
+	"math"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -21,6 +22,7 @@ import (
 	"github.com/go-redis/redis"
 	"github.com/golang/mock/gomock"
 	"github.com/topfreegames/maestro/models"
+	"github.com/topfreegames/maestro/testing"
 
 	goredis "github.com/go-redis/redis"
 	uuid "github.com/satori/go.uuid"
@@ -56,6 +58,45 @@ cmd:
   - "-serverType"
   - "6a8e136b-2dc1-417e-bbe8-0f0a2d2df431"
 `
+	yamlRoom2 = `
+name: %s
+game: game-name
+limits:
+  memory: "128Mi"
+  cpu: "1"
+autoscaling:
+  min: 100
+  up:
+    delta: 10
+    trigger:
+      usage: 70
+      time: 600
+      threshold: 80
+    cooldown: 300
+    metricsTrigger:
+    - type: cpu
+      delta: 2
+      time: 60
+      usage: 80
+      threshold: 80
+      limit: 90
+  down:
+    delta: 2
+    trigger:
+      usage: 50
+      time: 900
+      threshold: 80
+    metricsTrigger:
+    - type: mem
+      delta: 2
+      time: 60
+      usage: 80
+      threshold: 80
+      limit: 90
+    cooldown: 300
+cmd:
+  - "./room-binary"
+`
 )
 
 var _ = Describe("Room", func() {
@@ -63,11 +104,7 @@ var _ = Describe("Room", func() {
 		metricsClientset = metricsFake.NewSimpleClientset()
 		schedulerName    = uuid.NewV4().String()
 		name             = uuid.NewV4().String()
-		scheduler        = &models.Scheduler{
-			Name: schedulerName,
-			Game: "game-name",
-			YAML: fmt.Sprintf(yamlRoom, schedulerName),
-		}
+		scheduler        *models.Scheduler
 	)
 
 	reportStatus := func(scheduler, status, roomKey, statusKey string) {
@@ -87,6 +124,47 @@ var _ = Describe("Room", func() {
 			"gauge":                         "5",
 		})
 	}
+
+	mockSetStatusWithoutMetrics := func(room *models.Room, lastStatus, status string) {
+		allStatus := []string{
+			models.StatusCreating,
+			models.StatusOccupied,
+			models.StatusTerminating,
+			models.StatusTerminated,
+		}
+
+		mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+		mockPipeline.EXPECT().HMSet(room.GetRoomRedisKey(), gomock.Any())
+		mockPipeline.EXPECT().ZAdd(models.GetRoomPingRedisKey(room.SchedulerName), gomock.Any())
+		for _, st := range allStatus {
+			mockPipeline.EXPECT().SRem(models.GetRoomStatusSetRedisKey(room.SchedulerName, st), room.GetRoomRedisKey())
+		}
+		mockPipeline.EXPECT().ZRem(models.GetLastStatusRedisKey(room.SchedulerName, lastStatus), room.ID)
+		mockPipeline.EXPECT().SAdd(models.GetRoomStatusSetRedisKey(room.SchedulerName, status), room.GetRoomRedisKey())
+
+		mockPipeline.EXPECT().SCard(
+			models.GetRoomStatusSetRedisKey(room.SchedulerName, models.StatusCreating),
+		).Return(goredis.NewIntResult(0, nil))
+		mockPipeline.EXPECT().SCard(
+			models.GetRoomStatusSetRedisKey(room.SchedulerName, models.StatusReady),
+		).Return(goredis.NewIntResult(5, nil))
+		mockPipeline.EXPECT().SCard(
+			models.GetRoomStatusSetRedisKey(room.SchedulerName, models.StatusOccupied),
+		).Return(goredis.NewIntResult(0, nil))
+		mockPipeline.EXPECT().SCard(
+			models.GetRoomStatusSetRedisKey(room.SchedulerName, models.StatusTerminating),
+		).Return(goredis.NewIntResult(0, nil))
+
+		mockPipeline.EXPECT().Exec()
+	}
+
+	BeforeEach(func() {
+		scheduler = &models.Scheduler{
+			Name: schedulerName,
+			Game: "game-name",
+			YAML: fmt.Sprintf(yamlRoom, schedulerName),
+		}
+	})
 
 	Describe("NewRoom", func() {
 		It("should build correct room struct", func() {
@@ -210,6 +288,111 @@ var _ = Describe("Room", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(roomsCountByStatus).NotTo(BeNil())
 			Expect(roomsCountByStatus.Total()).To(Equal(5))
+		})
+
+		Context("when scheduler uses metrics trigger", func() {
+			var (
+				room       *models.Room
+				status     string
+				lastStatus string
+			)
+			BeforeEach(func() {
+				scheduler = &models.Scheduler{
+					Name: schedulerName,
+					Game: "game-name",
+					YAML: fmt.Sprintf(yamlRoom2, schedulerName),
+				}
+				room = models.NewRoom(name, schedulerName)
+				status = models.StatusReady
+				lastStatus = models.StatusOccupied
+			})
+
+			It("should add utilization metrics to redis", func() {
+				mockPipeline.EXPECT().ZAdd(models.GetRoomMetricsRedisKey(schedulerName, "cpu"), gomock.Any()).Do(
+					func(_ string, args redis.Z) {
+						Expect(args.Member).To(Equal(name))
+						Expect(args.Score).To(BeEquivalentTo(700))
+					})
+				mockPipeline.EXPECT().ZAdd(models.GetRoomMetricsRedisKey(schedulerName, "mem"), gomock.Any()).Do(
+					func(_ string, args redis.Z) {
+						Expect(args.Member).To(Equal(name))
+						Expect(args.Score).To(BeEquivalentTo(600))
+					})
+				mockSetStatusWithoutMetrics(room, lastStatus, status)
+				reportStatus(
+					room.SchedulerName,
+					status,
+					room.GetRoomRedisKey(),
+					models.GetRoomStatusSetRedisKey(schedulerName, status))
+
+				containerMetrics := testing.BuildContainerMetricsArray(
+					[]testing.ContainerMetricsDefinition{
+						testing.ContainerMetricsDefinition{
+							Name: room.ID,
+							Usage: map[models.AutoScalingPolicyType]int{
+								models.CPUAutoScalingPolicyType: 500,
+								models.MemAutoScalingPolicyType: 400,
+							},
+							MemScale: 0,
+						},
+						testing.ContainerMetricsDefinition{
+							Name: room.ID,
+							Usage: map[models.AutoScalingPolicyType]int{
+								models.CPUAutoScalingPolicyType: 200,
+								models.MemAutoScalingPolicyType: 200,
+							},
+							MemScale: 0,
+						},
+					},
+				)
+				fakeMetricsClient := testing.CreatePodMetricsList(containerMetrics, schedulerName)
+				roomsCountByStatus, err := room.SetStatus(mockRedisClient, mockDb, fakeMetricsClient, mmr, status, scheduler, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(roomsCountByStatus).NotTo(BeNil())
+				Expect(roomsCountByStatus.Total()).To(Equal(5))
+			})
+
+			It("should add utilization metrics to redis if metrics not yet available", func() {
+				mockPipeline.EXPECT().ZAdd(models.GetRoomMetricsRedisKey(schedulerName, "cpu"), gomock.Any()).Do(
+					func(_ string, args redis.Z) {
+						Expect(args.Member).To(Equal(name))
+						Expect(args.Score).To(BeNumerically("~", math.MaxInt64, 1))
+					})
+				mockPipeline.EXPECT().ZAdd(models.GetRoomMetricsRedisKey(schedulerName, "mem"), gomock.Any()).Do(
+					func(_ string, args redis.Z) {
+						Expect(args.Member).To(Equal(name))
+						Expect(args.Score).To(BeNumerically("~", math.MaxInt64, 1))
+					})
+				mockSetStatusWithoutMetrics(room, lastStatus, status)
+				reportStatus(
+					room.SchedulerName,
+					status,
+					room.GetRoomRedisKey(),
+					models.GetRoomStatusSetRedisKey(schedulerName, status))
+
+				fakeMetricsClient := testing.CreatePodMetricsList(nil, schedulerName, errors.New("scheduler not found"))
+				roomsCountByStatus, err := room.SetStatus(mockRedisClient, mockDb, fakeMetricsClient, mmr, status, scheduler, true)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(roomsCountByStatus).NotTo(BeNil())
+				Expect(roomsCountByStatus.Total()).To(Equal(5))
+			})
+
+			It("should not add utilization metrics to redis if unknown error occured", func() {
+				mockSetStatusWithoutMetrics(room, lastStatus, status)
+				reportStatus(
+					room.SchedulerName,
+					status,
+					room.GetRoomRedisKey(),
+					models.GetRoomStatusSetRedisKey(schedulerName, status))
+
+				fakeMetricsClient := testing.CreatePodMetricsList(nil, schedulerName, errors.New("unknown"))
+				roomsCountByStatus, err := room.SetStatus(mockRedisClient, mockDb, fakeMetricsClient, mmr, status, scheduler, true)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(roomsCountByStatus).NotTo(BeNil())
+				Expect(roomsCountByStatus.Total()).To(Equal(5))
+			})
 		})
 
 		It("should remove from redis is status is 'terminated'", func() {

--- a/models/room_test.go
+++ b/models/room_test.go
@@ -61,7 +61,7 @@ cmd:
 	yamlRoom2 = `
 name: %s
 game: game-name
-limits:
+requests:
   memory: "128Mi"
   cpu: "1"
 autoscaling:
@@ -316,7 +316,7 @@ var _ = Describe("Room", func() {
 				mockPipeline.EXPECT().ZAdd(models.GetRoomMetricsRedisKey(schedulerName, "mem"), gomock.Any()).Do(
 					func(_ string, args redis.Z) {
 						Expect(args.Member).To(Equal(name))
-						Expect(args.Score).To(BeEquivalentTo(600))
+						Expect(args.Score).To(BeEquivalentTo(60000000))
 					})
 				mockSetStatusWithoutMetrics(room, lastStatus, status)
 				reportStatus(
@@ -325,13 +325,27 @@ var _ = Describe("Room", func() {
 					room.GetRoomRedisKey(),
 					models.GetRoomStatusSetRedisKey(schedulerName, status))
 
+				mr.EXPECT().Report("gru.metric", map[string]interface{}{
+					reportersConstants.TagGame:      scheduler.Game,
+					reportersConstants.TagScheduler: scheduler.Name,
+					reportersConstants.TagMetric:    "cpu",
+					"gauge": "0.70",
+				})
+
+				mr.EXPECT().Report("gru.metric", map[string]interface{}{
+					reportersConstants.TagGame:      scheduler.Game,
+					reportersConstants.TagScheduler: scheduler.Name,
+					reportersConstants.TagMetric:    "mem",
+					"gauge": "0.45",
+				})
+
 				containerMetrics := testing.BuildContainerMetricsArray(
 					[]testing.ContainerMetricsDefinition{
 						testing.ContainerMetricsDefinition{
 							Name: room.ID,
 							Usage: map[models.AutoScalingPolicyType]int{
 								models.CPUAutoScalingPolicyType: 500,
-								models.MemAutoScalingPolicyType: 400,
+								models.MemAutoScalingPolicyType: 40000000,
 							},
 							MemScale: 0,
 						},
@@ -339,7 +353,7 @@ var _ = Describe("Room", func() {
 							Name: room.ID,
 							Usage: map[models.AutoScalingPolicyType]int{
 								models.CPUAutoScalingPolicyType: 200,
-								models.MemAutoScalingPolicyType: 200,
+								models.MemAutoScalingPolicyType: 20000000,
 							},
 							MemScale: 0,
 						},

--- a/models/room_test.go
+++ b/models/room_test.go
@@ -666,8 +666,8 @@ var _ = Describe("Room", func() {
 					expectedRet[idx] = r.GetRoomRedisKey()
 				}
 				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-				mockPipeline.EXPECT().SScan(pKey, uint64(0), "", int64(size)).Return(
-					redis.NewScanCmdResult(expectedRet, 0, nil))
+				mockPipeline.EXPECT().SRandMemberN(pKey, int64(size)).Return(
+					redis.NewStringSliceResult(expectedRet, nil))
 				mockPipeline.EXPECT().Exec()
 
 				rooms, err := models.GetRoomsByMetric(mockRedisClient, scheduler, metric, size, mmr)
@@ -682,8 +682,8 @@ var _ = Describe("Room", func() {
 				pKey := models.GetRoomStatusSetRedisKey(scheduler, models.StatusReady)
 
 				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-				mockPipeline.EXPECT().SScan(pKey, uint64(0), "", int64(size)).Return(
-					redis.NewScanCmdResult([]string{}, 0, errors.New("some error")))
+				mockPipeline.EXPECT().SRandMemberN(pKey, int64(size)).Return(
+					redis.NewStringSliceResult([]string{}, errors.New("some error")))
 				mockPipeline.EXPECT().Exec()
 
 				_, err := models.GetRoomsByMetric(mockRedisClient, scheduler, metric, size, mmr)

--- a/reporters/constants/constants.go
+++ b/reporters/constants/constants.go
@@ -2,10 +2,11 @@ package constants
 
 // Constants for event metrics possible of being reported
 const (
-	EventGruNew    = "gru.new"
-	EventGruPing   = "gru.ping"
-	EventGruDelete = "gru.delete"
-	EventGruStatus = "gru.status"
+	EventGruNew         = "gru.new"
+	EventGruPing        = "gru.ping"
+	EventGruDelete      = "gru.delete"
+	EventGruStatus      = "gru.status"
+	EventGruMetricUsage = "gru.metric"
 
 	EventSchedulerCreate = "scheduler.create"
 	EventSchedulerUpdate = "scheduler.update"
@@ -51,6 +52,7 @@ const (
 	TagTable        = "maestro-table"
 	TagType         = "maestro-type"
 	TagError        = "maestro-error"
+	TagMetric       = "maestro-metric"
 )
 
 // Value{...} are values that reporters use

--- a/reporters/dogstatsd/handlers.go
+++ b/reporters/dogstatsd/handlers.go
@@ -26,6 +26,7 @@ var handlers = map[string]interface{}{
 	constants.EventHTTPResponseTime: HTTPTimingHandler,
 	constants.EventPodLastStatus:    GaugeHandler,
 	constants.EventResponseTime:     TimingHandler,
+	constants.EventGruMetricUsage:   GaugeHandler,
 }
 
 // Find looks for a matching handler to a given event
@@ -133,6 +134,6 @@ func GaugeHandler(
 	if err != nil {
 		return err
 	}
-	c.Gauge(constants.EventPodLastStatus, gauge, tags, 1)
+	c.Gauge(event, gauge, tags, 1)
 	return nil
 }

--- a/scripts/start-minikube-if-not-yet.sh
+++ b/scripts/start-minikube-if-not-yet.sh
@@ -14,7 +14,7 @@ if [ ! $(which kubectl) ]; then
   elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
     echo "Installing kubectl on Linux"
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-  else 
+  else
     echo "No support to that system"
     exit 1
   fi
@@ -45,14 +45,14 @@ if [ ! $(which minikube) ]; then
     sudo apt-get install libvirt-bin qemu-kvm
     echo Installing minikube on Linux
     curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-    chmod +x minikube 
+    chmod +x minikube
     sudo mv minikube /usr/local/bin/
-  else 
+  else
     echo No support to that system
     exit 1
   fi
-fi 
- 
+fi
+
 localKubeVersion=$(kubectl version --short=true | awk '/Server/{print $3}')
 desiredKubeVersion=$(cat ./metadata/version.go | grep "KubeVersion" | egrep -oh "v(\d+\.?)+")
 if [ "$localKubeVersion" != "$desiredKubeVersion" ]; then
@@ -64,7 +64,7 @@ echo Starting minikube
 if [ $(minikube ip) ]; then
   echo Minikube already started
 elif [ "$(uname)" = "Darwin" ]; then
-  minikube start --vm-driver=xhyve --kubernetes-version $desiredKubeVersion
+  minikube start --vm-driver hyperkit --kubernetes-version $desiredKubeVersion
 elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
   sudo minikube start --vm-driver=kvm
 else

--- a/testing/common.go
+++ b/testing/common.go
@@ -893,50 +893,6 @@ func MockGetUsages(
 	mockPipeline.EXPECT().Exec().Times(times)
 }
 
-// MockGetUsages mockes the return of usage percentages from redis
-// func MockGetUsages(
-// 	mockPipeline *redismocks.MockPipeliner,
-// 	mockRedisClient *redismocks.MockRedisClient,
-// 	key string,
-// 	size, usageUp, usageDown, percentageAboveUp, percentageAboveDown int,
-// ) {
-// 	// Up
-// 	if usageUp > 0 {
-// 		mid := size * percentageAboveUp / 100
-// 		usages := make([]string, size)
-// 		for idx := range usages {
-// 			if idx < mid {
-// 				usages[idx] = strconv.FormatFloat(float64(usageUp)/100+0.1, 'f', 1, 32)
-// 			} else {
-// 				usages[idx] = strconv.FormatFloat(float64(usageUp)/100-0.1, 'f', 1, 32)
-// 			}
-// 		}
-// 		mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-// 		mockPipeline.EXPECT().LRange(key, gomock.Any(), gomock.Any()).Return(goredis.NewStringSliceResult(
-// 			usages, nil,
-// 		))
-// 		mockPipeline.EXPECT().Exec()
-// 	}
-
-// 	// Down
-// 	if usageDown > 0 {
-// 		mid := size * percentageAboveDown / 100
-// 		usages := make([]string, size)
-// 		for idx := range usages {
-// 			if idx < mid {
-// 				usages[idx] = strconv.FormatFloat(float64(usageDown)/100-0.1, 'f', 1, 32)
-// 			} else {
-// 				usages[idx] = strconv.FormatFloat(float64(usageDown)/100+0.1, 'f', 1, 32)
-// 			}
-// 		}
-// 		mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
-// 		mockPipeline.EXPECT().LRange(key, gomock.Any(), gomock.Any()).Return(goredis.NewStringSliceResult(
-// 			usages, nil,
-// 		))
-// 		mockPipeline.EXPECT().Exec()
-// 	}
-// }
-
 // MockGetScheduler mocks the retrieval of a scheduler
 func MockGetScheduler(
 	mockDb *pgmocks.MockDB,
@@ -1135,7 +1091,30 @@ func CreatePod(clientset *fake.Clientset, cpuRequests, memRequests, schedulerNam
 	clientset.CoreV1().Pods(schedulerName).Create(pod)
 }
 
-// CreatePodsMetricsList returns a fakeMetricsClientset with reactor to PodMetricses call
+// CreatePodMetricsList returns a fakeMetricsClientset with reactor to PodMetricses Get call
+func CreatePodMetricsList(containers []metricsapi.ContainerMetrics, schedulerName string, errArray ...error) *fakeMetricsClient.Clientset {
+	myFakeMetricsClient := &fakeMetricsClient.Clientset{}
+
+	myFakeMetricsClient.AddReactor("get", "pods", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+		if len(errArray) > 0 && errArray[0] != nil {
+			return true, nil, errArray[0]
+		}
+		podMetric := &metricsapi.PodMetrics{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      schedulerName,
+				Namespace: schedulerName,
+			},
+			Timestamp:  metav1.Time{Time: time.Now()},
+			Window:     metav1.Duration{Duration: time.Minute},
+			Containers: containers,
+		}
+		return true, podMetric, nil
+	})
+
+	return myFakeMetricsClient
+}
+
+// CreatePodsMetricsList returns a fakeMetricsClientset with reactor to PodMetricses List call
 // It will use the same array of containers for every pod
 func CreatePodsMetricsList(containers []metricsapi.ContainerMetrics, numPods int, schedulerName string) *fakeMetricsClient.Clientset {
 	myFakeMetricsClient := &fakeMetricsClient.Clientset{}
@@ -1154,7 +1133,6 @@ func CreatePodsMetricsList(containers []metricsapi.ContainerMetrics, numPods int
 			}
 			metrics.Items = append(metrics.Items, podMetric)
 		}
-
 		return true, metrics, nil
 	})
 

--- a/watcher/watcher_suite_test.go
+++ b/watcher/watcher_suite_test.go
@@ -42,7 +42,17 @@ var (
 	mockEventForwarder *eventforwardermock.MockEventForwarder
 	mr                 *models.MixedMetricsReporter
 	redisClient        *redis.Client
-	allStatus          = []string{models.StatusCreating, models.StatusReady, models.StatusOccupied, models.StatusTerminating, models.StatusTerminated}
+	allStatus          = []string{
+		models.StatusCreating,
+		models.StatusReady,
+		models.StatusOccupied,
+		models.StatusTerminating,
+		models.StatusTerminated,
+	}
+	allMetrics = []string{
+		string(models.CPUAutoScalingPolicyType),
+		string(models.MemAutoScalingPolicyType),
+	}
 )
 
 func TestWatcher(t *testing.T) {

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -1120,6 +1120,9 @@ var _ = Describe("Watcher", func() {
 						ZRem(gomock.Any(), gomock.Any())
 				}
 				mockPipeline.EXPECT().ZRem(models.GetRoomPingRedisKey(configYaml.Name), gomock.Any())
+				for _, mt := range allMetrics {
+					mockPipeline.EXPECT().ZRem(models.GetRoomMetricsRedisKey(configYaml.Name, mt), gomock.Any())
+				}
 				mockPipeline.EXPECT().Del(gomock.Any())
 				mockPipeline.EXPECT().Exec()
 
@@ -1322,6 +1325,9 @@ var _ = Describe("Watcher", func() {
 							ZRem(models.GetLastStatusRedisKey(room.SchedulerName, status), room.ID)
 					}
 					mockPipeline.EXPECT().ZRem(models.GetRoomPingRedisKey(scheduler.Name), room.ID)
+					for _, mt := range allMetrics {
+						mockPipeline.EXPECT().ZRem(models.GetRoomMetricsRedisKey(room.SchedulerName, mt), gomock.Any())
+					}
 					mockPipeline.EXPECT().Del(room.GetRoomRedisKey())
 					mockPipeline.EXPECT().Exec()
 				}
@@ -1662,6 +1668,9 @@ var _ = Describe("Watcher", func() {
 						ZRem(gomock.Any(), gomock.Any())
 				}
 				mockPipeline.EXPECT().ZRem(models.GetRoomPingRedisKey(configYaml.Name), gomock.Any())
+				for _, mt := range allMetrics {
+					mockPipeline.EXPECT().ZRem(models.GetRoomMetricsRedisKey(configYaml.Name, mt), gomock.Any())
+				}
 				mockPipeline.EXPECT().Del(gomock.Any())
 				mockPipeline.EXPECT().Exec()
 
@@ -3959,6 +3968,9 @@ var _ = Describe("Watcher", func() {
 					mockPipeline.EXPECT().ZRem(models.GetLastStatusRedisKey(schedulerName, status), roomName).Times(2)
 				}
 				mockPipeline.EXPECT().ZRem(models.GetRoomPingRedisKey(schedulerName), roomName).Times(2)
+				for _, mt := range allMetrics {
+					mockPipeline.EXPECT().ZRem(models.GetRoomMetricsRedisKey(schedulerName, mt), roomName).Times(2)
+				}
 				mockPipeline.EXPECT().Del(room.GetRoomRedisKey()).Times(2)
 				mockPipeline.EXPECT().Exec().Times(2)
 			}
@@ -4020,6 +4032,9 @@ var _ = Describe("Watcher", func() {
 					mockPipeline.EXPECT().ZRem(models.GetLastStatusRedisKey(schedulerName, status), roomName)
 				}
 				mockPipeline.EXPECT().ZRem(models.GetRoomPingRedisKey(schedulerName), roomName)
+				for _, mt := range allMetrics {
+					mockPipeline.EXPECT().ZRem(models.GetRoomMetricsRedisKey(schedulerName, mt), gomock.Any())
+				}
 				mockPipeline.EXPECT().Del(room.GetRoomRedisKey())
 				mockPipeline.EXPECT().Exec()
 			}
@@ -4143,6 +4158,9 @@ var _ = Describe("Watcher", func() {
 			}
 			mockPipeline.EXPECT().
 				ZRem(models.GetRoomPingRedisKey(w.SchedulerName), room.ID)
+			for _, mt := range allMetrics {
+				mockPipeline.EXPECT().ZRem(models.GetRoomMetricsRedisKey(w.SchedulerName, mt), gomock.Any())
+			}
 			mockPipeline.EXPECT().Del(room.GetRoomRedisKey())
 			mockPipeline.EXPECT().Exec().Return(nil, errDB)
 
@@ -4181,6 +4199,9 @@ var _ = Describe("Watcher", func() {
 			}
 			mockPipeline.EXPECT().
 				ZRem(models.GetRoomPingRedisKey(w.SchedulerName), room.ID)
+			for _, mt := range allMetrics {
+				mockPipeline.EXPECT().ZRem(models.GetRoomMetricsRedisKey(w.SchedulerName, mt), gomock.Any())
+			}
 			mockPipeline.EXPECT().Del(room.GetRoomRedisKey())
 			mockPipeline.EXPECT().Exec()
 

--- a/worker/worker_suite_int_test.go
+++ b/worker/worker_suite_int_test.go
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 	config.Set("pingTimeout", 600)
 	config.Set("occupiedTimeout", 1)
 
-	app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", nil, nil, nil, nil, clientset)
+	app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, false, "", nil, nil, nil, nil, clientset, metricsClientset)
 	Expect(err).NotTo(HaveOccurred())
 
 	user := &login.User{


### PR DESCRIPTION
This PR adds a route that returns a list of rooms ordered by a metric. For `legacy` and `room` metrics it returns at most `limit` available rooms. For `cpu` and `mem` metrics it returns at most `limit` rooms ordered by increasing cpu or memory usage.

Also, I'm now reporting room usage metrics (cpu and memory) when a ping event is received if the corresponding metrics trigger is enabled.

Last but not least, I've fixed a bug that allowed a scheduler to be updated with metrics autoscaling bu no requests specified.

In a later PR we might change the cpu and memory autoscaler to retrieve the data we're now storing in Redis instead of calling Kubernetes API. 