### PR TITLE
Room Addresses caching & go-extensions-k8s-client-go update

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -29,22 +29,6 @@
   revision = "86919dfcf80873d58ea2e527c15b1e02a5636ead"
 
 [[projects]]
-  digest = "1:8e47871087b94913898333f37af26732faaab30cdb41571136cf7aec9921dae7"
-  name = "github.com/PuerkitoBio/purell"
-  packages = ["."]
-  pruneopts = ""
-  revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
-  version = "v1.1.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:331a419049c2be691e5ba1d24342fc77c7e767a80c666a18fd8a9f7b82419c1c"
-  name = "github.com/PuerkitoBio/urlesc"
-  packages = ["."]
-  pruneopts = ""
-  revision = "de5bf2ad457846296e2031421a34e2568e304e35"
-
-[[projects]]
   digest = "1:37251e285603dd429a07371891a251b036a1a84bc8beaf16e6a04adb1e3e8389"
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
@@ -93,17 +77,6 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:8a34d7a37b8f07239487752e14a5faafcbbc718fc385ad429a2c4ac6f27a207f"
-  name = "github.com/emicklei/go-restful"
-  packages = [
-    ".",
-    "log",
-  ]
-  pruneopts = ""
-  revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
-  version = "v2.8.0"
-
-[[projects]]
   digest = "1:9f1e571696860f2b4f8a241b43ce91c6085e7aaed849ccca53f590a4dc7b95bd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
@@ -134,38 +107,6 @@
   pruneopts = ""
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
-
-[[projects]]
-  digest = "1:e116a4866bffeec941056a1fcfd37e520fad1ee60e4e3579719f19a43c392e10"
-  name = "github.com/go-openapi/jsonpointer"
-  packages = ["."]
-  pruneopts = ""
-  revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
-  version = "0.16.0"
-
-[[projects]]
-  digest = "1:3830527ef0f4f9b268d9286661c0f52f9115f8aefd9f45ee7352516f93489ac9"
-  name = "github.com/go-openapi/jsonreference"
-  packages = ["."]
-  pruneopts = ""
-  revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
-  version = "0.16.0"
-
-[[projects]]
-  digest = "1:222a38a6f9a0bac95fa14fb97b0bf4734dd652a3341306aa79dda33980d91f42"
-  name = "github.com/go-openapi/spec"
-  packages = ["."]
-  pruneopts = ""
-  revision = "384415f06ee238aae1df5caad877de6ceac3a5c4"
-  version = "0.16.0"
-
-[[projects]]
-  digest = "1:a8255150a79fa9cc785561966bacda7ff5b386abed1b5f5a9a784660407df836"
-  name = "github.com/go-openapi/swag"
-  packages = ["."]
-  pruneopts = ""
-  revision = "becd2f08beafcca035645a8a101e0e3e18140458"
-  version = "0.16.0"
 
 [[projects]]
   digest = "1:9d3afdcb2bb84f114df864f13ab5ec02bb8249ecad9803fcdfb717052f9265b8"
@@ -363,6 +304,7 @@
   revision = "1c35d901db3da928c72a72d8458480cc9ade058f"
 
 [[projects]]
+  digest = "1:31c6f3c4f1e15fcc24fcfc9f5f24603ff3963c56d6fa162116493b4025fb6acc"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = ""
@@ -387,18 +329,6 @@
   pruneopts = ""
   revision = "f917359f079a3759162704eaa8caeec3d01d9f91"
   version = "v1.7.2"
-
-[[projects]]
-  branch = "master"
-  digest = "1:212bebc561f4f654a653225868b2a97353cd5e160dc0b0bbc7232b06608474ec"
-  name = "github.com/mailru/easyjson"
-  packages = [
-    "buffer",
-    "jlexer",
-    "jwriter",
-  ]
-  pruneopts = ""
-  revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
   branch = "master"
@@ -670,14 +600,15 @@
   revision = "b8ad3d69db7176826b06c7173bd89eeef388b03a"
 
 [[projects]]
+  digest = "1:2eec5a9bc83841ab81b4e09aa9109015ec1c78c762f3788d7ae9e7b72e8fb1f2"
   name = "github.com/topfreegames/go-extensions-k8s-client-go"
   packages = [
     "kubernetes",
     "rest",
   ]
   pruneopts = ""
-  revision = "fca40c6c724da09dd6fce96ef406e206cd16e7fb"
-  version = "v2.0.4"
+  revision = "3c5ed223fb2ff2dbca5922341e4f66370196a827"
+  version = "kubernetes-1.11.7"
 
 [[projects]]
   branch = "master"
@@ -789,7 +720,6 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width",
   ]
   pruneopts = ""
   revision = "f4b4367115ec2de254587813edaa901bc1c723a8"
@@ -870,6 +800,7 @@
   revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
 
 [[projects]]
+  digest = "1:b7dfcf13245d66685997bc74c67c3d00b89b9e3e6bf6cfcdfa5b41ad44150445"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -907,6 +838,7 @@
   version = "kubernetes-1.11.7"
 
 [[projects]]
+  digest = "1:1cabd999b24a5205c04c88e95b3803fcb71512d563ed8e409ea7f88ab95f4230"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -914,7 +846,7 @@
     "pkg/api/resource",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
-    "pkg/apis/meta/v1alpha1",
+    "pkg/apis/meta/v1beta1",
     "pkg/conversion",
     "pkg/conversion/queryparams",
     "pkg/fields",
@@ -953,6 +885,7 @@
   version = "kubernetes-1.11.7"
 
 [[projects]]
+  digest = "1:d04779a8de7d5465e0463bd986506348de5e89677c74777f695d3145a7a8d15e"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1048,14 +981,12 @@
   branch = "master"
   digest = "1:951bc2047eea6d316a17850244274554f26fd59189360e45f4056b424dadf2c1"
   name = "k8s.io/kube-openapi"
-  packages = [
-    "pkg/common",
-    "pkg/util/proto",
-  ]
+  packages = ["pkg/util/proto"]
   pruneopts = ""
   revision = "e3762e86a74c878ffed47484592986685639c2cd"
 
 [[projects]]
+  digest = "1:4eb9dc49822944c6734b34daad6f5b04628966c641682fd86a6901b35fc9fba2"
   name = "k8s.io/metrics"
   packages = [
     "pkg/apis/metrics",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -81,6 +81,6 @@
   name = "github.com/spf13/viper"
   version = "v1.1.0"
 
-[[constraint]]
+[[override]]
   name = "github.com/topfreegames/go-extensions-k8s-client-go"
-  version = "v2.0.4"
+  version = "kubernetes-1.11.7"

--- a/api/app.go
+++ b/api/app.go
@@ -448,7 +448,6 @@ func (a *App) loadConfigurationDefaults() {
 	a.Config.SetDefault("jaeger.samplingProbability", 1.0)
 	a.Config.SetDefault("addrGetter.cache.use", false)
 	a.Config.SetDefault("addrGetter.cache.expirationInterval", "10m")
-	a.Config.SetDefault("addrGetter.cache.cleanupInterval", "30s")
 	a.Config.SetDefault(EnvironmentConfig, ProdEnvironment)
 }
 

--- a/api/app.go
+++ b/api/app.go
@@ -446,7 +446,7 @@ func (a *App) loadConfigurationDefaults() {
 	a.Config.SetDefault("api.limitManager.keyTimeout", 1*time.Minute)
 	a.Config.SetDefault("jaeger.disabled", false)
 	a.Config.SetDefault("jaeger.samplingProbability", 1.0)
-	a.Config.SetDefault("addrGetter.cache.use", true)
+	a.Config.SetDefault("addrGetter.cache.use", false)
 	a.Config.SetDefault("addrGetter.cache.expirationInterval", "10m")
 	a.Config.SetDefault("addrGetter.cache.cleanupInterval", "30s")
 	a.Config.SetDefault(EnvironmentConfig, ProdEnvironment)
@@ -572,19 +572,19 @@ func (a *App) configureServer(showProfile bool) {
 
 func (a *App) configureEnvironment() {
 	a.RoomAddrGetter = models.NewRoomAddressesFromHostPort(
+		a.Logger,
 		a.Config.GetString(Ipv6KubernetesLabelKey),
 		a.Config.GetBool("addrGetter.cache.use"),
 		a.Config.GetDuration("addrGetter.cache.expirationInterval"),
-		a.Config.GetDuration("addrGetter.cache.cleanupInterval"),
 	)
 	a.RoomManager = &models.GameRoom{}
 
 	if a.Config.GetString(EnvironmentConfig) == DevEnvironment {
 		a.RoomAddrGetter = models.NewRoomAddressesFromNodePort(
+			a.Logger,
 			a.Config.GetString(Ipv6KubernetesLabelKey),
 			a.Config.GetBool("addrGetter.cache.use"),
 			a.Config.GetDuration("addrGetter.cache.expirationInterval"),
-			a.Config.GetDuration("addrGetter.cache.cleanupInterval"),
 		)
 		a.RoomManager = &models.GameRoomWithService{}
 		a.Logger.Info("development environment")

--- a/api/app.go
+++ b/api/app.go
@@ -446,6 +446,9 @@ func (a *App) loadConfigurationDefaults() {
 	a.Config.SetDefault("api.limitManager.keyTimeout", 1*time.Minute)
 	a.Config.SetDefault("jaeger.disabled", false)
 	a.Config.SetDefault("jaeger.samplingProbability", 1.0)
+	a.Config.SetDefault("addrGetter.cache.use", true)
+	a.Config.SetDefault("addrGetter.cache.expirationInterval", "10m")
+	a.Config.SetDefault("addrGetter.cache.cleanupInterval", "30s")
 	a.Config.SetDefault(EnvironmentConfig, ProdEnvironment)
 }
 
@@ -568,11 +571,21 @@ func (a *App) configureServer(showProfile bool) {
 }
 
 func (a *App) configureEnvironment() {
-	a.RoomAddrGetter = models.NewRoomAddressesFromHostPort(a.Config.GetString(Ipv6KubernetesLabelKey))
+	a.RoomAddrGetter = models.NewRoomAddressesFromHostPort(
+		a.Config.GetString(Ipv6KubernetesLabelKey),
+		a.Config.GetBool("addrGetter.cache.use"),
+		a.Config.GetDuration("addrGetter.cache.expirationInterval"),
+		a.Config.GetDuration("addrGetter.cache.cleanupInterval"),
+	)
 	a.RoomManager = &models.GameRoom{}
 
 	if a.Config.GetString(EnvironmentConfig) == DevEnvironment {
-		a.RoomAddrGetter = models.NewRoomAddressesFromNodePort(a.Config.GetString(Ipv6KubernetesLabelKey))
+		a.RoomAddrGetter = models.NewRoomAddressesFromNodePort(
+			a.Config.GetString(Ipv6KubernetesLabelKey),
+			a.Config.GetBool("addrGetter.cache.use"),
+			a.Config.GetDuration("addrGetter.cache.expirationInterval"),
+			a.Config.GetDuration("addrGetter.cache.cleanupInterval"),
+		)
 		a.RoomManager = &models.GameRoomWithService{}
 		a.Logger.Info("development environment")
 		return

--- a/api/room_handler.go
+++ b/api/room_handler.go
@@ -87,6 +87,7 @@ func (g *RoomPingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, err = eventforwarder.ForwardRoomEvent(
 		ctx,
 		g.App.Forwarders,
+		g.App.RedisClient.Trace(ctx),
 		g.App.DBClient.WithContext(ctx),
 		kubernetesClient,
 		room, fmt.Sprintf("ping%s", strings.Title(payload.Status)),
@@ -212,6 +213,7 @@ func (g *RoomEventHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	resp, err := eventforwarder.ForwardRoomEvent(
 		r.Context(),
 		g.App.Forwarders,
+		g.App.RedisClient.Trace(ctx),
 		g.App.DBClient.WithContext(ctx),
 		kubernetesClient,
 		room,
@@ -293,6 +295,7 @@ func (g *RoomStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, err = eventforwarder.ForwardRoomEvent(
 		ctx,
 		g.App.Forwarders,
+		g.App.RedisClient.Trace(ctx),
 		g.App.DBClient.WithContext(ctx),
 		kubernetesClient,
 		room, payload.Status, "",
@@ -337,7 +340,7 @@ func (h *RoomAddressHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	room := models.NewRoom(params.Name, params.Scheduler)
 	kubernetesClient := kubernetes.TryWithContext(h.App.KubernetesClient, ctx)
-	roomAddresses, err := h.App.RoomAddrGetter.Get(room, kubernetesClient)
+	roomAddresses, err := h.App.RoomAddrGetter.Get(room, kubernetesClient, h.App.RedisClient.Trace(ctx))
 
 	if err != nil {
 		status := http.StatusInternalServerError

--- a/api/room_handler.go
+++ b/api/room_handler.go
@@ -291,7 +291,7 @@ func (g *RoomStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_, err = eventforwarder.ForwardRoomEvent(
-		r.Context(),
+		ctx,
 		g.App.Forwarders,
 		g.App.DBClient.WithContext(ctx),
 		kubernetesClient,

--- a/api/room_handler_test.go
+++ b/api/room_handler_test.go
@@ -114,6 +114,7 @@ forwarders:
 				})
 				request, _ = http.NewRequest("PUT", url, reader)
 
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 				mockDb.EXPECT().Query(gomock.Any(), "SELECT * FROM schedulers WHERE name = ?", namespace).
 					Do(func(scheduler *models.Scheduler, query string, modifier string) {
 						scheduler.YAML = yamlStr
@@ -146,6 +147,8 @@ forwarders:
 				})
 				request, _ = http.NewRequest("PUT", url, reader)
 
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 				mockDb.EXPECT().Query(gomock.Any(), "SELECT * FROM schedulers WHERE name = ?", namespace).
 					Do(func(scheduler *models.Scheduler, query string, modifier string) {
 						scheduler.YAML = yamlStr
@@ -277,6 +280,7 @@ forwarders:
 				})
 				request, _ = http.NewRequest("PUT", url, reader)
 
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 				mockDb.EXPECT().Query(gomock.Any(), "SELECT * FROM schedulers WHERE name = ?", namespace).
 					Do(func(scheduler *models.Scheduler, query string, modifier string) {
 						scheduler.YAML = yamlStr
@@ -329,6 +333,7 @@ forwarders:
 				})
 				request, _ = http.NewRequest("PUT", url, reader)
 
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 				mockDb.EXPECT().Query(gomock.Any(), "SELECT * FROM schedulers WHERE name = ?", namespace).
 					Do(func(scheduler *models.Scheduler, query string, modifier string) {
 						scheduler.YAML = yamlStr
@@ -437,6 +442,7 @@ forwarders:
 				})
 				request, _ = http.NewRequest("PUT", url, reader)
 
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 				mockDb.EXPECT().Query(gomock.Any(), "SELECT * FROM schedulers WHERE name = ?", namespace).
 					Do(func(scheduler *models.Scheduler, query string, modifier string) {
 						scheduler.YAML = yamlStr
@@ -591,6 +597,7 @@ forwarders:
 						mockPipeline.EXPECT().SRem(key, rKey)
 					}
 					mockPipeline.EXPECT().Exec()
+					mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 					mockDb.EXPECT().Query(gomock.Any(), "SELECT * FROM schedulers WHERE name = ?", namespace).
 						Do(func(scheduler *models.Scheduler, query string, modifier string) {
 							scheduler.YAML = yamlStr
@@ -629,6 +636,7 @@ forwarders:
 						mockPipeline.EXPECT().SRem(key, rKey)
 					}
 					mockPipeline.EXPECT().Exec()
+					mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 					mockDb.EXPECT().Query(gomock.Any(), "SELECT * FROM schedulers WHERE name = ?", namespace).
 						Do(func(scheduler *models.Scheduler, query string, modifier string) {
 							scheduler.YAML = yamlStr
@@ -906,6 +914,7 @@ forwarders:
 				scheduler.Game = game
 			})
 
+			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 			mockEventForwarder1.EXPECT().Forward(gomock.Any(), "roomEvent", gomock.Any(), gomock.Any()).Return(
 				int32(500), "", errors.New("some error occurred"),
 			)
@@ -929,6 +938,7 @@ forwarders:
 				"metadata":  make(map[string]interface{}),
 			})
 			request, _ = http.NewRequest("POST", url, reader)
+			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 			mockDb.EXPECT().Query(
 				gomock.Any(),
 				"SELECT * FROM schedulers WHERE name = ?",
@@ -961,6 +971,7 @@ forwarders:
 				"metadata":  make(map[string]interface{}),
 			})
 			request, _ = http.NewRequest("POST", url, reader)
+			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 			mockDb.EXPECT().Query(
 				gomock.Any(),
 				"SELECT * FROM schedulers WHERE name = ?",
@@ -1025,6 +1036,7 @@ forwarders:
 			_, err = pod.Create(clientset)
 			Expect(err).NotTo(HaveOccurred())
 
+			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 			url := fmt.Sprintf(
 				"/scheduler/%s/rooms/%s/address",
 				namespace,
@@ -1053,6 +1065,7 @@ forwarders:
 			_, err = pod.Create(clientset)
 			Expect(err).NotTo(HaveOccurred())
 
+			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 			namespace := "unexisting-name"
 			url := fmt.Sprintf(
 				"/scheduler/%s/rooms/%s/address",

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -77,4 +77,3 @@ addrGetter:
   cache:
     use: true
     expirationInterval: 10m
-    cleanupInterval: 30s

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -73,3 +73,8 @@ api:
   limitManager:
     keyTimeout: 1h
 ipv6KubernetesLabelKey: "local.io/ipv6"
+addrGetter:
+  cache:
+    use: true
+    expirationInterval: 10m
+    cleanupInterval: 30s

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -25,7 +25,7 @@ import (
 	"github.com/topfreegames/maestro/reporters"
 	reportersConstants "github.com/topfreegames/maestro/reporters/constants"
 	yaml "gopkg.in/yaml.v2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/sirupsen/logrus"

--- a/eventforwarder/eventforwarder_suite_test.go
+++ b/eventforwarder/eventforwarder_suite_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	pgmocks "github.com/topfreegames/extensions/pg/mocks"
+	redismocks "github.com/topfreegames/extensions/redis/mocks"
 	eventforwardermock "github.com/topfreegames/maestro/eventforwarder/mock"
 	reportermock "github.com/topfreegames/maestro/reporters/mocks"
 )
@@ -36,6 +37,7 @@ var (
 	mockDB                 *pgmocks.MockDB
 	mockEventForwarder     *eventforwardermock.MockEventForwarder
 	mockForwarders         []*eventforwarder.Info
+	mockRedisClient        *redismocks.MockRedisClient
 	mockReporter           *reportermock.MockReporter
 	room                   *models.Room
 	clientset              *fake.Clientset
@@ -77,6 +79,8 @@ var _ = BeforeEach(func() {
 	mockReporter = reportermock.NewMockReporter(mockCtrl)
 	r.SetReporter("mockReporter", mockReporter)
 
+	mockRedisClient = redismocks.NewMockRedisClient(mockCtrl)
+
 	clientset = fake.NewSimpleClientset()
 
 	mockDB = pgmocks.NewMockDB(mockCtrl)
@@ -114,5 +118,5 @@ var _ = BeforeEach(func() {
 	_, err = clientset.CoreV1().Nodes().Create(node)
 
 	room = models.NewRoom(roomName, schedulerName)
-	roomAddrGetter = models.NewRoomAddressesFromHostPort(ipv6KubernetesLabelKey, false, 0, 0)
+	roomAddrGetter = models.NewRoomAddressesFromHostPort(logger, ipv6KubernetesLabelKey, false, 0)
 })

--- a/eventforwarder/eventforwarder_suite_test.go
+++ b/eventforwarder/eventforwarder_suite_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/topfreegames/maestro/eventforwarder"
 	"github.com/topfreegames/maestro/models"
 	"github.com/topfreegames/maestro/reporters"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"testing"
@@ -114,5 +114,5 @@ var _ = BeforeEach(func() {
 	_, err = clientset.CoreV1().Nodes().Create(node)
 
 	room = models.NewRoom(roomName, schedulerName)
-	roomAddrGetter = models.NewRoomAddressesFromHostPort(ipv6KubernetesLabelKey)
+	roomAddrGetter = models.NewRoomAddressesFromHostPort(ipv6KubernetesLabelKey, false, 0, 0)
 })

--- a/eventforwarder/forward.go
+++ b/eventforwarder/forward.go
@@ -8,7 +8,8 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/topfreegames/extensions/pg/interfaces"
+	pginterfaces "github.com/topfreegames/extensions/pg/interfaces"
+	redisinterfaces "github.com/topfreegames/extensions/redis/interfaces"
 	"github.com/topfreegames/maestro/models"
 	"github.com/topfreegames/maestro/reporters"
 	reportersConstants "github.com/topfreegames/maestro/reporters/constants"
@@ -52,7 +53,8 @@ func getEnabledForwarders(
 func ForwardRoomEvent(
 	ctx context.Context,
 	forwarders []*Info,
-	db interfaces.DB,
+	redis redisinterfaces.RedisClient,
+	db pginterfaces.DB,
 	kubernetesClient kubernetes.Interface,
 	room *models.Room,
 	status string,
@@ -113,7 +115,7 @@ func ForwardRoomEvent(
 					"game":   cachedScheduler.Scheduler.Game,
 				}
 				if eventType != PingTimeoutEvent && eventType != OccupiedTimeoutEvent {
-					infos, err = room.GetRoomInfos(db, kubernetesClient, schedulerCache, cachedScheduler.Scheduler, addrGetter)
+					infos, err = room.GetRoomInfos(redis, db, kubernetesClient, schedulerCache, cachedScheduler.Scheduler, addrGetter)
 					metadata["ipv6Label"] = infos["ipv6Label"]
 
 					if err != nil {
@@ -146,7 +148,7 @@ func ForwardRoomEvent(
 func ForwardRoomInfo(
 	ctx context.Context,
 	forwarders []*Info,
-	db interfaces.DB,
+	db pginterfaces.DB,
 	kubernetesClient kubernetes.Interface,
 	schedulerName string,
 	schedulerCache *models.SchedulerCache,
@@ -201,7 +203,7 @@ func ForwardRoomInfo(
 func ForwardPlayerEvent(
 	ctx context.Context,
 	forwarders []*Info,
-	db interfaces.DB,
+	db pginterfaces.DB,
 	kubernetesClient kubernetes.Interface,
 	room *models.Room,
 	event string,
@@ -296,7 +298,7 @@ func ForwardEventToForwarders(
 func reportRPCStatus(
 	eventWasForwarded bool,
 	schedulerName, forwardRoute string,
-	db interfaces.DB,
+	db pginterfaces.DB,
 	cache *models.SchedulerCache,
 	logger logrus.FieldLogger,
 	eventForwarderErr error,

--- a/eventforwarder/forward_test.go
+++ b/eventforwarder/forward_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Forward", func() {
 			response, err := ForwardRoomEvent(
 				ctx,
 				mockForwarders,
+				mockRedisClient,
 				mockDB,
 				clientset,
 				room,
@@ -95,6 +96,7 @@ var _ = Describe("Forward", func() {
 			response, err := ForwardRoomEvent(
 				ctx,
 				mockForwarders,
+				mockRedisClient,
 				mockDB,
 				clientset,
 				room,
@@ -136,6 +138,7 @@ var _ = Describe("Forward", func() {
 			response, err = ForwardRoomEvent(
 				ctx,
 				mockForwarders,
+				mockRedisClient,
 				mockDB,
 				clientset,
 				room,
@@ -155,7 +158,7 @@ var _ = Describe("Forward", func() {
 		It("should report fail if event forward fails", func() {
 			errMsg := "event forward failed"
 			ctx := context.Background()
-			noIpv6roomAddrGetter := models.NewRoomAddressesFromHostPort("", false, 0, 0)
+			noIpv6roomAddrGetter := models.NewRoomAddressesFromHostPort(logger, "", false, 0)
 			mockEventForwarder.EXPECT().Forward(
 				ctx,
 				models.StatusReady,
@@ -190,6 +193,7 @@ var _ = Describe("Forward", func() {
 			response, err := ForwardRoomEvent(
 				ctx,
 				mockForwarders,
+				mockRedisClient,
 				mockDB,
 				clientset,
 				room,
@@ -229,6 +233,7 @@ var _ = Describe("Forward", func() {
 			_, err := ForwardRoomEvent(
 				ctx,
 				mockForwarders,
+				mockRedisClient,
 				mockDB,
 				clientset,
 				room,
@@ -258,6 +263,7 @@ game: game
 			response, err := ForwardRoomEvent(
 				context.Background(),
 				mockForwarders,
+				mockRedisClient,
 				mockDB,
 				clientset,
 				room,

--- a/eventforwarder/forward_test.go
+++ b/eventforwarder/forward_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Forward", func() {
 		It("should report fail if event forward fails", func() {
 			errMsg := "event forward failed"
 			ctx := context.Background()
-			noIpv6roomAddrGetter := models.NewRoomAddressesFromHostPort("")
+			noIpv6roomAddrGetter := models.NewRoomAddressesFromHostPort("", false, 0, 0)
 			mockEventForwarder.EXPECT().Forward(
 				ctx,
 				models.StatusReady,

--- a/models/interfaces.go
+++ b/models/interfaces.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	pginterfaces "github.com/topfreegames/extensions/pg/interfaces"
 	redisinterfaces "github.com/topfreegames/extensions/redis/interfaces"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -40,7 +40,7 @@ type ContainerIface interface {
 
 // AddrGetter return IP and ports of a room
 type AddrGetter interface {
-	Get(room *Room, kubernetesClient kubernetes.Interface) (*RoomAddresses, error)
+	Get(*Room, kubernetes.Interface, redisinterfaces.RedisClient) (*RoomAddresses, error)
 }
 
 // RoomManager should create and delete a game room

--- a/models/room.go
+++ b/models/room.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-redis/redis"
 	pginterfaces "github.com/topfreegames/extensions/pg/interfaces"
 	"github.com/topfreegames/extensions/redis/interfaces"
+	redisinterfaces "github.com/topfreegames/extensions/redis/interfaces"
 	"github.com/topfreegames/maestro/reporters"
 	reportersConstants "github.com/topfreegames/maestro/reporters/constants"
 	"k8s.io/client-go/kubernetes"
@@ -389,6 +390,7 @@ func GetRoomMetricsRedisKey(schedulerName string, metric string) string {
 
 // GetRoomInfos returns a map with room informations
 func (r *Room) GetRoomInfos(
+	redis redisinterfaces.RedisClient,
 	db pginterfaces.DB,
 	kubernetesClient kubernetes.Interface,
 	schedulerCache *SchedulerCache,
@@ -402,7 +404,7 @@ func (r *Room) GetRoomInfos(
 		}
 		scheduler = cachedScheduler.Scheduler
 	}
-	address, err := addrGetter.Get(r, kubernetesClient)
+	address, err := addrGetter.Get(r, kubernetesClient, redis)
 	if err != nil {
 		return nil, err
 	}

--- a/models/room.go
+++ b/models/room.go
@@ -48,10 +48,29 @@ type RoomAddresses struct {
 	Ipv6Label string      `json:"ipv6Label"`
 }
 
+func (r RoomAddresses) Clone() *RoomAddresses {
+	ports := make([]*RoomPort, len(r.Ports))
+	for i, port := range r.Ports {
+		ports[i] = port.Clone()
+	}
+	return &RoomAddresses{
+		Ports:     ports,
+		Host:      r.Host,
+		Ipv6Label: r.Ipv6Label,
+	}
+}
+
 // RoomPort struct
 type RoomPort struct {
 	Name string `json:"name"`
 	Port int32  `json:"port"`
+}
+
+func (r RoomPort) Clone() *RoomPort {
+	return &RoomPort{
+		Name: r.Name,
+		Port: r.Port,
+	}
 }
 
 // RoomUsage struct

--- a/models/room_address.go
+++ b/models/room_address.go
@@ -110,7 +110,7 @@ func (r RoomAddressesFromHostPort) fromCache(redisClient redisinterfaces.RedisCl
 }
 
 func (r *RoomAddressesFromHostPort) buildCacheKey(room *Room) string {
-	return fmt.Sprintf("room-adrr-%s-%s", room.SchedulerName, room.ID)
+	return fmt.Sprintf("room-addr-%s-%s", room.SchedulerName, room.ID)
 }
 
 // RoomAddressesFromNodePort is the struct that defines room addresses in development (using NodePort service)

--- a/models/room_address.go
+++ b/models/room_address.go
@@ -46,7 +46,7 @@ func NewRoomAddressesFromHostPort(
 func (r *RoomAddressesFromHostPort) Get(room *Room, kubernetesClient kubernetes.Interface) (*RoomAddresses, error) {
 	if r.cache != nil {
 		if cached, found := r.cache.Get(r.buildCacheKey(room)); found {
-			return cached.(*RoomAddresses), nil
+			return cached.(*RoomAddresses).Clone(), nil
 		}
 	}
 	addrs, err := getRoomAddresses(false, r.ipv6KubernetesLabelKey, room, kubernetesClient)
@@ -54,7 +54,7 @@ func (r *RoomAddressesFromHostPort) Get(room *Room, kubernetesClient kubernetes.
 		return nil, err
 	}
 	if r.cache != nil {
-		r.cache.Set(r.buildCacheKey(room), addrs, 0)
+		r.cache.Set(r.buildCacheKey(room), addrs.Clone(), 0)
 	}
 	return addrs, nil
 }
@@ -89,7 +89,7 @@ func NewRoomAddressesFromNodePort(
 func (r *RoomAddressesFromNodePort) Get(room *Room, kubernetesClient kubernetes.Interface) (*RoomAddresses, error) {
 	if r.cache != nil {
 		if cached, found := r.cache.Get(r.buildCacheKey(room)); found {
-			return cached.(*RoomAddresses), nil
+			return cached.(*RoomAddresses).Clone(), nil
 		}
 	}
 	addrs, err := getRoomAddresses(true, r.ipv6KubernetesLabelKey, room, kubernetesClient)
@@ -97,7 +97,7 @@ func (r *RoomAddressesFromNodePort) Get(room *Room, kubernetesClient kubernetes.
 		return nil, err
 	}
 	if r.cache != nil {
-		r.cache.Set(r.buildCacheKey(room), addrs, 0)
+		r.cache.Set(r.buildCacheKey(room), addrs.Clone(), 10*time.Second)
 	}
 	return addrs, nil
 }

--- a/models/room_address.go
+++ b/models/room_address.go
@@ -110,7 +110,7 @@ func (r RoomAddressesFromHostPort) fromCache(redisClient redisinterfaces.RedisCl
 }
 
 func (r *RoomAddressesFromHostPort) buildCacheKey(room *Room) string {
-	return fmt.Sprintf("%s-%s", room.SchedulerName, room.ID)
+	return fmt.Sprintf("room-adrr-%s-%s", room.SchedulerName, room.ID)
 }
 
 // RoomAddressesFromNodePort is the struct that defines room addresses in development (using NodePort service)
@@ -200,7 +200,7 @@ func (r RoomAddressesFromNodePort) fromCache(redisClient redisinterfaces.RedisCl
 }
 
 func (r RoomAddressesFromNodePort) buildCacheKey(room *Room) string {
-	return fmt.Sprintf("%s-%s", room.SchedulerName, room.ID)
+	return fmt.Sprintf("room-addr-%s-%s", room.SchedulerName, room.ID)
 }
 
 func getRoomAddresses(IsNodePort bool, ipv6KubernetesLabelKey string, room *Room, kubernetesClient kubernetes.Interface) (*RoomAddresses, error) {

--- a/models/room_address_test.go
+++ b/models/room_address_test.go
@@ -147,9 +147,9 @@ var _ = Describe("AddressGetter", func() {
 
 				step1 := len(clientset.Fake.Actions())
 				addrGetter := models.NewRoomAddressesFromNodePort(logger, ipv6KubernetesLabelKey, true, 10*time.Second)
-				mockRedisClient.EXPECT().Get("pong-free-for-all-pong-free-for-all-0").
+				mockRedisClient.EXPECT().Get("room-adrr-pong-free-for-all-pong-free-for-all-0").
 					Return(goredis.NewStringResult("", goredis.Nil))
-				mockRedisClient.EXPECT().Set("pong-free-for-all-pong-free-for-all-0", gomock.Any(), gomock.Any()).
+				mockRedisClient.EXPECT().Set("room-adrr-pong-free-for-all-pong-free-for-all-0", gomock.Any(), gomock.Any()).
 					Return(goredis.NewStatusCmd())
 				addrs1, err := addrGetter.Get(room, clientset, mockRedisClient)
 				Expect(err).NotTo(HaveOccurred())
@@ -157,7 +157,7 @@ var _ = Describe("AddressGetter", func() {
 				Expect(step2).To(Equal(step1 + 3))
 				b, err := json.Marshal(addrs1)
 				Expect(err).NotTo(HaveOccurred())
-				mockRedisClient.EXPECT().Get("pong-free-for-all-pong-free-for-all-0").
+				mockRedisClient.EXPECT().Get("room-adrr-pong-free-for-all-pong-free-for-all-0").
 					Return(goredis.NewStringResult(string(b), nil))
 				addrs2, err := addrGetter.Get(room, clientset, mockRedisClient)
 				Expect(err).NotTo(HaveOccurred())
@@ -194,9 +194,9 @@ var _ = Describe("AddressGetter", func() {
 
 				step1 := len(clientset.Fake.Actions())
 				addrGetter := models.NewRoomAddressesFromHostPort(logger, ipv6KubernetesLabelKey, true, 10*time.Second)
-				mockRedisClient.EXPECT().Get("pong-free-for-all-pong-free-for-all-0").
+				mockRedisClient.EXPECT().Get("room-adrr-pong-free-for-all-pong-free-for-all-0").
 					Return(goredis.NewStringResult("", goredis.Nil))
-				mockRedisClient.EXPECT().Set("pong-free-for-all-pong-free-for-all-0", gomock.Any(), gomock.Any()).
+				mockRedisClient.EXPECT().Set("room-adrr-pong-free-for-all-pong-free-for-all-0", gomock.Any(), gomock.Any()).
 					Return(goredis.NewStatusCmd())
 				addrs1, err := addrGetter.Get(room, clientset, mockRedisClient)
 				Expect(err).NotTo(HaveOccurred())
@@ -204,7 +204,7 @@ var _ = Describe("AddressGetter", func() {
 				Expect(step2).To(Equal(step1 + 2))
 				b, err := json.Marshal(addrs1)
 				Expect(err).NotTo(HaveOccurred())
-				mockRedisClient.EXPECT().Get("pong-free-for-all-pong-free-for-all-0").
+				mockRedisClient.EXPECT().Get("room-adrr-pong-free-for-all-pong-free-for-all-0").
 					Return(goredis.NewStringResult(string(b), nil))
 				addrs2, err := addrGetter.Get(room, clientset, mockRedisClient)
 				Expect(err).NotTo(HaveOccurred())

--- a/models/room_address_test.go
+++ b/models/room_address_test.go
@@ -147,9 +147,9 @@ var _ = Describe("AddressGetter", func() {
 
 				step1 := len(clientset.Fake.Actions())
 				addrGetter := models.NewRoomAddressesFromNodePort(logger, ipv6KubernetesLabelKey, true, 10*time.Second)
-				mockRedisClient.EXPECT().Get("room-adrr-pong-free-for-all-pong-free-for-all-0").
+				mockRedisClient.EXPECT().Get("room-addr-pong-free-for-all-pong-free-for-all-0").
 					Return(goredis.NewStringResult("", goredis.Nil))
-				mockRedisClient.EXPECT().Set("room-adrr-pong-free-for-all-pong-free-for-all-0", gomock.Any(), gomock.Any()).
+				mockRedisClient.EXPECT().Set("room-addr-pong-free-for-all-pong-free-for-all-0", gomock.Any(), gomock.Any()).
 					Return(goredis.NewStatusCmd())
 				addrs1, err := addrGetter.Get(room, clientset, mockRedisClient)
 				Expect(err).NotTo(HaveOccurred())
@@ -157,7 +157,7 @@ var _ = Describe("AddressGetter", func() {
 				Expect(step2).To(Equal(step1 + 3))
 				b, err := json.Marshal(addrs1)
 				Expect(err).NotTo(HaveOccurred())
-				mockRedisClient.EXPECT().Get("room-adrr-pong-free-for-all-pong-free-for-all-0").
+				mockRedisClient.EXPECT().Get("room-addr-pong-free-for-all-pong-free-for-all-0").
 					Return(goredis.NewStringResult(string(b), nil))
 				addrs2, err := addrGetter.Get(room, clientset, mockRedisClient)
 				Expect(err).NotTo(HaveOccurred())
@@ -194,9 +194,9 @@ var _ = Describe("AddressGetter", func() {
 
 				step1 := len(clientset.Fake.Actions())
 				addrGetter := models.NewRoomAddressesFromHostPort(logger, ipv6KubernetesLabelKey, true, 10*time.Second)
-				mockRedisClient.EXPECT().Get("room-adrr-pong-free-for-all-pong-free-for-all-0").
+				mockRedisClient.EXPECT().Get("room-addr-pong-free-for-all-pong-free-for-all-0").
 					Return(goredis.NewStringResult("", goredis.Nil))
-				mockRedisClient.EXPECT().Set("room-adrr-pong-free-for-all-pong-free-for-all-0", gomock.Any(), gomock.Any()).
+				mockRedisClient.EXPECT().Set("room-addr-pong-free-for-all-pong-free-for-all-0", gomock.Any(), gomock.Any()).
 					Return(goredis.NewStatusCmd())
 				addrs1, err := addrGetter.Get(room, clientset, mockRedisClient)
 				Expect(err).NotTo(HaveOccurred())
@@ -204,7 +204,7 @@ var _ = Describe("AddressGetter", func() {
 				Expect(step2).To(Equal(step1 + 2))
 				b, err := json.Marshal(addrs1)
 				Expect(err).NotTo(HaveOccurred())
-				mockRedisClient.EXPECT().Get("room-adrr-pong-free-for-all-pong-free-for-all-0").
+				mockRedisClient.EXPECT().Get("room-addr-pong-free-for-all-pong-free-for-all-0").
 					Return(goredis.NewStringResult(string(b), nil))
 				addrs2, err := addrGetter.Get(room, clientset, mockRedisClient)
 				Expect(err).NotTo(HaveOccurred())

--- a/models/room_address_test.go
+++ b/models/room_address_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/topfreegames/maestro/models"
 	reportersConstants "github.com/topfreegames/maestro/reporters/constants"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -97,7 +97,7 @@ var _ = Describe("AddressGetter", func() {
 	})
 
 	Context("When in development env", func() {
-		var addrGetter = models.NewRoomAddressesFromNodePort(ipv6KubernetesLabelKey)
+		var addrGetter = models.NewRoomAddressesFromNodePort(ipv6KubernetesLabelKey, false, 0, 0)
 
 		Describe("Get", func() {
 			It("should not crash if pod does not exist", func() {
@@ -257,7 +257,7 @@ var _ = Describe("AddressGetter", func() {
 	})
 
 	Context("When in production env", func() {
-		var addrGetter = models.NewRoomAddressesFromHostPort(ipv6KubernetesLabelKey)
+		var addrGetter = models.NewRoomAddressesFromHostPort(ipv6KubernetesLabelKey, false, 0, 0)
 
 		Describe("Get", func() {
 			It("should not crash if pod does not exist", func() {

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -515,7 +515,7 @@ func (w *Watcher) RemoveDeadRooms() {
 
 			_, err := eventforwarder.ForwardRoomEvent(
 				context.Background(),
-				w.EventForwarders, w.DB, w.KubernetesClient,
+				w.EventForwarders, w.RedisClient.Client, w.DB, w.KubernetesClient,
 				room, models.RoomTerminated, eventforwarder.PingTimeoutEvent,
 				metadatas[roomName], nil, w.Logger, w.RoomAddrGetter)
 			if err != nil {
@@ -590,7 +590,7 @@ func (w *Watcher) RemoveDeadRooms() {
 				}
 
 				_, err = eventforwarder.ForwardRoomEvent(
-					context.Background(), w.EventForwarders, w.DB, w.KubernetesClient,
+					context.Background(), w.EventForwarders, w.RedisClient.Client, w.DB, w.KubernetesClient,
 					room, models.RoomTerminated, eventforwarder.OccupiedTimeoutEvent,
 					metadatas[roomName], nil, w.Logger, w.RoomAddrGetter)
 				if err != nil {


### PR DESCRIPTION
* local cache with configurable expiration/cleanup times.
* updating go-extensions-k8s-client-go to tag `kubernetes-1.11.7` that uses reflection to set restClient in all components