### PR TITLE
Refactor/ensure correct rooms

### DIFF
--- a/api/scheduler_rollback_handler_test.go
+++ b/api/scheduler_rollback_handler_test.go
@@ -84,11 +84,7 @@ autoscaling:
 
 			calls := NewCalls()
 
-			lockKey := models.GetSchedulerScalingLockKey(config.GetString("watcher.lockKey"), scheduler1.Name)
 			configLockKey := models.GetSchedulerConfigLockKey(config.GetString("watcher.lockKey"), scheduler1.Name)
-
-			// Get global lock
-			MockRedisLock(mockRedisClient, lockKey, lockTimeoutMs, true, nil)
 
 			// Get config lock
 			MockRedisLock(mockRedisClient, configLockKey, lockTimeoutMs, true, nil)
@@ -108,12 +104,6 @@ autoscaling:
 
 			// Count to delete old versions if necessary
 			MockCountNumberOfVersions(scheduler1, numberOfVersions, mockDb, nil)
-
-			// Release globalLock
-			MockReturnRedisLock(mockRedisClient, lockKey, nil)
-
-			// Release globalLock (again defer)
-			MockReturnRedisLock(mockRedisClient, lockKey, nil)
 
 			// Release configLock
 			MockReturnRedisLock(mockRedisClient, configLockKey, nil)
@@ -222,11 +212,7 @@ autoscaling:
 
 			calls := NewCalls()
 
-			lockKey := models.GetSchedulerScalingLockKey(config.GetString("watcher.lockKey"), scheduler1.Name)
 			configLockKey := models.GetSchedulerConfigLockKey(config.GetString("watcher.lockKey"), scheduler1.Name)
-
-			// Get global lock
-			MockRedisLock(mockRedisClient, lockKey, lockTimeoutMs, true, nil)
 
 			// Get config lock
 			MockRedisLock(mockRedisClient, configLockKey, lockTimeoutMs, true, nil)
@@ -246,12 +232,6 @@ autoscaling:
 
 			// Count to delete old versions if necessary
 			MockCountNumberOfVersions(scheduler1, numberOfVersions, mockDb, nil)
-
-			// Release globalLock
-			MockReturnRedisLock(mockRedisClient, lockKey, nil)
-
-			// Release globalLock (again defer)
-			MockReturnRedisLock(mockRedisClient, lockKey, nil)
 
 			// Release configLock
 			MockReturnRedisLock(mockRedisClient, configLockKey, nil)

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -244,26 +244,8 @@ func dbRollback(
 	clock clockinterfaces.Clock,
 	scheduler *models.Scheduler,
 	config *viper.Viper,
-	operationManager *models.OperationManager,
 	oldVersion, globalLockKey string,
 ) (err error) {
-	globalLock, _, _ := AcquireLock(
-		ctx,
-		logger,
-		redisClient,
-		config,
-		operationManager,
-		globalLockKey,
-		scheduler.Name,
-	)
-
-	defer ReleaseLock(
-		logger,
-		redisClient,
-		globalLock,
-		scheduler.Name,
-	)
-
 	err = scheduler.UpdateVersionStatus(db)
 	if err != nil {
 		return err
@@ -290,15 +272,6 @@ func dbRollback(
 	if err != nil {
 		return err
 	}
-
-	// Don't worry, there is a defer ReleaseLock()
-	// in case any error before this code happen ;)
-	ReleaseLock(
-		logger,
-		redisClient,
-		globalLock,
-		scheduler.Name,
-	)
 
 	return nil
 }

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -988,8 +988,9 @@ func AcquireLock(
 
 	// guarantee that downScaling and config locks doesn't timeout before update times out.
 	// otherwise it can result in all pods dying during a rolling update that is destined to timeout
-	if lockKey == models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), schedulerName) ||
-		lockKey == models.GetSchedulerConfigLockKey(config.GetString("watcher.lockKey"), schedulerName) {
+	if (lockKey == models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), schedulerName) ||
+		lockKey == models.GetSchedulerConfigLockKey(config.GetString("watcher.lockKey"), schedulerName)) &&
+		lockTimeoutMS < timeoutSec*1000 {
 		lockTimeoutMS = (timeoutSec + 1) * 1000
 	}
 

--- a/models/constants.go
+++ b/models/constants.go
@@ -121,3 +121,6 @@ const OpManagerWaitingLock = "waiting for lock"
 
 // OpManagerFinished constant
 const OpManagerFinished = "finished"
+
+// OpManagerRollingBack constant
+const OpManagerRollingBack = "rolling back"

--- a/models/scheduler.go
+++ b/models/scheduler.go
@@ -212,17 +212,6 @@ func (c *Scheduler) Load(db interfaces.DB) error {
 	return err
 }
 
-// LoadWithVersionStatus loads a scheduler from the database using the scheduler name
-// and also loads its RollingUpdateStatus
-func (c *Scheduler) LoadWithVersionStatus(db interfaces.DB) error {
-	_, err := db.Query(c, "SELECT * FROM schedulers WHERE name = ?", c.Name)
-	if c.Version == "" {
-		c.Version = "v1.0"
-	}
-	_, err = db.Query(c, "SELECT rolling_update_status FROM scheduler_versions WHERE name = ? AND version = ?", c.Name, c.Version)
-	return err
-}
-
 // LoadSchedulers loads a slice of schedulers from database by names
 func LoadSchedulers(db interfaces.DB, names []string) ([]Scheduler, error) {
 	var schedulers []Scheduler

--- a/models/scheduler.go
+++ b/models/scheduler.go
@@ -212,6 +212,17 @@ func (c *Scheduler) Load(db interfaces.DB) error {
 	return err
 }
 
+// LoadWithVersionStatus loads a scheduler from the database using the scheduler name
+// and also loads its RollingUpdateStatus
+func (c *Scheduler) LoadWithVersionStatus(db interfaces.DB) error {
+	_, err := db.Query(c, "SELECT * FROM schedulers WHERE name = ?", c.Name)
+	if c.Version == "" {
+		c.Version = "v1.0"
+	}
+	_, err = db.Query(c, "SELECT rolling_update_status FROM scheduler_versions WHERE name = ? AND version = ?", c.Name, c.Version)
+	return err
+}
+
 // LoadSchedulers loads a slice of schedulers from database by names
 func LoadSchedulers(db interfaces.DB, names []string) ([]Scheduler, error) {
 	var schedulers []Scheduler

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -240,7 +240,7 @@ func (w *Watcher) Start() {
 		case <-ticker.C:
 			w.WithRedisLock(l, w.watchRooms)
 		case <-tickerEnsure.C:
-			w.WithRedisLock(l, w.EnsureCorrectRooms)
+			w.EnsureCorrectRooms()
 		case <-tickerStateCount.C:
 			w.PodStatesCount()
 		case sig := <-sigchan:
@@ -1011,7 +1011,7 @@ func (w *Watcher) EnsureCorrectRooms() error {
 		return err
 	}
 
-	configYaml, err := models.NewConfigYAML(scheduler.YAML)
+	configYAML, err := models.NewConfigYAML(scheduler.YAML)
 	if err != nil {
 		logger.WithError(err).Error("failed to unmarshal config yaml")
 		return err
@@ -1041,12 +1041,12 @@ func (w *Watcher) EnsureCorrectRooms() error {
 		return err
 	}
 
-	podsToDelete := []string{}
-	concat := func(podNames []string, err error) error {
+	podsToDelete := []v1.Pod{}
+	concat := func(pods []v1.Pod, err error) error {
 		if err != nil {
 			return err
 		}
-		podsToDelete = append(podsToDelete, podNames...)
+		podsToDelete = append(podsToDelete, pods...)
 		return nil
 	}
 
@@ -1068,12 +1068,55 @@ func (w *Watcher) EnsureCorrectRooms() error {
 		logger.Info("no invalid pods to delete")
 	}
 
-	for _, podName := range podsToDelete {
-		err = controller.DeletePodAndRoom(logger, w.RoomManager, w.MetricsReporter,
-			k, w.RedisClient.Client, configYaml, podName, reportersConstants.ReasonInvalidPod)
-		if err != nil {
-			logger.WithError(err).WithField("podName", podName).Error("failed to delete pod")
-		}
+	timeoutSec := w.Config.GetInt("updateTimeoutSeconds")
+	timeoutDur := time.Duration(timeoutSec) * time.Second
+	willTimeoutAt := time.Now().Add(timeoutDur)
+
+	// Lock down scaling so it doesn't interfer with rolling update surges
+	downScalingLockKey := models.GetSchedulerDownScalingLockKey(w.Config.GetString("watcher.lockKey"), configYAML.Name)
+	downScalingLock, _, err := controller.AcquireLock(
+		ctx,
+		logger,
+		w.RedisClient,
+		w.Config,
+		nil,
+		downScalingLockKey,
+		w.SchedulerName,
+	)
+	defer controller.ReleaseLock(
+		logger,
+		w.RedisClient,
+		downScalingLock,
+		w.SchedulerName,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	timeoutErr, _, err := controller.SegmentAndReplacePods(
+		ctx,
+		logger,
+		w.RoomManager,
+		w.MetricsReporter,
+		w.KubernetesClient,
+		w.DB,
+		w.RedisClient.Client,
+		willTimeoutAt,
+		configYAML,
+		podsToDelete,
+		scheduler,
+		nil,
+		w.Config.GetInt("watcher.maxSurge"),
+		nil,
+	)
+
+	if timeoutErr != nil {
+		logger.WithError(err).Error("timeout replacing pods on EnsureCorrectRooms")
+	}
+
+	if err != nil {
+		logger.WithError(err).Error("replacing pods returned error on EnsureCorrectRooms")
 	}
 
 	return nil
@@ -1081,17 +1124,17 @@ func (w *Watcher) EnsureCorrectRooms() error {
 
 func (w *Watcher) podsNotRegistered(
 	pods *v1.PodList,
-) ([]string, error) {
+) ([]v1.Pod, error) {
 	registered, err := models.GetAllRegisteredRooms(w.RedisClient.Client,
 		w.SchedulerName)
 	if err != nil {
 		return nil, err
 	}
 
-	notRegistered := []string{}
+	notRegistered := []v1.Pod{}
 	for _, pod := range pods.Items {
 		if _, ok := registered[pod.Name]; !ok {
-			notRegistered = append(notRegistered, pod.Name)
+			notRegistered = append(notRegistered, pod)
 		}
 	}
 	return notRegistered, nil
@@ -1119,8 +1162,8 @@ func (w *Watcher) splitedVersion(version string) (majorInt, minorInt int, err er
 func (w *Watcher) podsOfIncorrectVersion(
 	pods *v1.PodList,
 	scheduler *models.Scheduler,
-) ([]string, error) {
-	podNames := []string{}
+) ([]v1.Pod, error) {
+	incorrectPods := []v1.Pod{}
 	for _, pod := range pods.Items {
 		podMajorVersion, _, err := w.splitedVersion(pod.Labels["version"])
 		if err != nil {
@@ -1133,10 +1176,10 @@ func (w *Watcher) podsOfIncorrectVersion(
 		}
 
 		if podMajorVersion != schedulerMajorVersion {
-			podNames = append(podNames, pod.GetName())
+			incorrectPods = append(incorrectPods, pod)
 		}
 	}
-	return podNames, nil
+	return incorrectPods, nil
 }
 
 func hasTerminationState(status *v1.ContainerStatus) bool {

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	uuid "github.com/satori/go.uuid"
+	"github.com/topfreegames/extensions/clock"
 	pginterfaces "github.com/topfreegames/extensions/pg/interfaces"
 	redis "github.com/topfreegames/extensions/redis"
 	"github.com/topfreegames/maestro/constants"
@@ -1108,7 +1109,7 @@ func (w *Watcher) EnsureCorrectRooms() error {
 		scheduler,
 		nil,
 		w.Config.GetInt("watcher.maxSurge"),
-		nil,
+		&clock.Clock{},
 	)
 
 	if timeoutErr != nil {

--- a/watcher/watcher_suite_test.go
+++ b/watcher/watcher_suite_test.go
@@ -24,6 +24,7 @@ import (
 	pgmocks "github.com/topfreegames/extensions/pg/mocks"
 	redismocks "github.com/topfreegames/extensions/redis/mocks"
 	eventforwardermock "github.com/topfreegames/maestro/eventforwarder/mock"
+	"github.com/topfreegames/maestro/mocks"
 	"github.com/topfreegames/maestro/models"
 	mtesting "github.com/topfreegames/maestro/testing"
 )
@@ -37,6 +38,7 @@ var (
 	roomManager           models.RoomManager
 	mockCtrl              *gomock.Controller
 	mockDb                *pgmocks.MockDB
+	mockPortChooser       *mocks.MockPortChooser
 	mockPipeline          *redismocks.MockPipeliner
 	mockRedisClient       *redismocks.MockRedisClient
 	mockRedisTraceWrapper *redismocks.MockTraceWrapper
@@ -72,6 +74,7 @@ var _ = BeforeEach(func() {
 	clientset = fake.NewSimpleClientset()
 	metricsClientset = metricsFake.NewSimpleClientset()
 	mockCtrl = gomock.NewController(GinkgoT())
+	mockPortChooser = mocks.NewMockPortChooser(mockCtrl)
 	mockDb = pgmocks.NewMockDB(mockCtrl)
 	mockRedisClient = redismocks.NewMockRedisClient(mockCtrl)
 	mockPipeline = redismocks.NewMockPipeliner(mockCtrl)

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -4588,7 +4588,7 @@ var _ = Describe("Watcher", func() {
 			err := w.EnsureCorrectRooms()
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(hook.LastEntry().Message).To(Equal("replacing pods returned error on EnsureCorrectRooms"))
+			Expect(hook.LastEntry().Message).To(Equal("error replacing chunk of pods"))
 		})
 
 		It("should delete invalid pods", func() {


### PR DESCRIPTION
- Now watcher's EnsureCorrectRooms replaces pods using rolling strategy.
- When an updateConfig needs a rollback, the API only rolls back the scheduler on database. EnsureCorrectRooms should then replace pods asynchronously.