### PR TITLE
Use only downscalingLock in watcher operations

### DIFF
--- a/api/scheduler_locks_handler_test.go
+++ b/api/scheduler_locks_handler_test.go
@@ -61,7 +61,6 @@ var _ = Describe("SchedulerLocksHandler", func() {
 
 		It("should return unlocked watcher locks", func() {
 			for _, lockKey := range []string{
-				"maestro-lock-key-scheduler-name",
 				"maestro-lock-key-scheduler-name-config",
 				"maestro-lock-key-scheduler-name-downscaling",
 			} {
@@ -76,10 +75,9 @@ var _ = Describe("SchedulerLocksHandler", func() {
 			Expect(recorder.Code).To(Equal(http.StatusOK))
 			var locks []models.SchedulerLock
 			json.Unmarshal(recorder.Body.Bytes(), &locks)
-			Expect(locks).To(HaveLen(3))
+			Expect(locks).To(HaveLen(2))
 
 			for i, lockKey := range []string{
-				"maestro-lock-key-scheduler-name",
 				"maestro-lock-key-scheduler-name-config",
 				"maestro-lock-key-scheduler-name-downscaling",
 			} {
@@ -91,7 +89,6 @@ var _ = Describe("SchedulerLocksHandler", func() {
 
 		It("should return locked watcher lock", func() {
 			for _, lockKey := range []string{
-				"maestro-lock-key-scheduler-name",
 				"maestro-lock-key-scheduler-name-config",
 				"maestro-lock-key-scheduler-name-downscaling",
 			} {
@@ -108,7 +105,6 @@ var _ = Describe("SchedulerLocksHandler", func() {
 			json.Unmarshal(recorder.Body.Bytes(), &locks)
 
 			for i, lockKey := range []string{
-				"maestro-lock-key-scheduler-name",
 				"maestro-lock-key-scheduler-name-config",
 				"maestro-lock-key-scheduler-name-downscaling",
 			} {
@@ -127,7 +123,6 @@ var _ = Describe("SchedulerLocksHandler", func() {
 
 		It("should remove lockName key in redis", func() {
 			for _, lockKey := range []string{
-				models.GetSchedulerScalingLockKey(app.Config.GetString("watcher.lockKey"), configYaml.Name),
 				models.GetSchedulerConfigLockKey(app.Config.GetString("watcher.lockKey"), configYaml.Name),
 				models.GetSchedulerDownScalingLockKey(app.Config.GetString("watcher.lockKey"), configYaml.Name),
 			} {

--- a/models/scheduler.go
+++ b/models/scheduler.go
@@ -516,7 +516,6 @@ func ListSchedulerLocks(
 // ListSchedulerLocksKeys lists a slice of locks keys for schedulerName and prefix
 func ListSchedulerLocksKeys(prefix, schedulerName string) []string {
 	return []string{
-		GetSchedulerScalingLockKey(prefix, schedulerName),
 		GetSchedulerConfigLockKey(prefix, schedulerName),
 		GetSchedulerDownScalingLockKey(prefix, schedulerName),
 	}
@@ -528,11 +527,6 @@ func DeleteSchedulerLock(
 ) error {
 	_, err := redisClient.Del(lockKey).Result()
 	return err
-}
-
-// GetSchedulerScalingLockKey returns the key of the scheduler lock
-func GetSchedulerScalingLockKey(prefix, schedulerName string) string {
-	return fmt.Sprintf("%s-%s", prefix, schedulerName)
 }
 
 // GetSchedulerConfigLockKey returns the key of the scheduler update config lock

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -421,7 +421,6 @@ var _ = Describe("Watcher", func() {
 			Expect(w.Logger).NotTo(BeNil())
 			Expect(w.MetricsReporter).To(Equal(mr))
 			Expect(w.RedisClient).To(Equal(redisClient))
-			Expect(w.LockKey).To(Equal(fmt.Sprintf("%s-%s", lockKey, name)))
 			Expect(w.LockTimeoutMS).To(Equal(lockTimeoutMs))
 			Expect(w.SchedulerName).To(Equal(name))
 		})
@@ -435,7 +434,6 @@ var _ = Describe("Watcher", func() {
 				})
 			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, name, gameName, occupiedTimeout, []*eventforwarder.Info{})
 			Expect(w.AutoScalingPeriod).To(Equal(10))
-			Expect(w.LockKey).To(Equal("maestro-lock-key-my-scheduler"))
 			Expect(w.LockTimeoutMS).To(Equal(180000))
 		})
 	})
@@ -448,7 +446,6 @@ var _ = Describe("Watcher", func() {
 			config.Set("watcher.autoScalingPeriod", 1)
 			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient).AnyTimes()
 		})
-
 		It("should start watcher", func() {
 			// Testing here if no scaling needs to be done
 			err := yaml.Unmarshal([]byte(yaml1), &configYaml)
@@ -470,11 +467,7 @@ var _ = Describe("Watcher", func() {
 			Expect(w).NotTo(BeNil())
 
 			// EnterCriticalSection (lock done by redis-lock)
-			lockKey := fmt.Sprintf("maestro-lock-key-%s", configYaml.Name)
 			downscalingLockKey := fmt.Sprintf("maestro-lock-key-%s-downscaling", configYaml.Name)
-			mockRedisClient.EXPECT().
-				SetNX(lockKey, gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(true, nil)).
-				AnyTimes()
 			mockRedisClient.EXPECT().
 				SetNX(downscalingLockKey, gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(true, nil)).
 				AnyTimes()
@@ -498,6 +491,7 @@ var _ = Describe("Watcher", func() {
 				scheduler.YAML = yaml1
 				scheduler.State = models.StateInSync
 			}).AnyTimes()
+
 			creating := models.GetRoomStatusSetRedisKey(configYaml.Name, "creating")
 			ready := models.GetRoomStatusSetRedisKey(configYaml.Name, "ready")
 			occupied := models.GetRoomStatusSetRedisKey(configYaml.Name, "occupied")
@@ -545,7 +539,6 @@ var _ = Describe("Watcher", func() {
 			}, mockDb, nil, nil)
 
 			// LeaveCriticalSection (unlock done by redis-lock)
-			mockRedisClient.EXPECT().Eval(gomock.Any(), []string{lockKey}, gomock.Any()).Return(redis.NewCmdResult(nil, nil)).AnyTimes()
 			mockRedisClient.EXPECT().Eval(gomock.Any(), []string{downscalingLockKey}, gomock.Any()).Return(redis.NewCmdResult(nil, nil)).AnyTimes()
 			w.Start()
 		})
@@ -556,14 +549,28 @@ var _ = Describe("Watcher", func() {
 			mockDb.EXPECT().Query(gomock.Any(), "SELECT * FROM schedulers WHERE name = ?", name).
 				Do(func(scheduler *models.Scheduler, query string, modifier string) {
 					scheduler.YAML = yaml1
-				})
+				}).AnyTimes()
 			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, name, gameName, occupiedTimeout, []*eventforwarder.Info{})
 			Expect(w).NotTo(BeNil())
 			defer func() { w.Run = false }()
 
 			// EnterCriticalSection (lock done by redis-lock)
-			mockRedisClient.EXPECT().SetNX("maestro-lock-key-my-scheduler", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, errors.New("some error in lock"))).AnyTimes()
-			mockRedisClient.EXPECT().SetNX("maestro-lock-key-my-scheduler-downscaling", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, nil)).AnyTimes()
+			mockRedisClient.EXPECT().
+				SetNX("maestro-lock-key-my-scheduler-downscaling", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, errors.New("some error in lock"))).AnyTimes()
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline).AnyTimes()
+			creating := models.GetRoomStatusSetRedisKey(name, "creating")
+			occupied := models.GetRoomStatusSetRedisKey(name, "occupied")
+			terminating := models.GetRoomStatusSetRedisKey(name, "terminating")
+			ready := models.GetRoomStatusSetRedisKey(name, "ready")
+			expC := &models.RoomsStatusCount{0, 0, 1, 0}
+			mockPipeline.EXPECT().LPush(gomock.Any(), gomock.Any()).AnyTimes()
+			mockPipeline.EXPECT().LTrim(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			mockPipeline.EXPECT().SCard(creating).Return(redis.NewIntResult(int64(expC.Creating), nil)).AnyTimes()
+			mockPipeline.EXPECT().SCard(occupied).Return(redis.NewIntResult(int64(expC.Occupied), nil)).AnyTimes()
+			mockPipeline.EXPECT().SCard(terminating).Return(redis.NewIntResult(int64(expC.Terminating), nil)).AnyTimes()
+			mockPipeline.EXPECT().SCard(ready).Return(redis.NewIntResult(int64(expC.Ready), nil)).AnyTimes()
+			mockPipeline.EXPECT().Exec().AnyTimes()
 
 			Expect(func() {
 				go func() {
@@ -573,7 +580,7 @@ var _ = Describe("Watcher", func() {
 			}).ShouldNot(Panic())
 			Eventually(func() bool { return w.Run }).Should(BeTrue())
 			Eventually(func() bool { return hook.LastEntry() != nil }).Should(BeTrue())
-			Eventually(func() string { return hook.LastEntry().Message }, 1500*time.Millisecond).Should(Equal("error getting watcher lock"))
+			time.Sleep(3 * time.Second)
 		})
 
 		It("should not panic if lock is being used", func() {
@@ -588,7 +595,6 @@ var _ = Describe("Watcher", func() {
 			defer func() { w.Run = false }()
 
 			// EnterCriticalSection (lock done by redis-lock)
-			mockRedisClient.EXPECT().SetNX("maestro-lock-key-my-scheduler", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, nil)).AnyTimes()
 			mockRedisClient.EXPECT().SetNX("maestro-lock-key-my-scheduler-downscaling", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, nil)).AnyTimes()
 
 			Expect(func() {
@@ -599,8 +605,7 @@ var _ = Describe("Watcher", func() {
 			}).ShouldNot(Panic())
 			Eventually(func() bool { return w.Run }).Should(BeTrue())
 			Eventually(func() bool { return hook.LastEntry() != nil }).Should(BeTrue())
-			Eventually(func() string { return hook.LastEntry().Message }, 1500*time.Millisecond).
-				Should(Equal("unable to get watcher my-scheduler lock, maybe some other process has it..."))
+			time.Sleep(3 * time.Second)
 		})
 	})
 


### PR DESCRIPTION
- watcher operations using only downscaling lock
- ScaleUp does not use lock
- ScaleDown use downscalingLock
- Pod metrics saving on redis (for metrics triggers) does not use lock
