### PR TITLE
Remove rooms that are stuck in terminating state in RemoveDeadRooms

### DIFF
--- a/api/room_handler_test.go
+++ b/api/room_handler_test.go
@@ -1145,16 +1145,6 @@ forwarders:
 						redis.NewBoolResult(true, nil))
 				}
 
-				// Create rooms to MockGetRegisteredRoomsPerStatus
-				// MockGetRegisteredRoomsPerStatus(
-				// 	mockRedisClient,
-				// 	mockPipeline,
-				// 	namespace,
-				// 	[]string{models.StatusReady, models.StatusOccupied},
-				// 	rooms,
-				// 	nil,
-				// )
-
 				url := fmt.Sprintf("/scheduler/%s/rooms?metric=cpu&limit=123", namespace)
 				request, err := http.NewRequest("GET", url, nil)
 				Expect(err).NotTo(HaveOccurred())

--- a/models/constants.go
+++ b/models/constants.go
@@ -46,6 +46,9 @@ const SegmentHMSet = "Redis/HMSet"
 //SegmentZRangeBy represents a segment
 const SegmentZRangeBy = "Redis/ZRangeBy"
 
+//SegmentSMembers represents a segment
+const SegmentSMembers = "Redis/SMembers"
+
 //SegmentSIsMember represents a segment
 const SegmentSIsMember = "Redis/SIsMember"
 

--- a/testing/common.go
+++ b/testing/common.go
@@ -1587,3 +1587,20 @@ func MockRollingUpdateFlow(
 	calls.Append(
 		MockReturnRedisLock(mockRedisClient, configLockKey, nil))
 }
+
+// MockRemoveZombieRooms mocks removal of rooms that are in terminating state but pods are already removed
+func MockRemoveZombieRooms(
+	mockPipeline *redismocks.MockPipeliner,
+	mockRedisClient *redismocks.MockRedisClient,
+	rooms []string,
+	schedulerName,
+	status string,
+) {
+	mockRedisClient.EXPECT().SMembers(models.GetRoomStatusSetRedisKey(schedulerName, status)).Return(
+		goredis.NewStringSliceResult(rooms, nil))
+
+	amount := len(rooms)
+	if amount > 0 {
+		MockClearAll(mockPipeline, mockRedisClient, schedulerName, amount)
+	}
+}

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -457,6 +457,9 @@ var _ = Describe("Watcher", func() {
 			testing.CopyAutoScaling(configYaml.AutoScaling, mockAutoScaling)
 			testing.TransformLegacyInMetricsTrigger(mockAutoScaling)
 
+			// Mock get terminating rooms
+			testing.MockRemoveZombieRooms(mockPipeline, mockRedisClient, []string{}, configYaml.Name, "terminating")
+
 			// Mock send usage percentage
 			testing.MockSendUsage(mockPipeline, mockRedisClient, mockAutoScaling)
 
@@ -4092,6 +4095,9 @@ var _ = Describe("Watcher", func() {
 			// Mock room creation
 			testing.MockCreateRoomsAnyTimes(mockRedisClient, mockPipeline, &configYaml, 0)
 
+			// Mock get terminating rooms
+			testing.MockRemoveZombieRooms(mockPipeline, mockRedisClient, []string{"scheduler:controller-name:rooms:room-0"}, schedulerName, "terminating")
+
 			for _, roomName := range expectedRooms {
 				room := models.NewRoom(roomName, schedulerName)
 				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
@@ -4169,6 +4175,9 @@ var _ = Describe("Watcher", func() {
 				Expect(max).To(BeNumerically("~", ts, 1*time.Second))
 			}).Return(redis.NewStringSliceResult([]string{}, errors.New("some error"))).AnyTimes()
 
+			// Mock get terminating rooms
+			testing.MockRemoveZombieRooms(mockPipeline, mockRedisClient, []string{}, schedulerName, "terminating")
+
 			// DeleteRoomsOccupiedTimeout
 			ts = time.Now().Unix() - w.OccupiedTimeout
 			expectedRooms := []string{"room1", "room2", "room3"}
@@ -4236,6 +4245,9 @@ var _ = Describe("Watcher", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(max).To(BeNumerically("~", ts, 1*time.Second))
 			}).Return(redis.NewStringSliceResult([]string{}, nil))
+
+			// Mock get terminating rooms
+			testing.MockRemoveZombieRooms(mockPipeline, mockRedisClient, []string{}, schedulerName, "terminating")
 
 			// DeleteRoomsOccupiedTimeout
 			ts = time.Now().Unix() - w.OccupiedTimeout


### PR DESCRIPTION
This prevents leakage of roomStatus terminating keys in redis. This leakage affects the status of maestro schedulers (it sees more rooms terminating than it really has).
