### PR TITLE
Refactor/rolling update progress

### DIFF
--- a/api/scheduler_handler_test.go
+++ b/api/scheduler_handler_test.go
@@ -736,8 +736,8 @@ autoscaling:
 					// Count to delete old versions if necessary
 					MockCountNumberOfVersions(scheduler1, numberOfVersions, mockDb, nil)
 
-					// Mock rolling update with rollback
-					MockAnySetDescription(opManager, mockRedisClient, models.OpManagerRollingUpdate, nil)
+					MockGetInvalidRooms(mockRedisClient, mockPipeline, configYaml.Name, 0, 0, nil)
+					MockRemoveInvalidRoomsKey(mockRedisClient, mockPipeline, configYaml.Name)
 
 					mockRedisClient.EXPECT().HGetAll(gomock.Any()).Return(
 						goredis.NewStringStringMapResult(map[string]string{
@@ -1093,7 +1093,8 @@ autoscaling:
 					// Count to delete old versions if necessary
 					MockCountNumberOfVersions(scheduler1, numberOfVersions, mockDb, nil)
 
-					MockAnySetDescription(opManager, mockRedisClient, models.OpManagerRollingUpdate, nil)
+					MockGetInvalidRooms(mockRedisClient, mockPipeline, configYaml.Name, 0, 0, nil)
+					MockRemoveInvalidRoomsKey(mockRedisClient, mockPipeline, configYaml.Name)
 
 					mockRedisClient.EXPECT().HGetAll(gomock.Any()).Return(
 						goredis.NewStringStringMapResult(map[string]string{
@@ -2177,7 +2178,8 @@ game: game-name
 				// Count to delete old versions if necessary
 				MockCountNumberOfVersions(scheduler1, numberOfVersions, mockDb, nil)
 
-				MockAnySetDescription(opManager, mockRedisClient, models.OpManagerRollingUpdate, nil)
+				MockGetInvalidRooms(mockRedisClient, mockPipeline, configYaml.Name, 0, 0, nil)
+				MockRemoveInvalidRoomsKey(mockRedisClient, mockPipeline, configYaml.Name)
 
 				mockRedisClient.EXPECT().HGetAll(gomock.Any()).Return(
 					goredis.NewStringStringMapResult(map[string]string{
@@ -2262,7 +2264,8 @@ game: game-name
 				// Count to delete old versions if necessary
 				MockCountNumberOfVersions(scheduler1, numberOfVersions, mockDb, nil)
 
-				MockAnySetDescription(opManager, mockRedisClient, models.OpManagerRollingUpdate, nil)
+				MockGetInvalidRooms(mockRedisClient, mockPipeline, configYaml.Name, 0, 0, nil)
+				MockRemoveInvalidRoomsKey(mockRedisClient, mockPipeline, configYaml.Name)
 
 				mockRedisClient.EXPECT().HGetAll(gomock.Any()).Return(
 					goredis.NewStringStringMapResult(map[string]string{
@@ -2627,7 +2630,8 @@ game: game-name
 				// Count to delete old versions if necessary
 				MockCountNumberOfVersions(scheduler1, numberOfVersions, mockDb, nil)
 
-				MockAnySetDescription(opManager, mockRedisClient, models.OpManagerRollingUpdate, nil)
+				MockGetInvalidRooms(mockRedisClient, mockPipeline, configYaml.Name, 0, 0, nil)
+				MockRemoveInvalidRoomsKey(mockRedisClient, mockPipeline, configYaml.Name)
 
 				// Update scheduler rolling update status
 				calls.Append(
@@ -2726,7 +2730,9 @@ game: game-name
 
 				// Set new operation manager description
 				MockAnySetDescription(opManager, mockRedisClient, models.OpManagerRunning, nil)
-				MockAnySetDescription(opManager, mockRedisClient, models.OpManagerRollingUpdate, nil)
+
+				MockGetInvalidRooms(mockRedisClient, mockPipeline, configYaml1.Name, 0, 0, nil)
+				MockRemoveInvalidRoomsKey(mockRedisClient, mockPipeline, configYaml1.Name)
 
 				// Get scheduler from DB
 				MockSelectScheduler(jsonString, mockDb, nil)
@@ -2842,7 +2848,8 @@ game: game-name
 				// Count to delete old versions if necessary
 				MockCountNumberOfVersions(scheduler1, numberOfVersions, mockDb, nil)
 
-				MockAnySetDescription(opManager, mockRedisClient, models.OpManagerRollingUpdate, nil)
+				MockGetInvalidRooms(mockRedisClient, mockPipeline, configYaml.Name, 0, 0, nil)
+				MockRemoveInvalidRoomsKey(mockRedisClient, mockPipeline, configYaml.Name)
 
 				mockRedisClient.EXPECT().HGetAll(gomock.Any()).Return(
 					goredis.NewStringStringMapResult(map[string]string{

--- a/api/scheduler_operation_handler_test.go
+++ b/api/scheduler_operation_handler_test.go
@@ -96,6 +96,9 @@ var _ = Describe("SchedulerOperationHandler", func() {
 			// Select current scheduler
 			MockSelectScheduler(yamlString, mockDb, nil)
 
+			// Mock getting invalid rooms from redis to track progress
+			MockGetInvalidRooms(mockRedisClient, mockPipeline, schedulerName, 1, 2, nil)
+
 			// Create half of the pods in version v1.0 and half in v2.0
 			createPod("pod1", schedulerName, "v1.0")
 			createPod("pod2", schedulerName, "v2.0")
@@ -205,6 +208,9 @@ var _ = Describe("SchedulerOperationHandler", func() {
 			// Create half of the pods in version v1.0 and half in v2.0
 			createPod("pod1", schedulerName, "v1.0")
 			createPod("pod2", schedulerName, "v2.0")
+
+			// Mock getting invalid rooms from redis to track progress
+			MockGetInvalidRooms(mockRedisClient, mockPipeline, schedulerName, 1, 2, nil)
 
 			app.Router.ServeHTTP(recorder, request)
 			Expect(recorder.Code).To(Equal(http.StatusOK))

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -4820,7 +4820,7 @@ containers:
 					Expect(pod.ObjectMeta.Labels["version"]).To(Equal("v1.0"))
 				}
 
-				mt.MockAnySetDescription(opManager, mockRedisClient, "rolling update", nil)
+				mt.MockRemoveInvalidRoomsKey(mockRedisClient, mockPipeline, configYaml.Name)
 
 				mockRedisClient.EXPECT().HGetAll(gomock.Any()).Return(
 					goredis.NewStringStringMapResult(nil, nil)).AnyTimes()

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -923,28 +923,29 @@ func validateConfig(logger logrus.FieldLogger, configYAML *models.ConfigYAML, ma
 	return validateMetricsTrigger(configYAML, logger)
 }
 
-func loadScheduler(
+// LoadScheduler loads a scheduler from DB with its YAML config
+func LoadScheduler(
 	mr *models.MixedMetricsReporter,
 	db pginterfaces.DB,
 	schedulerOrNil *models.Scheduler,
 	schedulerName string,
 ) (*models.Scheduler, models.ConfigYAML, error) {
 	var scheduler *models.Scheduler
-	var oldConfig models.ConfigYAML
+	var configYAML models.ConfigYAML
 	var err error
 	if schedulerOrNil != nil {
 		scheduler = schedulerOrNil
-		err = yaml.Unmarshal([]byte(scheduler.YAML), &oldConfig)
+		err = yaml.Unmarshal([]byte(scheduler.YAML), &configYAML)
 		if err != nil {
-			return scheduler, oldConfig, err
+			return scheduler, configYAML, err
 		}
 	} else {
-		scheduler, oldConfig, err = schedulerAndConfigFromName(mr, db, schedulerName)
+		scheduler, configYAML, err = schedulerAndConfigFromName(mr, db, schedulerName)
 		if err != nil {
-			return scheduler, oldConfig, err
+			return scheduler, configYAML, err
 		}
 	}
-	return scheduler, oldConfig, nil
+	return scheduler, configYAML, nil
 }
 
 // AcquireLock acquires a lock defined by its lockKey
@@ -1137,7 +1138,8 @@ func saveConfigYAML(
 	return nil
 }
 
-func listCurrentPods(
+// ListCurrentPods returns a list of kubernetes pods
+func ListCurrentPods(
 	mr *models.MixedMetricsReporter,
 	clientset kubernetes.Interface,
 	schedulerName string,

--- a/models/constants.go
+++ b/models/constants.go
@@ -49,6 +49,12 @@ const SegmentZRangeBy = "Redis/ZRangeBy"
 //SegmentSMembers represents a segment
 const SegmentSMembers = "Redis/SMembers"
 
+//SegmentSAdd represents a segment
+const SegmentSAdd = "Redis/SAdd"
+
+//SegmentSRem represents a segment
+const SegmentSRem = "Redis/SRem"
+
 //SegmentSIsMember represents a segment
 const SegmentSIsMember = "Redis/SIsMember"
 

--- a/models/constants.go
+++ b/models/constants.go
@@ -55,6 +55,9 @@ const SegmentSAdd = "Redis/SAdd"
 //SegmentSRem represents a segment
 const SegmentSRem = "Redis/SRem"
 
+//SegmentGet represents a segment
+const SegmentGet = "Redis/Get"
+
 //SegmentSIsMember represents a segment
 const SegmentSIsMember = "Redis/SIsMember"
 

--- a/models/room.go
+++ b/models/room.go
@@ -609,38 +609,87 @@ func GetInvalidRoomsKey(schedulerName string) string {
 	return fmt.Sprintf("scheduler:%s:invalidRooms", schedulerName)
 }
 
+// GetInvalidRoomsCountKey gets the key for the string that keeps count of invalid rooms
+func GetInvalidRoomsCountKey(schedulerName string) string {
+	return fmt.Sprintf("scheduler:%s:invalidRooms:count", schedulerName)
+}
+
 // SetInvalidRooms save a room in invalid redis set
 // A room is considered invalid if its version is not the scheduler current version
 func SetInvalidRooms(redisClient interfaces.RedisClient, mr *MixedMetricsReporter, schedulerName string, roomIDs []string) error {
 	pipe := redisClient.TxPipeline()
-	err := mr.WithSegment(SegmentSAdd, func() error {
+	pipe.Del(GetInvalidRoomsKey(schedulerName))
+	pipe.Del(GetInvalidRoomsCountKey(schedulerName))
+	pipe.SAdd(GetInvalidRoomsKey(schedulerName), roomIDs)
+	pipe.Set(GetInvalidRoomsCountKey(schedulerName), len(roomIDs), 2*time.Hour)
+	return mr.WithSegment(SegmentPipeExec, func() error {
 		var err error
-		pipe.Del(GetInvalidRoomsKey(schedulerName))
-		pipe.SAdd(GetInvalidRoomsKey(schedulerName), roomIDs)
+		_, err = pipe.Exec()
+		return err
+	})
+}
+
+// RemoveInvalidRooms deletes an invalid room
+func RemoveInvalidRooms(redisClient interfaces.RedisClient, mr *MixedMetricsReporter, schedulerName string, roomIDs []string) error {
+	pipe := redisClient.TxPipeline()
+	pipe.SRem(GetInvalidRoomsKey(schedulerName), roomIDs)
+	err := mr.WithSegment(SegmentPipeExec, func() error {
+		var err error
+		_, err = pipe.Exec()
+		if err == redis.Nil {
+			return nil
+		}
+		return err
+	})
+	return err
+}
+
+// RemoveInvalidRoomsKey deletes invalidRooms redis key
+func RemoveInvalidRoomsKey(redisClient interfaces.RedisClient, mr *MixedMetricsReporter, schedulerName string) error {
+	pipe := redisClient.TxPipeline()
+	pipe.Del(GetInvalidRoomsKey(schedulerName))
+	pipe.Del(GetInvalidRoomsCountKey(schedulerName))
+	err := mr.WithSegment(SegmentPipeExec, func() error {
+		var err error
 		_, err = pipe.Exec()
 		return err
 	})
 	return err
 }
 
-// RemoveInvalidRooms deletes an invalid room
-func RemoveInvalidRooms(redisClient interfaces.RedisClient, mr *MixedMetricsReporter, schedulerName string, roomIDs []string) error {
-	err := mr.WithSegment(SegmentSRem, func() error {
+// GetCurrentInvalidRoomsCount returns the count of current invalid rooms
+func GetCurrentInvalidRoomsCount(redisClient interfaces.RedisClient, mr *MixedMetricsReporter, schedulerName string) (int, error) {
+	pipe := redisClient.TxPipeline()
+	res := pipe.SCard(GetInvalidRoomsKey(schedulerName))
+	count := 0
+	err := mr.WithSegment(SegmentPipeExec, func() error {
 		var err error
-		_, err = redisClient.SRem(GetInvalidRoomsKey(schedulerName), roomIDs).Result()
+		_, err = pipe.Exec()
+		if err == redis.Nil {
+			return nil
+		}
+		if err == nil {
+			count = int(res.Val())
+		}
 		return err
 	})
-	return err
+	return count, err
 }
 
-// GetInvalidRoomsCount returns the total invalid rooms
+// GetInvalidRoomsCount returns the count of invalid rooms saved on InvalidRoomsCountKey
 func GetInvalidRoomsCount(redisClient interfaces.RedisClient, mr *MixedMetricsReporter, schedulerName string) (int, error) {
 	count := 0
-	err := mr.WithSegment(SegmentSMembers, func() error {
+	err := mr.WithSegment(SegmentGet, func() error {
 		var err error
-		keys, err := redisClient.SMembers(GetInvalidRoomsKey(schedulerName)).Result()
-		count = len(keys)
-		return err
+		c, err := redisClient.Get(GetInvalidRoomsCountKey(schedulerName)).Result()
+		if err == redis.Nil {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		count, err = strconv.Atoi(c)
+		return nil
 	})
 	return count, err
 }

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	maestroErrors "github.com/topfreegames/maestro/errors"
 	reportersConstants "github.com/topfreegames/maestro/reporters/constants"
 	reportersMocks "github.com/topfreegames/maestro/reporters/mocks"
 	yaml "gopkg.in/yaml.v2"
@@ -4525,7 +4526,7 @@ var _ = Describe("Watcher", func() {
 			testing.MockSelectScheduler(yaml1, mockDb, errDB)
 			err := w.EnsureCorrectRooms()
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(errDB))
+			Expect(err).To(Equal(maestroErrors.NewDatabaseError(errDB)))
 		})
 
 		It("should return error if fail to unmarshal yaml", func() {
@@ -4598,7 +4599,7 @@ var _ = Describe("Watcher", func() {
 			err := w.EnsureCorrectRooms()
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(hook.LastEntry().Message).To(Equal(fmt.Sprintf("error deleting pod %s during rolling update", podNames[1])))
+			Expect(hook.LastEntry().Message).To(Equal(fmt.Sprintf("error deleting pod %s", podNames[1])))
 		})
 
 		It("should delete invalid pods", func() {


### PR DESCRIPTION
** New strategy for tracking rolling update progress **

- When Watcher's EnsureCorrecRooms starts rolling updating, it set opManager to rolling update status and saves the amount of rooms to be replaced in a redis string along with a set with the roomIDs to be replaced
- Every time a room is deleted, the watcher remove a roomID from the redis set (`scheduler:%schedulerName:invalidRooms`)
- Instead of polling kube api to check if the rolling update has finished, the API polls redis and gives the progress percentage as `1 - scheduler:%schedulerName:invalidRooms / scheduler:%schedulerName:invalidRooms:count` where `scheduler:%schedulerName:invalidRooms:count` is the redis key holding a count of rooms to be replaced