### PR TITLE
 Always set status to RollingUpdate if operation exists

### DIFF
--- a/helm/charts/maestro-postgres/templates/maestro-postgres.yaml
+++ b/helm/charts/maestro-postgres/templates/maestro-postgres.yaml
@@ -38,6 +38,8 @@ spec:
           value: maestro
         - name: POSTGRES_DB
           value: maestro
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: trust
         livenessProbe:
           exec:
             command:

--- a/helm/charts/maestro/Chart.yaml
+++ b/helm/charts/maestro/Chart.yaml
@@ -1,7 +1,7 @@
 name: maestro
 home: https://github.com/topfreegames/maestro
 description: Maestro api and worker
-version: 7.2.2
+version: 9.5.1
 maintainers:
   - name: TFGCo
     email: backend@tfgco.com

--- a/metadata/version.go
+++ b/metadata/version.go
@@ -8,7 +8,7 @@
 package metadata
 
 //Version of Maestro
-var Version = "9.4.1"
+var Version = "9.5.2"
 
 //KubeVersion is the desired Kubernetes version
 var KubeVersion = "v1.13.9"

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -1289,6 +1289,10 @@ func (w *Watcher) EnsureCorrectRooms() error {
 					return err
 				}
 			}
+
+			logger.WithFields(logrus.Fields{
+				"operation": operationManager.GetOperationKey(),
+			}).Infof(`changing state from "%s" to "%s"`, status["description"], models.OpManagerRollingUpdate)
 			err = operationManager.SetDescription(models.OpManagerRollingUpdate)
 			if err != nil {
 				logger.WithError(err).Error("error trying to set opmanager to rolling update status")

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -494,6 +494,9 @@ var _ = Describe("Watcher", func() {
 				w.Run = false
 			}, mockDb, nil, nil)
 
+			opManager := models.NewOperationManager(configYaml.Name, mockRedisClient, logger)
+			testing.MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
 			mockPipeline.EXPECT().Del(models.GetInvalidRoomsKey(configYaml.Name))
 			mockPipeline.EXPECT().Exec()


### PR DESCRIPTION
When trying to do operation that requires to recreate the pods (change image, env vars, etc ...) and there are no pods the operation gets stuck until it timeouts. This happens because on `GetOperationStatus` it checks if the operation is in `RollingUpdate` status and if not the progress always returns zero and `EnsureCorrectRooms` do not set the status if the number of invalid pods is zero.

This PR makes `EnsureCorrectRooms` always set the status to `RollingUpdate` if there is a current operation even if there are zero pods to update.