### PR TITLE
Worker should stop when operation is canceled

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -6473,7 +6473,6 @@ containers:
 				nil,
 				10,
 				1,
-				&clock.Clock{},
 			)
 			Expect(timeoutErr).To(HaveOccurred())
 			Expect(cancelErr).ToNot(HaveOccurred())
@@ -6515,7 +6514,6 @@ containers:
 				opManager,
 				10,
 				1,
-				&clock.Clock{},
 			)
 			Expect(timeoutErr).ToNot(HaveOccurred())
 			Expect(cancelErr).To(HaveOccurred())
@@ -6533,7 +6531,7 @@ containers:
 				HGetAll(opManager.GetOperationKey()).
 				Return(goredis.NewStringStringMapResult(map[string]string{
 					"description": models.OpManagerRollingUpdate,
-				}, nil)).Times(5)
+				}, nil))
 
 			mockRedisClient.EXPECT().
 				HGetAll(opManager.GetOperationKey()).
@@ -6542,6 +6540,13 @@ containers:
 			mt.MockCreateRoomsAnyTimes(mockRedisClient, mockPipeline, &configYaml1, 0)
 			mt.MockGetPortsFromPoolAnyTimes(&configYaml1, mockRedisClient, mockPortChooser, workerPortRange, portStart, portEnd)
 			mt.MockAnyRunningPod(mockRedisClient, configYaml1.Name, 0)
+
+			mockPipeline.EXPECT().
+				SIsMember(models.GetRoomStatusSetRedisKey(configYaml1.Name, "ready"), gomock.Any()).
+				Return(goredis.NewBoolResult(true, nil))
+			mockPipeline.EXPECT().
+				SIsMember(models.GetRoomStatusSetRedisKey(configYaml1.Name, "occupied"), gomock.Any()).
+				Return(goredis.NewBoolResult(false, nil))
 
 			for _, pod := range pods {
 				podv1 := &v1.Pod{}
@@ -6571,7 +6576,6 @@ containers:
 				opManager,
 				10,
 				1,
-				&clock.Clock{},
 			)
 			Expect(timeoutErr).ToNot(HaveOccurred())
 			Expect(cancelErr).To(HaveOccurred())
@@ -6625,7 +6629,6 @@ containers:
 				opManager,
 				10,
 				1,
-				&clock.Clock{},
 			)
 			Expect(timeoutErr).ToNot(HaveOccurred())
 			Expect(cancelErr).ToNot(HaveOccurred())
@@ -6695,7 +6698,6 @@ containers:
 				opManager,
 				10,
 				1,
-				&clock.Clock{},
 			)
 			Expect(timeoutErr).ToNot(HaveOccurred())
 			Expect(cancelErr).ToNot(HaveOccurred())

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -6471,7 +6471,7 @@ containers:
 				pods,
 				scheduler,
 				nil,
-				time.Second,
+				10 * time.Second,
 				10,
 				1,
 			)
@@ -6513,7 +6513,7 @@ containers:
 				pods,
 				scheduler,
 				opManager,
-				time.Second,
+				10 * time.Second,
 				10,
 				1,
 			)
@@ -6576,7 +6576,7 @@ containers:
 				pods,
 				scheduler,
 				opManager,
-				time.Second,
+				10 * time.Second,
 				10,
 				1,
 			)
@@ -6630,7 +6630,7 @@ containers:
 				pods,
 				scheduler,
 				opManager,
-				time.Second,
+				10 * time.Second,
 				10,
 				1,
 			)
@@ -6700,7 +6700,7 @@ containers:
 				pods,
 				scheduler,
 				opManager,
-				time.Second,
+				10 * time.Second,
 				10,
 				1,
 			)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -6471,6 +6471,7 @@ containers:
 				pods,
 				scheduler,
 				nil,
+				time.Second,
 				10,
 				1,
 			)
@@ -6512,6 +6513,7 @@ containers:
 				pods,
 				scheduler,
 				opManager,
+				time.Second,
 				10,
 				1,
 			)
@@ -6574,6 +6576,7 @@ containers:
 				pods,
 				scheduler,
 				opManager,
+				time.Second,
 				10,
 				1,
 			)
@@ -6627,6 +6630,7 @@ containers:
 				pods,
 				scheduler,
 				opManager,
+				time.Second,
 				10,
 				1,
 			)
@@ -6696,6 +6700,7 @@ containers:
 				pods,
 				scheduler,
 				opManager,
+				time.Second,
 				10,
 				1,
 			)

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"math/rand"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -39,7 +40,6 @@ import (
 // SegmentAndReplacePods acts when a scheduler rolling update is needed.
 // It segment the list of current pods in chunks of size maxSurge and replace them with new ones
 func SegmentAndReplacePods(
-	ctx context.Context,
 	logger logrus.FieldLogger,
 	roomManager models.RoomManager,
 	mr *models.MixedMetricsReporter,
@@ -86,13 +86,13 @@ func SegmentAndReplacePods(
 
 		if timedout {
 			timeoutErr = errors.New("timedout waiting rooms to be replaced, rolled back")
-			l.WithError(timeoutErr).Error("error replacing chunk of pods")
+			l.WithError(timeoutErr).Error("operation timed out while replacing chunk of pods")
 			break
 		}
 
 		if canceled {
 			cancelErr = errors.New("operation was canceled, rolled back")
-			l.WithError(cancelErr).Error("error replacing chunk of pods")
+			l.WithError(cancelErr).Error("operation canceled while error replacing chunk of pods")
 			break
 		}
 
@@ -122,12 +122,11 @@ func replacePodsAndWait(
 	goroutinePoolSize int,
 ) (timedout, canceled bool, err error) {
 	logger.Debug("starting to replace pods with new ones")
-	stop := make(chan struct{}, 1)
-	defer close(stop) // Dont leak goroutines
-	finishedReplace := make(chan struct{})
 
-	timedoutChan := make(chan bool)
-	canceledChan := make(chan bool)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	finishedReplace := make(chan struct{})
+	canceledChan := make(chan struct{})
 	errChan := make(chan error)
 
 	pods := make(chan *models.Pod, len(podsChunk))
@@ -135,91 +134,107 @@ func replacePodsAndWait(
 		pods <- pod
 	}
 
+	inRollingUpdate := operationManager != nil
+
+	var wg sync.WaitGroup
 	logger.Infof("starting %d in-memory workers to replace %d pods", goroutinePoolSize, len(podsChunk))
 	for i := 0; i < goroutinePoolSize; i++ {
-		go replacePodWorker(
-			logger,
-			roomManager,
-			mr,
-			clientset,
-			db,
-			redisClient,
-			willTimeoutAt,
-			configYAML,
-			scheduler,
-			operationManager,
-			clock,
-			pods,
-			stop, finishedReplace,
-			timedoutChan, canceledChan, errChan,
-		)
-	}
-
-	select {
-	case err = <-errChan:
-		return false, false, err
-
-	case canceled = <-canceledChan:
-		return false, canceled, nil
-
-	case timedout = <-timedoutChan:
-		return timedout, false, nil
-
-	case <-finishedReplace:
-		logger.Debug("all pods were successfully replaced")
-		break
-	}
-
-	return timedout, canceled, err
-}
-
-func replacePodWorker(
-	logger logrus.FieldLogger,
-	roomManager models.RoomManager,
-	mr *models.MixedMetricsReporter,
-	clientset kubernetes.Interface,
-	db pginterfaces.DB,
-	redisClient redisinterfaces.RedisClient,
-	willTimeoutAt time.Time,
-	configYAML *models.ConfigYAML,
-	scheduler *models.Scheduler,
-	operationManager *models.OperationManager,
-	clock clockinterfaces.Clock,
-	pods <-chan *models.Pod,
-	stop, finishedReplace chan struct{},
-	timedoutChan, canceledChan chan<- bool,
-	errChan chan<- error,
-) {
-	for {
-		select {
-		case pod := <-pods:
-			localTimedout, localCanceled, localErr := createNewRemoveOldPod(
+		wg.Add(1)
+		go func () {
+			defer wg.Done()
+			replacePodWorker(
+				ctx,
 				logger,
 				roomManager,
 				mr,
 				clientset,
 				db,
 				redisClient,
-				willTimeoutAt,
 				configYAML,
 				scheduler,
-				operationManager,
+				pods,
+				inRollingUpdate,
+				finishedReplace,
+				errChan,
+			)
+		}()
+	}
+	
+	if inRollingUpdate {
+		go func() {
+			for {
+				canceled, err := operationManager.WasCanceled()
+				if err != nil {
+					continue
+				}
+				if canceled {
+					close(canceledChan)
+					return
+				}
+			}
+		}()
+	}
+
+	duration := willTimeoutAt.Sub(clock.Now())
+	timeout := time.NewTimer(duration)
+
+	select {
+	case err = <-errChan:
+		logger.Error("operation terminated with error")
+	case <-canceledChan:
+		logger.Warn("operation was canceled")
+		canceled = true
+	case <-timeout.C:
+		logger.Warn("operation timedout")
+		timedout = true
+	case <-finishedReplace:
+		logger.Debug("all pods were successfully replaced")
+	}
+
+	cancel()
+	wg.Wait()
+
+	return timedout, canceled, err
+}
+
+func replacePodWorker(
+	ctx context.Context,
+	logger logrus.FieldLogger,
+	roomManager models.RoomManager,
+	mr *models.MixedMetricsReporter,
+	clientset kubernetes.Interface,
+	db pginterfaces.DB,
+	redisClient redisinterfaces.RedisClient,
+	configYAML *models.ConfigYAML,
+	scheduler *models.Scheduler,
+	pods <-chan *models.Pod,
+	inRollingUpdate bool,
+	finishedReplace chan struct{},
+	errChan chan<- error,
+) {
+	for {
+		select {
+		case pod := <-pods:
+			canceled, err := createNewRemoveOldPod(
+				ctx,
+				logger,
+				roomManager,
+				mr,
+				clientset,
+				db,
+				redisClient,
+				configYAML,
+				scheduler,
 				pod,
-				clock,
+				inRollingUpdate,
 			)
 
-			if localErr != nil {
-				errChan <- localErr
+			if err != nil {
+				errChan <- err
 				return
 			}
 
-			if localCanceled {
-				canceledChan <- localCanceled
-				return
-			}
-
-			if localTimedout {
-				timedoutChan <- localTimedout
+			if canceled {
 				return
 			}
 
@@ -228,26 +243,25 @@ func replacePodWorker(
 				finishedReplace <- struct{}{}
 				return
 			}
-		case <-stop:
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
 func createNewRemoveOldPod(
+	ctx context.Context,
 	logger logrus.FieldLogger,
 	roomManager models.RoomManager,
 	mr *models.MixedMetricsReporter,
 	clientset kubernetes.Interface,
 	db pginterfaces.DB,
 	redisClient redisinterfaces.RedisClient,
-	willTimeoutAt time.Time,
 	configYAML *models.ConfigYAML,
 	scheduler *models.Scheduler,
-	operationManager *models.OperationManager,
 	pod *models.Pod,
-	clock clockinterfaces.Clock,
-) (timedout, canceled bool, err error) {
+	inRollingUpdate bool,
+) (canceled bool, err error) {
 	logger.Debug("creating pod")
 
 	// create new pod
@@ -256,67 +270,60 @@ func createNewRemoveOldPod(
 
 	if err != nil {
 		logger.WithError(err).Errorf("error creating pod")
-		return false, false, err
+		return false, err
 	}
 
 	// wait for new pod to be created
-	timeout := willTimeoutAt.Sub(clock.Now())
-	timedout, canceled, err = waitCreatingPods(
-		logger, clientset, redisClient, timeout, configYAML.Name,
-		[]v1.Pod{*newPod}, operationManager, mr)
-	if timedout || canceled || err != nil {
+	canceled, err = waitCreatingPods(
+		ctx, logger, clientset, redisClient, configYAML.Name,
+		[]v1.Pod{*newPod}, mr)
+	if canceled || err != nil {
 		logger.Errorf("error waiting for pod to be created")
-		return timedout, canceled, err
+		return canceled, err
 	}
 
-	timedout, canceled, err = DeletePodsAndWait(
+	canceled, err = DeletePodsAndWait(
+		ctx,
 		logger,
 		roomManager,
 		mr,
 		clientset,
 		redisClient,
-		willTimeoutAt,
 		configYAML,
-		scheduler,
-		operationManager,
 		[]*models.Pod{pod},
-		clock,
 	)
 
 	if err != nil && !strings.Contains(err.Error(), "redis") {
-		return false, false, nil
+		return false, nil
 	}
 
-	if timedout || canceled {
-		return timedout, canceled, nil
+	if canceled {
+		return true, nil
 	}
 
 	// Remove invalid rooms redis keys if in a rolling update operation
 	// in order to track progress correctly
-	if operationManager != nil {
+	if inRollingUpdate {
 		err = models.RemoveInvalidRooms(redisClient, mr, configYAML.Name, []string{pod.Name})
 		if err != nil {
 			logger.WithError(err).Warnf("error removing room %s from invalidRooms redis key during rolling update", pod.Name)
 		}
 	}
 
-	return false, false, nil
+	return false, nil
 }
 
 // DeletePodsAndWait deletes a list of pods
 func DeletePodsAndWait(
+	ctx context.Context,
 	logger logrus.FieldLogger,
 	roomManager models.RoomManager,
 	mr *models.MixedMetricsReporter,
 	clientset kubernetes.Interface,
 	redisClient redisinterfaces.RedisClient,
-	willTimeoutAt time.Time,
 	configYAML *models.ConfigYAML,
-	scheduler *models.Scheduler,
-	operationManager *models.OperationManager,
 	pods []*models.Pod,
-	clock clockinterfaces.Clock,
-) (timedout, canceled bool, err error) {
+) (canceled bool, err error) {
 
 	for _, pod := range pods {
 		logger.Debugf("deleting pod %s", pod.Name)
@@ -324,23 +331,19 @@ func DeletePodsAndWait(
 			configYAML, pod.Name, reportersConstants.ReasonUpdate)
 		if err != nil && !strings.Contains(err.Error(), "redis") {
 			logger.WithError(err).Errorf("error deleting pod %s", pod.Name)
-			return false, false, nil
+			return  false, nil
 		}
 	}
 
 	// wait for old pods to be deleted
 	// we assume that maxSurge == maxUnavailable as we can't set maxUnavailable yet
 	// so for every pod created in a chunk one is deleted right after it
-	timeout := willTimeoutAt.Sub(clock.Now())
-	timedout, canceled = waitTerminatingPods(
-		logger, clientset, redisClient, timeout, configYAML.Name,
-		pods, operationManager, mr)
-	if timedout || canceled || err != nil {
-		logger.Error("error waiting for pods to be deleted")
-		return timedout, canceled, nil
+	canceled = waitTerminatingPods(ctx, logger, clientset, redisClient, configYAML.Name, pods, mr)
+	if canceled {
+		return canceled, nil
 	}
 
-	return false, false, nil
+	return false, nil
 }
 
 // DBRollback perform a rollback on a scheduler config in the database
@@ -396,15 +399,14 @@ func DBRollback(
 }
 
 func waitTerminatingPods(
+	ctx context.Context,
 	l logrus.FieldLogger,
 	clientset kubernetes.Interface,
 	redisClient redisinterfaces.RedisClient,
-	timeout time.Duration,
 	namespace string,
 	deletedPods []*models.Pod,
-	operationManager *models.OperationManager,
 	mr *models.MixedMetricsReporter,
-) (timedout, wasCanceled bool) {
+) (wasCanceled bool) {
 	logger := l.WithFields(logrus.Fields{
 		"source":    "controller.waitTerminatingPods",
 		"scheduler": namespace,
@@ -412,21 +414,16 @@ func waitTerminatingPods(
 
 	logger.Debugf("waiting for pods to terminate: %#v", names(deletedPods))
 
-	timeoutTimer := time.NewTimer(timeout)
-	defer timeoutTimer.Stop()
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
 	for {
 		exit := true
 		select {
+		case <-ctx.Done():
+			logger.Warn("operation canceled/timedout waiting for rooms to be removed")
+			return true
 		case <-ticker.C:
-			// operationManger is nil when rolling back (rollback can't be canceled)
-			if operationManager != nil && operationManager.WasCanceled() {
-				logger.Warn("operation was canceled")
-				return false, true
-			}
-
 			for _, pod := range deletedPods {
 				p, err := models.GetPodFromRedis(redisClient, mr, pod.Name, namespace)
 				if err != nil {
@@ -453,9 +450,6 @@ func waitTerminatingPods(
 					break
 				}
 			}
-		case <-timeoutTimer.C:
-			logger.Error("timeout waiting for rooms to be removed")
-			return true, false
 		}
 
 		if exit {
@@ -464,26 +458,23 @@ func waitTerminatingPods(
 		}
 	}
 
-	return false, false
+	return false
 }
 
 func waitCreatingPods(
+	ctx context.Context,
 	l logrus.FieldLogger,
 	clientset kubernetes.Interface,
 	redisClient redisinterfaces.RedisClient,
-	timeout time.Duration,
 	namespace string,
 	createdPods []v1.Pod,
-	operationManager *models.OperationManager,
 	mr *models.MixedMetricsReporter,
-) (timedout, wasCanceled bool, err error) {
+) (canceled bool, err error) {
 	logger := l.WithFields(logrus.Fields{
 		"source":    "controller.waitCreatingPods",
 		"scheduler": namespace,
 	})
 
-	timeoutTimer := time.NewTimer(timeout)
-	defer timeoutTimer.Stop()
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
@@ -497,12 +488,6 @@ func waitCreatingPods(
 		exit := true
 		select {
 		case <-ticker.C:
-			// operationManger is nil when rolling back (rollback can't be canceled)
-			if operationManager != nil && operationManager.WasCanceled() {
-				logger.Warn("operation was canceled")
-				return false, true, nil
-			}
-
 			for i, pod := range createdPods {
 				createdPod, err := models.GetPodFromRedis(redisClient, mr, pod.GetName(), namespace)
 				if err != nil {
@@ -583,16 +568,16 @@ func waitCreatingPods(
 
 					if err != nil {
 						logger.WithField("pod", pod.GetName()).WithError(err).Error("invalid pod waiting state")
-						return false, false, err
+						return false, err
 					}
 
 					exit = false
 					break
 				}
 			}
-		case <-timeoutTimer.C:
-			logger.Error("timeout waiting for rooms to be created")
-			return true, false, nil
+		case <-ctx.Done():
+			logger.Warn("operation canceled/timeout waiting for rooms to be created")
+			return true, nil
 		}
 
 		if exit {
@@ -601,7 +586,7 @@ func waitCreatingPods(
 		}
 	}
 
-	return false, false, nil
+	return false, nil
 }
 
 // DeletePodAndRoom deletes the pod and removes the room from redis
@@ -1144,9 +1129,12 @@ func AcquireLock(
 			l.Warn("timeout while wating for redis lock")
 			return nil, false, errors.New("timeout while wating for redis lock")
 		case <-ticker.C:
-			if operationManager != nil && operationManager.WasCanceled() {
-				l.Warn("operation was canceled")
-				return nil, true, nil
+			if operationManager != nil {
+				canceled, err := operationManager.WasCanceled()
+				if canceled && err == nil {
+					l.Warn("operation was canceled")
+					return nil, true, nil
+				}
 			}
 
 			if err != nil {

--- a/metadata/version.go
+++ b/metadata/version.go
@@ -8,7 +8,7 @@
 package metadata
 
 //Version of Maestro
-var Version = "9.5.2"
+var Version = "9.5.3"
 
 //KubeVersion is the desired Kubernetes version
 var KubeVersion = "v1.13.9"

--- a/models/operation_manager.go
+++ b/models/operation_manager.go
@@ -27,8 +27,6 @@ type OperationManager struct {
 	redisClient     redisinterfaces.RedisClient
 	logger          logrus.FieldLogger
 	operationKey    string
-	wasCanceledBool bool
-	continueLoop    bool
 	operationName   string
 	loopTime        time.Duration
 }
@@ -43,17 +41,9 @@ func NewOperationManager(
 		schedulerName: schedulerName,
 		redisClient:   redisClient,
 		logger:        logger,
-		continueLoop:  true,
-		loopTime:      10 * time.Second,
 	}
 	o.operationKey = o.buildKey()
 	return o
-}
-
-// SetLoopTime sets how much will wait to check again if operation was canceled
-// Default is 10s
-func (o *OperationManager) SetLoopTime(t time.Duration) {
-	o.loopTime = t
 }
 
 // GetOperationKey returns the operation key
@@ -108,54 +98,19 @@ func (o *OperationManager) Start(
 		return err
 	}
 
-	l.Debug("starting check loop on a goroutine")
-	go func() {
-		ticker := time.NewTicker(o.loopTime)
-		defer ticker.Stop()
-
-		for o.continueLoop {
-			select {
-			case <-ticker.C:
-				l.Debug("operationManager loop")
-				wasCanceled, err := o.wasCanceled()
-				if err != nil {
-					l.WithError(err).Warn("error getting operationKey on redis")
-					continue
-				}
-				if wasCanceled {
-					l.Debug("operation was canceled")
-					o.continueLoop = false
-					o.wasCanceledBool = true
-					continue
-				}
-
-				l.Debug("operation was not canceled, continuing...")
-			}
-		}
-	}()
-
 	return nil
 }
 
-// WasCanceled returns a channel that is true when operation was canceled
-func (o *OperationManager) WasCanceled() bool {
+func (o *OperationManager) WasCanceled() (bool, error) {
 	if o == nil {
-		return false
+		return false, nil
 	}
 
-	return o.wasCanceledBool
-}
-
-func (o *OperationManager) wasCanceled() (bool, error) {
 	l := o.logger.WithFields(logrus.Fields{
 		"source":       "OperationManager",
-		"operation":    "wasCanceled",
+		"operation":    "WasCanceled",
 		"operationKey": o.operationKey,
 	})
-
-	if !o.continueLoop {
-		return true, nil
-	}
 
 	l.Debug("checking if operation was canceled")
 	r, err := o.redisClient.HGetAll(o.operationKey).Result()
@@ -171,9 +126,6 @@ func (o *OperationManager) wasCanceled() (bool, error) {
 
 // Cancel removes operationKey from redis and this cancels an operation
 func (o *OperationManager) Cancel(operationKey string) error {
-	o.wasCanceledBool = true
-	o.continueLoop = false
-
 	l := o.logger.WithFields(logrus.Fields{
 		"source":       "OperationManager",
 		"operation":    "Cancel",
@@ -201,8 +153,6 @@ func (o *OperationManager) Cancel(operationKey string) error {
 
 // Finish updates operationKey on redis to the finish state
 func (o *OperationManager) Finish(status int, description string, opErr error) error {
-	o.continueLoop = false
-
 	l := o.logger.WithFields(logrus.Fields{
 		"source":       "OperationManager",
 		"operation":    "Finish",
@@ -272,16 +222,6 @@ func (o *OperationManager) CurrentOperation() (string, error) {
 	}
 
 	return currOp, err
-}
-
-// StopLoop sets continueLoop to false
-func (o *OperationManager) StopLoop() {
-	o.continueLoop = false
-}
-
-// IsStopped returns true if operation manager is not in loop
-func (o *OperationManager) IsStopped() bool {
-	return !o.continueLoop
 }
 
 // SetDescription sets the description and error of the operation current state

--- a/models/operation_manager.go
+++ b/models/operation_manager.go
@@ -114,11 +114,11 @@ func (o *OperationManager) WasCanceled() (bool, error) {
 
 	l.Debug("checking if operation was canceled")
 	r, err := o.redisClient.HGetAll(o.operationKey).Result()
-	l.Debug("successfully accessed redis")
 
 	if err != nil {
 		return false, err
 	}
+	l.Debug("successfully accessed redis")
 
 	wasCanceled := r == nil || len(r) == 0
 	return wasCanceled, nil

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -1326,7 +1326,6 @@ func (w *Watcher) EnsureCorrectRooms() error {
 		operationManager,
 		w.Config.GetInt("watcher.maxSurge"),
 		w.Config.GetInt("watcher.goroutinePoolSize"),
-		&clock.Clock{},
 	)
 
 	if err != nil {

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -153,6 +153,7 @@ func (w *Watcher) loadConfigurationDefaults() {
 	w.Config.SetDefault("watcher.lockTimeoutMs", 180000)
 	w.Config.SetDefault("watcher.maxScaleUpAmount", 300)
 	w.Config.SetDefault("watcher.gracefulShutdownTimeout", 300)
+	w.Config.SetDefault("watcher.cancelPollingPeriod", "10s")
 	w.Config.SetDefault("pingTimeout", 30)
 	w.Config.SetDefault("occupiedTimeout", 60*60)
 	w.Config.SetDefault(constants.EnvironmentConfig, constants.ProdEnvironment)
@@ -1324,6 +1325,7 @@ func (w *Watcher) EnsureCorrectRooms() error {
 		invalidPods,
 		scheduler,
 		operationManager,
+		w.Config.GetDuration("watcher.cancelPollingPeriod"),
 		w.Config.GetInt("watcher.maxSurge"),
 		w.Config.GetInt("watcher.goroutinePoolSize"),
 	)

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -4509,6 +4509,44 @@ var _ = Describe("Watcher", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("should stop when operation is canceled", func() {
+			testing.MockSelectScheduler(yaml1, mockDb, nil)
+			//mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().HGetAll(
+				models.GetPodMapRedisKey(configYaml.Name)).
+				Return(redis.NewStringStringMapResult(map[string]string{
+					"room-1": `{"name": "room-1", "version": "v2.0"}`,
+					"room-2": `{"name": "room-1", "version": "v2.0"}`,
+			}, nil))
+			//mockPipeline.EXPECT().Exec()
+
+			testing.MockGetRegisteredRooms(mockRedisClient, mockPipeline, w.SchedulerName, [][]string{}, nil)
+
+			opKey := fmt.Sprintf("opmanager:%s:operation", configYaml.Name)
+			opManager := models.NewOperationManager(configYaml.Name, mockRedisClient, logger)
+
+			mockRedisClient.EXPECT().Get(opManager.BuildCurrOpKey()).Return(redis.NewStringResult(opKey, nil))
+
+			call := mockRedisClient.EXPECT().HGetAll(opKey).Return(
+				redis.NewStringStringMapResult(map[string]string{
+					"description": models.OpManagerRollingUpdate,
+				}, nil)).Times(2)
+			mockRedisClient.EXPECT().HGetAll(opKey).
+				Return(redis.NewStringStringMapResult(map[string]string(nil), nil)).
+				After(call)
+
+			// Create room
+			testing.MockCreateRoomsAnyTimes(mockRedisClient, mockPipeline, &configYaml, 0)
+			testing.MockGetPortsFromPoolAnyTimes(&configYaml, mockRedisClient, mockPortChooser,
+				models.NewPortRange(5000, 6000).String(), 5000, 6000)
+
+			testing.MockPodNotFound(mockRedisClient, w.SchedulerName, gomock.Any()).AnyTimes()
+
+			err := w.EnsureCorrectRooms()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hook.Entries).To(testing.ContainLogMessage("operation was canceled"))
+		})
 	})
 
 	Describe("PodStatesCount", func() {

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -4545,7 +4545,7 @@ var _ = Describe("Watcher", func() {
 
 			err := w.EnsureCorrectRooms()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(hook.Entries).To(testing.ContainLogMessage("operation was canceled"))
+			Expect(hook.Entries).To(testing.ContainLogMessage("operation canceled while error replacing chunk of pods"))
 		})
 	})
 


### PR DESCRIPTION
When an operation is canceled the worker should know and stop the operation and the api should issue a rollback. Right now this is not happening because `OperationManager.WasCanceled` checks a cached state and never hits redis and the worker never starts the loop to check for operation updates.

I changed to `OperationManager` to remove the loop and make it so `WasCanceled` always check on redis. This works for most use cases inside maestro. To prevent having multiple goroutines hitting redis at the same time I moved the loop to inside the worker and separated from `OperationManager`.

I also added tests to `SegmentAndReplacePods` that were missing and added a test case to the watcher for when an operation is canceled.