### PR TITLE
Cancel operation after an error

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -6586,6 +6586,7 @@ containers:
 		It("should return error when it fails to create pod", func() {
 			pods := []*models.Pod{
 				&models.Pod{Name: "room-1"},
+				&models.Pod{Name: "room-2"},
 			}
 
 			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, string(configYaml1.ToYAML()))
@@ -6614,8 +6615,32 @@ containers:
 			mockPipeline.EXPECT().
 				ZAdd(models.GetRoomPingRedisKey(configYaml1.Name), gomock.Any())
 
+			mockPipeline.EXPECT().Exec()
+
+			mockRedisClient.EXPECT().
+				TxPipeline().
+				Return(mockPipeline)
+
+			mockPipeline.EXPECT().
+				HMSet(gomock.Any(), gomock.Any()).
+				Do(func(schedulerName string, statusInfo map[string]interface{}) {
+					Expect(statusInfo["status"]).To(Equal(models.StatusCreating))
+					Expect(statusInfo["lastPing"]).To(BeNumerically("~", time.Now().Unix(), 1))
+				})
+
+			mockPipeline.EXPECT().
+				SAdd(models.GetRoomStatusSetRedisKey(configYaml1.Name, "creating"),
+					gomock.Any())
+
+			mockPipeline.EXPECT().
+				ZAdd(models.GetRoomPingRedisKey(configYaml1.Name), gomock.Any())
+
 			mockPipeline.EXPECT().Exec().Return(nil, errors.New("redis error"))
 
+			mt.MockGetPortsFromPoolAnyTimes(&configYaml1, mockRedisClient, mockPortChooser, workerPortRange, portStart, portEnd)
+			mt.MockPodNotFound(mockRedisClient, configYaml1.Name, gomock.Any()).AnyTimes()
+
+			now := time.Now()
 			timeoutErr, cancelErr, err := controller.SegmentAndReplacePods(
 				logger,
 				roomManager,
@@ -6623,14 +6648,14 @@ containers:
 				clientset,
 				mockDb,
 				mockRedisClient,
-				time.Now().Add(time.Minute),
+				now.Add(time.Minute),
 				&configYaml1,
 				pods,
 				scheduler,
 				opManager,
 				10*time.Second,
-				10,
-				1,
+				100,
+				2,
 			)
 			Expect(timeoutErr).ToNot(HaveOccurred())
 			Expect(cancelErr).ToNot(HaveOccurred())

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -432,7 +432,7 @@ func waitTerminatingPods(
 	for {
 		exit := true
 
-		// go select statement chooses "randomly" when two branches are available, sot it can make select ignore
+		// go select statement chooses "randomly" when two branches are available, so it can make select ignore
 		// ctx.Done() for iterations. This check prevents to enter select if the context was already cancelled.
 		if ctx.Err() != nil {
 			logger.Warn("operation canceled/timedout waiting for rooms to be removed")
@@ -507,7 +507,7 @@ func waitCreatingPods(
 	for {
 		exit := true
 
-		// go select statement chooses "randomly" when two branches are available, sot it can make select ignore
+		// go select statement chooses "randomly" when two branches are available, so it can make select ignore
 		// ctx.Done() for iterations. This check prevents to enter select if the context was already cancelled.
 		if ctx.Err() != nil {
 			logger.Warn("operation canceled/timeout waiting for rooms to be created")


### PR DESCRIPTION
After the refactoring to fix the cancellation of an operation there was a bug in SegmentAndReplacePods where the operation could be stuck for a long time after finished (with an error for example) waiting for the goroutines to complete.

This PRs solves a lot of problems of goroutine leaks in this flow and also the new bug by using a child context. 