### PR TITLE
Add a flag to scheduler forwarders configuration to not return its response

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,34 +354,8 @@ Maestro's auto scaling policies are based on the number of rooms that are in rea
 
 In order to properly set their statuses, game rooms must call the maestro-api HTTP routes described in the [Maestro API docs](http://maestro.readthedocs.io/en/latest/api.html).
 
-## Event Forwarders:
+## Event Forwarders
 
 Event forwarders are pluggable components that forwards events like: RoomReady, RoomTerminated, RoomTerminating, etc... to other services.
 
-A event forwarder is a go native plugin that should be compiled and put into bin folder, it should contain a method ```func NewForwarder(config *viper.Viper) (eventforwarder.EventForwarder)``` that returns a configured instance of a struct that implements "eventforwarder.EventForwarder".
-
-An example is provided in the plugins/grpc folder, compile it with: 
-```
-go build -o bin/grpc.so -buildmode=plugin plugins/grpc/forwarder.go
-```
-
-Then to turn it on, include a config like that in the active config file:
-```
-forwarders:
-  grpc:
-    matchmaking: 
-      address: "10.0.23.57:10000"
-    local:
-      address: "localhost:10000"
-```
-
-In this example, maestro will look for a plugin "grpc.so" in the bin folder and create 2 forwarders from it, matchmaking and local one, each using a different address.
-Then, every time a room is changing states, all forwarders will be called with infos about the change.
-
-There's also a route: ```/scheduler/{schedulerName}/rooms/{roomName}/playerevent``` that can be called like that, for example:
-```
-curl -X POST -d '{"timestamp":12424124234, "event":"playerJoin", "metadata":{"playerId":"sime"}}' localhost:8080/scheduler/some/rooms/r1/playerevent
-```
-It will forward the playerEvent "playerJoin" with the provided metadata and roomId to all the configured forwarders.
-
-For the provided plugin, the valid values for event field are: ['playerJoin','playerLeft']
+[More information about it can e found here.](docs/forwarders.md)

--- a/docs/forwarders.md
+++ b/docs/forwarders.md
@@ -1,0 +1,49 @@
+Event Forwarders
+========
+
+Event forwarders are pluggable components that forwards events like: RoomReady, RoomTerminated, RoomTerminating, etc... to other services.
+
+A event forwarder is a go native plugin that should be compiled and put into bin folder, it should contain a method ```func NewForwarder(config *viper.Viper) (eventforwarder.EventForwarder)``` that returns a configured instance of a struct that implements "eventforwarder.EventForwarder".
+
+An example is provided in the plugins/grpc folder, compile it with:
+```
+go build -o bin/grpc.so -buildmode=plugin plugins/grpc/forwarder.go
+```
+
+## Configuration
+Then to turn it on, include a config like that in the active config file:
+```
+forwarders:
+  grpc:
+    matchmaking:
+      address: "10.0.23.57:10000"
+    local:
+      address: "localhost:10000"
+```
+
+In this example, maestro will look for a plugin "grpc.so" in the bin folder and create 2 forwarders from it, matchmaking and local one, each using a different address.
+Then, every time a room is changing states, all forwarders will be called with infos about the change.
+
+### Testing
+There's also a route: ```/scheduler/{schedulerName}/rooms/{roomName}/playerevent``` that can be called like that, for example:
+```
+curl -X POST -d '{"timestamp":12424124234, "event":"playerJoin", "metadata":{"playerId":"sime"}}' localhost:8080/scheduler/some/rooms/r1/playerevent
+```
+It will forward the playerEvent "playerJoin" with the provided metadata and roomId to all the configured forwarders.
+
+For the provided plugin, the valid values for event field are: ['playerJoin','playerLeft']
+
+## Responses
+All forwarders responses are put in consideration even if they're not returned
+to the clients. This means that if a forwarder fails the API notifying the event
+also fails. This behaviour is deprecated and in future versions the forwarder
+failure/success won't impact any of the notifiers. To achieve this in the
+current version you can add the `forwardMessage (default: true)` configuration
+to your scheduler like in this example:
+```
+forwarders:
+  grpc:
+    matchamaking:
+      enabled: true
+      forwardResponse: false
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Contents:
    cli
    testing
    autoscaling
+   forwarders
 
 Indices and tables
 ==================

--- a/eventforwarder/forward.go
+++ b/eventforwarder/forward.go
@@ -223,7 +223,7 @@ func ForwardEventToForwarders(
 	event string,
 	infos map[string]interface{},
 	logger logrus.FieldLogger,
-) (*Response, error, error) {
+) (resp *Response, warning error, err error) {
 	logger.WithFields(logrus.Fields{
 		"forwarders": len(forwarders),
 		"infos":      infos,
@@ -257,7 +257,7 @@ func ForwardEventToForwarders(
 		}
 	}
 
-	resp := &Response{
+	resp = &Response{
 		Code:    respCode,
 		Message: strings.Join(respMessage, ";"),
 	}

--- a/models/config_yaml.go
+++ b/models/config_yaml.go
@@ -9,6 +9,10 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+// DefaultForwarderForwardResponse is the default value set to `Forwarder`
+// `ForwardResponse` property.
+const DefaultForwarderForwardResponse = true
+
 // ConfigYAMLv1 is the ConfigYAML before refactor to n containers per pod
 type ConfigYAMLv1 struct {
 	Name            string                           `yaml:"name"`
@@ -296,4 +300,23 @@ func (c *ConfigYAML) HasPorts() bool {
 		}
 	}
 	return false
+}
+
+// UnmarshalYAML implements a custom way to unmarshal the `Forward` type. This
+// is done in order to set default values to the type.
+// TODO: make a pattern to set default values for the scheduler config, instead
+//       of having this or the `EnsureDefaultValues`.
+func (f *Forwarder) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// We define a "temporary" type in order to avoid creating a recursion on
+	// `Forward` unmarshal.
+	type rawForwarder Forwarder
+	raw := rawForwarder{ForwardResponse: DefaultForwarderForwardResponse}
+	err := unmarshal(&raw)
+	if err != nil {
+		return err
+	}
+
+	*f = Forwarder(raw)
+
+	return nil
 }

--- a/models/config_yaml_test.go
+++ b/models/config_yaml_test.go
@@ -7,6 +7,44 @@ import (
 )
 
 var _ = Describe("ConfigYaml", func() {
+	Describe("NewCofigYaml", func() {
+		It("should define default value for forwarder", func() {
+			configYaml, _ := NewConfigYAML(`name: scheduler-name
+game: game
+image: nginx:alpine
+ports:
+- containerPort: 8080
+  protocol: TCP
+  name: tcp
+limits:
+  cpu: 100m
+  memory: 100Mi
+requests:
+  cpu: 50m
+  memory: 50Mi
+cmd: ["/bin/bash", "-c", "./start.sh"]
+env:
+- name: ENV_1
+  value: VALUE_1
+containers: []
+forwarders:
+  grpc:
+    sampleGRPC:
+      enabled: true
+      metadata: {}
+    anotherGRPC:
+      enabled: true
+      metadata: {}
+`)
+
+			for _, pluginType := range configYaml.Forwarders {
+				for _, plugin := range pluginType {
+					Expect(plugin.ForwardResponse).To(Equal(DefaultForwarderForwardResponse))
+				}
+			}
+		})
+	})
+
 	Describe("ToYaml", func() {
 		It("should return yaml for version v1", func() {
 			configYaml, _ := NewConfigYAML(`name: scheduler-name

--- a/models/scheduler.go
+++ b/models/scheduler.go
@@ -117,8 +117,9 @@ type AutoScaling struct {
 
 // Forwarder has the configuration for the event forwarders
 type Forwarder struct {
-	Enabled  bool                   `yaml:"enabled" json:"enabled"`
-	Metadata map[string]interface{} `yaml:"metadata" json:"metadata"`
+	Enabled         bool                   `yaml:"enabled" json:"enabled"`
+	ForwardResponse bool                   `yaml:"forwardResponse" json:"forwardResponse"`
+	Metadata        map[string]interface{} `yaml:"metadata" json:"metadata"`
 }
 
 // Container represents a container inside a pod


### PR DESCRIPTION
Currently API calls that forward events expect the forward to return a response and error, those values are used to return the API. For example if a forward fails the API call also fails.

This new configuration enable the schedulers to choose if they want to receive forwarders response (and also errors).

In order to not break the current behaviour this flag is set to `true` keeping the current behaviour.