### PR TITLE
Disable panic scale by default

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1145,7 +1145,10 @@ func SetRoomStatus(
 ) error {
 	log := logger.WithFields(logrus.Fields{
 		"operation": "SetRoomStatus",
+		"status":    roomPayload.Status,
 	})
+
+	log.Debug("Updating room status")
 
 	cachedScheduler, err := schedulerCache.LoadScheduler(db, room.SchedulerName, true)
 	if err != nil {
@@ -1158,7 +1161,7 @@ func SetRoomStatus(
 		return err
 	}
 
-	if roomPayload.Status != models.StatusOccupied {
+	if roomPayload.Status != models.StatusOccupied || !cachedScheduler.ConfigYAML.AutoScaling.EnablePanicScale {
 		return nil
 	}
 

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -61,6 +61,11 @@ It is the period to wait before running another scaling if it is needed. Cooldow
 ## Min and Max
 These are hard caps for the total number of rooms (ready, occupied and creating) that can exist simultaneously. If Max is set to 0, it means that the scheduler can scale up indefinitely.
 
+## Panic Scale
+A **panic scale** happens when a new room is set to occupied and the percentage of occupied rooms is above the limit so it triggers a scale up.
+
+This behaviour is deprecated and disabled by default but can be enabled with `enablePanicScale` flag.
+
 ## Requests
 Containers resources requests. It is required to define these values in order to use resource triggers(cpu and memory)
 

--- a/models/config_yaml.go
+++ b/models/config_yaml.go
@@ -154,8 +154,9 @@ func (c *ConfigYAML) EnsureDefaultValues() {
 
 	if c.AutoScaling == nil {
 		c.AutoScaling = &AutoScaling{
-			Up:   defaultScalingPolicy,
-			Down: defaultScalingPolicy,
+			Up:               defaultScalingPolicy,
+			Down:             defaultScalingPolicy,
+			EnablePanicScale: false,
 		}
 	}
 

--- a/models/scheduler.go
+++ b/models/scheduler.go
@@ -109,10 +109,11 @@ type ScalingPolicy struct {
 
 // AutoScaling has the configuration for the GRU's auto scaling
 type AutoScaling struct {
-	Min  int            `yaml:"min" json:"min" valid:"int64"`
-	Max  int            `yaml:"max" json:"max" valid:"int64"`
-	Up   *ScalingPolicy `yaml:"up" json:"up" valid:"int64"`
-	Down *ScalingPolicy `yaml:"down" json:"down" valid:"int64"`
+	Min              int            `yaml:"min" json:"min" valid:"int64"`
+	Max              int            `yaml:"max" json:"max" valid:"int64"`
+	Up               *ScalingPolicy `yaml:"up" json:"up" valid:"int64"`
+	Down             *ScalingPolicy `yaml:"down" json:"down" valid:"int64"`
+	EnablePanicScale bool           `yaml:"enablePanicScale" json:"enablePanicScale" valid:"bool"`
 }
 
 // Forwarder has the configuration for the event forwarders


### PR DESCRIPTION
After some incidents we could see that panic scales is not helping most of the time and sometimes it's actually making things worse so this PR puts this behaviour behind a flag that will be disabled by default but can be enabled if someone really wants it. 