### PR TITLE
Use kubernetes informer instead of watcher

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -253,6 +253,17 @@
   revision = "8e809c8a86450a29b90dcc9efbf062d0fe6d9746"
 
 [[projects]]
+  digest = "1:e9ba8bd7f740264f703a41911c9523fb06aaf439dd899cedb263aadddc4be90e"
+  name = "github.com/hashicorp/golang-lru"
+  packages = [
+    ".",
+    "simplelru",
+  ]
+  pruneopts = ""
+  revision = "14eae340515388ca95aa8e7b86f0de668e981f54"
+  version = "v0.5.4"
+
+[[projects]]
   branch = "master"
   digest = "1:b9dff0da7554921f421d84db1feb4b52153174c3d142382b6b058e201b017162"
   name = "github.com/hashicorp/hcl"
@@ -419,6 +430,7 @@
   packages = [
     ".",
     "format",
+    "ghttp",
     "internal/assertion",
     "internal/asyncassertion",
     "internal/oraclematcher",
@@ -870,6 +882,7 @@
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",
+    "pkg/apis/meta/internalversion",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
     "pkg/apis/meta/v1beta1",
@@ -887,7 +900,9 @@
     "pkg/runtime/serializer/versioning",
     "pkg/selection",
     "pkg/types",
+    "pkg/util/cache",
     "pkg/util/clock",
+    "pkg/util/diff",
     "pkg/util/errors",
     "pkg/util/framer",
     "pkg/util/intstr",
@@ -900,6 +915,7 @@
     "pkg/util/strategicpatch",
     "pkg/util/validation",
     "pkg/util/validation/field",
+    "pkg/util/wait",
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
@@ -916,6 +932,8 @@
   packages = [
     "discovery",
     "discovery/fake",
+    "informers/core/v1",
+    "informers/internalinterfaces",
     "kubernetes",
     "kubernetes/fake",
     "kubernetes/scheme",
@@ -983,6 +1001,7 @@
     "kubernetes/typed/storage/v1alpha1/fake",
     "kubernetes/typed/storage/v1beta1",
     "kubernetes/typed/storage/v1beta1/fake",
+    "listers/core/v1",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
     "pkg/apis/clientauthentication/v1beta1",
@@ -992,18 +1011,23 @@
     "rest/watch",
     "testing",
     "tools/auth",
+    "tools/cache",
     "tools/clientcmd",
     "tools/clientcmd/api",
     "tools/clientcmd/api/latest",
     "tools/clientcmd/api/v1",
     "tools/metrics",
+    "tools/pager",
     "tools/reference",
     "transport",
+    "util/buffer",
     "util/cert",
     "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
+    "util/retry",
+    "util/workqueue",
   ]
   pruneopts = ""
   revision = "e64494209f554a6723674bd494d69445fb76a1d4"
@@ -1073,6 +1097,7 @@
     "github.com/newrelic/go-agent",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
+    "github.com/onsi/gomega/ghttp",
     "github.com/onsi/gomega/types",
     "github.com/opentracing/opentracing-go",
     "github.com/pmylund/go-cache",
@@ -1112,13 +1137,17 @@
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/util/yaml",
     "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/informers/core/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/util/workqueue",
     "k8s.io/metrics/pkg/apis/metrics/v1beta1",
     "k8s.io/metrics/pkg/client/clientset/versioned",
     "k8s.io/metrics/pkg/client/clientset/versioned/fake",

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -256,7 +256,9 @@ func replacePodWorker(
 
 			logger.Infof("pods remaining to replace: %d", len(pods))
 
-			return nil
+			if len(pods) == 0 {
+				return nil
+			}
 		case <-ctx.Done():
 			return nil
 		}

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -255,6 +255,8 @@ func replacePodWorker(
 			}
 
 			logger.Infof("pods remaining to replace: %d", len(pods))
+
+			return nil
 		case <-ctx.Done():
 			return nil
 		}


### PR DESCRIPTION
Using informers gives us access to many tools in client-go and also takes care of many things that we need to do like worrying about reconnections.