### PR TITLE
Fix RemoveDeadRooms delete metric reason

### DIFF
--- a/controller/utils.go
+++ b/controller/utils.go
@@ -644,7 +644,7 @@ func DeletePodAndRoom(
 	}
 
 	err = roomManager.Delete(logger, mr, clientset, redisClient, configYaml,
-		pod.Name, reportersConstants.ReasonUpdate)
+		pod.Name, reason)
 	if err != nil && !strings.Contains(err.Error(), "not found") {
 		logger.
 			WithField("roomName", pod.Name).

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -300,6 +300,7 @@ func createNewRemoveOldPod(
 
 	canceled, err = DeletePodsAndWait(
 		ctx,
+		reportersConstants.ReasonUpdate,
 		logger,
 		roomManager,
 		mr,
@@ -332,6 +333,7 @@ func createNewRemoveOldPod(
 // DeletePodsAndWait deletes a list of pods
 func DeletePodsAndWait(
 	ctx context.Context,
+	reason string,
 	logger logrus.FieldLogger,
 	roomManager models.RoomManager,
 	mr *models.MixedMetricsReporter,
@@ -344,7 +346,7 @@ func DeletePodsAndWait(
 	for _, pod := range pods {
 		logger.Debugf("deleting pod %s", pod.Name)
 		err = DeletePodAndRoom(logger, roomManager, mr, clientset, redisClient,
-			configYAML, pod.Name, reportersConstants.ReasonUpdate)
+			configYAML, pod.Name, reason)
 		if err != nil && !strings.Contains(err.Error(), "redis") {
 			logger.WithError(err).Errorf("error deleting pod %s", pod.Name)
 			return false, nil

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -743,6 +743,7 @@ func (w *Watcher) RemoveDeadRooms() error {
 		var timeoutErr bool
 		timedout, err := controller.DeletePodsAndWait(
 			ctx,
+			reportersConstants.ReasonPingTimeout,
 			logger,
 			w.RoomManager,
 			w.MetricsReporter,


### PR DESCRIPTION
When RemoveDeadRooms deletes a room it is reported with a reason as "update". Now RemoveDeadRooms will report the reason as "ping_timeout" when it deletes pods.