### PR TITLE
Move pod state count report to different loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.11
+- 1.12.9
 services:
 - docker
 cache:

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -155,7 +155,7 @@ func (w *Watcher) loadConfigurationDefaults() {
 	w.Config.SetDefault("watcher.autoScalingPeriod", 10)
 	w.Config.SetDefault("watcher.roomsStatusesReportPeriod", 10)
 	w.Config.SetDefault("watcher.ensureCorrectRoomsPeriod", 10*time.Minute)
-	w.Config.SetDefault("watcher.podStatesCountPeriod", 10*time.Second)
+	w.Config.SetDefault("watcher.podStatesCountPeriod", 30*time.Second)
 	w.Config.SetDefault("watcher.lockKey", "maestro-lock-key")
 	w.Config.SetDefault("watcher.lockTimeoutMs", 180000)
 	w.Config.SetDefault("watcher.maxScaleUpAmount", 300)


### PR DESCRIPTION
Because the routine to report pod state count is in the same loop as the watcher's main operations (EnsureCorrectRooms/RemoveDeadRooms/AutoScale) it can not be reported for some time while these operations are running and these are the times the metric is needed most.

The routine was moved to another goroutine running alongside the report of GRU's state.