### PR TITLE
Remove ScaleUp from CreateScheduler

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -122,6 +122,17 @@ func CreateScheduler(
 		return err
 	}
 
+	logger.Info("creating ports pool if necessary")
+	_, err = checkPortRange(nil, configYAML, logger, db, redisClient)
+	if err != nil {
+		logger.WithError(err).Error("error checking port range, deleting scheduler")
+		deleteErr := deleteSchedulerHelper(logger, mr, db, redisClient, clientset, scheduler, namespace, timeoutSec)
+		if deleteErr != nil {
+			logger.WithError(err).Error("error deleting scheduler after check port range error")
+		}
+		return err
+	}
+
 	scheduler.State = models.StateInSync
 	scheduler.StateLastChangedAt = time.Now().Unix()
 	scheduler.LastScaleOpAt = time.Now().Unix()


### PR DESCRIPTION
This MR removes the step of scaling up from the step of creating a scheduler. The scale-up step should now happen the first time the watcher runs the auto-scaling process.

Tests that relied on the pods creation made in CreateScheduler had the ScaleUp process replaced by a call to the ScaleScheduler function via ScaleSchedulerHandler.