### PR TITLE
Stop pods creation when they have error

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -392,12 +392,12 @@ func ScaleUp(
 
 	configYAML, _ := models.NewConfigYAML(scheduler.YAML)
 
-	existPendingPods, err := pendingPods(config, redisClient, scheduler.Name, mr)
+	existPendingPods, err := pendingOrFailedPods(config, redisClient, scheduler.Name, mr)
 	if err != nil {
 		return err
 	}
 	if existPendingPods {
-		return errors.New("there are pending pods, check if there are enough CPU and memory to allocate new rooms")
+		return errors.New("there are pending or failed pods")
 	}
 
 	amount, err = SetScalingAmount(

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1594,7 +1594,46 @@ cmd:
 
 			err = controller.ScaleUp(logger, roomManager, mr, mockDb, mockRedisClient, clientset, scheduler, amount, timeoutSec, true, config, true)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("there are pending pods, check if there are enough CPU and memory to allocate new rooms"))
+			Expect(err.Error()).To(Equal("there are pending or failed pods"))
+		})
+
+		It("should return error and not scale up if there are failed pods", func() {
+			amount := 5
+			var configYaml1 models.ConfigYAML
+			err := yaml.Unmarshal([]byte(yaml1), &configYaml1)
+			Expect(err).NotTo(HaveOccurred())
+			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, yaml1)
+
+			pods := make([]string, 0, amount*2)
+			for i := 0; i < amount; i++ {
+				pod := &models.Pod{}
+				pod.Name = fmt.Sprintf("room-%d", i)
+				pod.Status.Phase = v1.PodRunning
+				if i == 0 {
+					pod.Status.ContainerStatuses = []v1.ContainerStatus{
+						{
+							State: v1.ContainerState{
+								Waiting: &v1.ContainerStateWaiting{
+									Reason: "ErrImagePull",
+								},
+							},
+						},
+					}
+				}
+				jsonBytes, err := pod.MarshalToRedis()
+				Expect(err).NotTo(HaveOccurred())
+				pods = append(pods, pod.Name, string(jsonBytes))
+			}
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().
+				HScan(models.GetPodMapRedisKey(configYaml1.Name), uint64(0), "*", gomock.Any()).
+				Return(goredis.NewScanCmdResult(pods, 0, nil))
+			mockPipeline.EXPECT().Exec()
+
+			err = controller.ScaleUp(logger, roomManager, mr, mockDb, mockRedisClient, clientset, scheduler, amount, timeoutSec, true, config, true)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("there are pending or failed pods"))
 		})
 
 		It("should scale up to max if scaling amount is higher than max", func() {
@@ -6862,6 +6901,49 @@ containers:
 			Expect(timeoutErr).ToNot(HaveOccurred())
 			Expect(cancelErr).ToNot(HaveOccurred())
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error when a pod is with error", func() {
+			pods := []*models.Pod{
+				&models.Pod{Name: "room-1"},
+			}
+
+			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, string(configYaml1.ToYAML()))
+
+			mockRedisClient.EXPECT().
+				HGetAll(opManager.GetOperationKey()).
+				Return(goredis.NewStringStringMapResult(map[string]string{
+					"description": models.OpManagerRollingUpdate,
+				}, nil)).AnyTimes()
+
+			mt.MockCreateRoomsAnyTimes(mockRedisClient, mockPipeline, &configYaml1, 1)
+			mt.MockGetPortsFromPoolAnyTimes(&configYaml1, mockRedisClient, mockPortChooser, workerPortRange, portStart, portEnd)
+
+			runningPodJSON := `{"name":"room-1", "status":{"phase":"Pending", "containerStatuses": [{"state": {"waiting": {"reason": "ErrImagePull"}}}]}}`
+			mockRedisClient.EXPECT().
+				HGet(models.GetPodMapRedisKey(configYaml1.Name), gomock.Any()).
+				Return(goredis.NewStringResult(runningPodJSON, nil)).
+				Times(2)
+
+			timeoutErr, cancelErr, err := controller.SegmentAndReplacePods(
+				logger,
+				roomManager,
+				mr,
+				clientset,
+				mockDb,
+				mockRedisClient,
+				time.Now().Add(time.Minute),
+				&configYaml1,
+				pods,
+				scheduler,
+				opManager,
+				10*time.Second,
+				10,
+				1,
+			)
+			Expect(timeoutErr).ToNot(HaveOccurred())
+			Expect(cancelErr).ToNot(HaveOccurred())
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/models/constants.go
+++ b/models/constants.go
@@ -124,6 +124,8 @@ var InvalidPodWaitingStates = []string{
 	"ErrImagePullBackOff",
 	"ImagePullBackOff",
 	"ErrInvalidImageName",
+	"ErrImagePull",
+	"CrashLoopBackOff",
 }
 
 // OperationManager description constants


### PR DESCRIPTION
Context: During a scale or update, Maestro starts to create pods that never become ready because of an error (say image pull back off). It would be trying to keep the operation until the timeout happens.

This PR adds a check every time Maestro is waiting for a pod to become `ready`. If it identifies that the pod has an error, it aborts the operation. The `EnsureCorrectRooms` flow will eventually remove those pods with errors.

**Note:** Even with the operation being aborted, nothing prevents it to start again and be in this cycle of creating a pod with error -> abort -> start a new operation. This will be addressed in a future change.