### PR TITLE
EnsureCorrectRooms replace only invalid versions

### DIFF
--- a/api/scheduler_handler_test.go
+++ b/api/scheduler_handler_test.go
@@ -1018,7 +1018,7 @@ autoscaling:
 						Return(goredis.NewStringResult(workerPortRange, nil)).
 						AnyTimes()
 
-					MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+					MockGetCurrentOperationKey(opManager, mockRedisClient, "", nil)
 					MockOperationManagerStart(opManager, timeoutDur, mockRedisClient, mockPipeline)
 
 					mockRedisClient.EXPECT().HGetAll(gomock.Any()).Return(
@@ -1128,7 +1128,7 @@ autoscaling:
 					Expect(err).NotTo(HaveOccurred())
 
 					opManager = models.NewOperationManager(configYaml.Name, mockRedisClient, logger)
-					MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+					MockGetCurrentOperationKey(opManager, mockRedisClient, "", nil)
 
 					mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
 					mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(func(_ string, m map[string]interface{}) {
@@ -2771,7 +2771,7 @@ game: game-name
 					Return(goredis.NewStringResult(workerPortRange, nil)).
 					AnyTimes()
 
-				MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+				MockGetCurrentOperationKey(opManager, mockRedisClient, "", nil)
 				MockOperationManagerStart(opManager, timeoutDur, mockRedisClient, mockPipeline)
 
 				mockRedisClient.EXPECT().HGetAll(gomock.Any()).Return(
@@ -2881,7 +2881,7 @@ game: game-name
 				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient).AnyTimes()
 				opManager = models.NewOperationManager(configYaml.Name, mockRedisClient, logger)
 
-				MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+				MockGetCurrentOperationKey(opManager, mockRedisClient, "", nil)
 				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
 				mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(func(_ string, m map[string]interface{}) {
 					Expect(m).To(HaveKeyWithValue("operation", "UpdateSchedulerImage"))
@@ -3297,7 +3297,7 @@ game: game-name
 			It("should update min asynchronously", func() {
 				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient).AnyTimes()
 				opManager = models.NewOperationManager(configYaml1.Name, mockRedisClient, logger)
-				MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+				MockGetCurrentOperationKey(opManager, mockRedisClient, "", nil)
 
 				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
 				mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(func(_ string, m map[string]interface{}) {
@@ -3380,7 +3380,7 @@ game: game-name
 			It("should update min asynchronously and show error when occurred", func() {
 				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient).AnyTimes()
 				opManager = models.NewOperationManager(configYaml1.Name, mockRedisClient, logger)
-				MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+				MockGetCurrentOperationKey(opManager, mockRedisClient, "", nil)
 
 				mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
 				mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(func(_ string, m map[string]interface{}) {

--- a/api/scheduler_operation_handler_test.go
+++ b/api/scheduler_operation_handler_test.go
@@ -136,7 +136,7 @@ var _ = Describe("SchedulerOperationHandler", func() {
 				gomock.Any(), mockRedisClient,
 			).Return(mockRedisClient)
 			var err error
-			MockGetCurrentOperationKey(opManager, mockRedisClient, err)
+			MockGetCurrentOperationKey(opManager, mockRedisClient, "", err)
 			status := map[string]string{
 				"operating": "false",
 			}

--- a/api/scheduler_rollback_handler_test.go
+++ b/api/scheduler_rollback_handler_test.go
@@ -182,7 +182,7 @@ autoscaling:
 			scheduler1 := models.NewScheduler(configYaml.Name, configYaml.Game, yamlStringToRollbackTo)
 
 			opManager = models.NewOperationManager(configYaml.Name, mockRedisClient, logger)
-			MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+			MockGetCurrentOperationKey(opManager, mockRedisClient, "", nil)
 
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
 			mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(func(_ string, m map[string]interface{}) {
@@ -262,7 +262,7 @@ autoscaling:
 			yaml.Unmarshal([]byte(yamlStringToRollbackTo), &configYaml)
 
 			opManager = models.NewOperationManager(configYaml.Name, mockRedisClient, logger)
-			MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+			MockGetCurrentOperationKey(opManager, mockRedisClient, "", nil)
 
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
 			mockPipeline.EXPECT().HMSet(gomock.Any(), gomock.Any()).Do(func(_ string, m map[string]interface{}) {

--- a/testing/common.go
+++ b/testing/common.go
@@ -928,8 +928,21 @@ func MockGetCurrentOperationKey(
 ) {
 	mockRedisClient.EXPECT().
 		Get(opManager.BuildCurrOpKey()).
-		Return(goredis.NewStringResult("", err))
+		Return(goredis.NewStringResult(opManager.GetOperationKey(), err))
 }
+
+func MockGetCurrentOperation(
+	opManager *models.OperationManager,
+	mockRedisClient *redismocks.MockRedisClient,
+	description string,
+) {
+	mockRedisClient.EXPECT().HGetAll(gomock.Any()).Return(
+		goredis.NewStringStringMapResult(map[string]string{
+			"description": description,
+		}, nil),
+	).AnyTimes()
+}
+
 
 // MockSetDescription mocks the set description call
 func MockSetDescription(

--- a/testing/common.go
+++ b/testing/common.go
@@ -893,7 +893,7 @@ func MockOperationManager(
 	mockRedisClient *redismocks.MockRedisClient,
 	mockPipeline *redismocks.MockPipeliner,
 ) {
-	MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+	MockGetCurrentOperationKey(opManager, mockRedisClient, "", nil)
 	MockOperationManagerStart(opManager, timeout, mockRedisClient, mockPipeline)
 
 	mockRedisClient.EXPECT().HGetAll(gomock.Any()).Return(
@@ -924,11 +924,12 @@ func MockDeleteRedisKey(
 func MockGetCurrentOperationKey(
 	opManager *models.OperationManager,
 	mockRedisClient *redismocks.MockRedisClient,
+	opKey string,
 	err error,
 ) {
 	mockRedisClient.EXPECT().
 		Get(opManager.BuildCurrOpKey()).
-		Return(goredis.NewStringResult(opManager.GetOperationKey(), err))
+		Return(goredis.NewStringResult(opKey, err))
 }
 
 func MockGetCurrentOperation(

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -1230,7 +1230,7 @@ func (w *Watcher) EnsureCorrectRooms() error {
 		return err
 	}
 
-	if len(incorrectPods) <= 0 {
+	if len(incorrectPods) == 0 {
 		// delete invalidRooms key for safety
 		models.RemoveInvalidRoomsKey(w.RedisClient.Trace(ctx), w.MetricsReporter, w.SchedulerName)
 		logger.Debug("no invalid pods to replace")

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -4365,7 +4365,7 @@ var _ = Describe("Watcher", func() {
 			testing.MockSelectScheduler(yaml1, mockDb, nil)
 
 			opManager := models.NewOperationManager(configYaml.Name, mockRedisClient, logger)
-			testing.MockGetCurrentOperationKey(opManager, mockRedisClient, nil)
+			testing.MockGetCurrentOperationKey(opManager, mockRedisClient, opManager.GetOperationKey(), nil)
 			testing.MockGetCurrentOperation(opManager, mockRedisClient, models.OpManagerRollingUpdate)
 
 			// Create room


### PR DESCRIPTION
This PR changes how the `EnsureCorrectRooms` (process inside the Watcher). The previous behavior was: list pods that are not sending status information and pods with incorrect versions.

This PR removes that part of replacing pods that are not sending status, and now it will only replace pods with invalid versions. The invalid pods will be removed by the RemoveDeadRooms process and "replaced" by the AutoScale process.