### PR TITLE
Common Kubernetes interface

### DIFF
--- a/internal/entities/game_room_container.go
+++ b/internal/entities/game_room_container.go
@@ -1,0 +1,29 @@
+package entities
+
+type GameRoomContainer struct {
+	Name            string
+	Image           string
+	ImagePullPolicy string
+	Command         []string
+	Environment     []GameRoomContainerEnvironment
+	Requests        GameRoomContainerResources
+	Limits          GameRoomContainerResources
+	Ports           []GameRoomContainerPort
+}
+
+type GameRoomContainerEnvironment struct {
+	Name  string
+	Value string
+}
+
+type GameRoomContainerResources struct {
+	Memory string
+	CPU    string
+}
+
+type GameRoomContainerPort struct {
+	Name     string
+	Protocol string
+	Port     int
+	HostPort int
+}

--- a/internal/entities/game_room_spec.go
+++ b/internal/entities/game_room_spec.go
@@ -1,0 +1,14 @@
+package entities
+
+import "time"
+
+type GameRoomSpec struct {
+	Version                string
+	TerminationGracePeriod time.Duration
+	Containers             []GameRoomContainer
+
+	// NOTE: consider moving it to a kubernetes-specific option?
+	Toleration string
+	// NOTE: consider moving it to a kubernetes-specific option?
+	Affinity string
+}

--- a/internal/services/runtime/errors.go
+++ b/internal/services/runtime/errors.go
@@ -1,0 +1,12 @@
+package runtime
+
+import "errors"
+
+var (
+	ErrSchedulerAlreadyExists  = errors.New("scheduler already exists")
+	ErrSchedulerNotFound       = errors.New("scheduler not found")
+	ErrGameRoomConversionError = errors.New("failed to convert game room to runtime")
+	ErrGameRoomNotFound        = errors.New("game room not found")
+	ErrInvalidGameRoomSpec     = errors.New("game room specification is invalid")
+	ErrUnknown                 = errors.New("unknown error from runtime")
+)

--- a/internal/services/runtime/errors.go
+++ b/internal/services/runtime/errors.go
@@ -1,12 +1,96 @@
 package runtime
 
-import "errors"
+import (
+	"fmt"
+)
+
+type errorKind int
+
+const (
+	schedulerAlreadyExists errorKind = iota
+	schedulerNotFound
+	gameRoomConversion
+	gameRoomNotFound
+	invalidGameRoomSpec
+	unknown
+)
 
 var (
-	ErrSchedulerAlreadyExists  = errors.New("scheduler already exists")
-	ErrSchedulerNotFound       = errors.New("scheduler not found")
-	ErrGameRoomConversionError = errors.New("failed to convert game room to runtime")
-	ErrGameRoomNotFound        = errors.New("game room not found")
-	ErrInvalidGameRoomSpec     = errors.New("game room specification is invalid")
-	ErrUnknown                 = errors.New("unknown error from runtime")
+	ErrSchedulerAlreadyExists = &runtimeError{kind: schedulerAlreadyExists}
+	ErrSchedulerNotFound      = &runtimeError{kind: schedulerNotFound}
+	ErrGameRoomConversion     = &runtimeError{kind: gameRoomConversion}
+	ErrGameRoomNotFound       = &runtimeError{kind: gameRoomNotFound}
+	ErrInvalidGameRoomSpec    = &runtimeError{kind: invalidGameRoomSpec}
+	ErrUnknown                = &runtimeError{kind: unknown}
 )
+
+type runtimeError struct {
+	kind    errorKind
+	message string
+	err     error
+}
+
+func (re *runtimeError) Unwrap() error {
+	return re.err
+}
+
+func (re *runtimeError) Error() string {
+	if re.err == nil {
+		return re.message
+	}
+
+	return fmt.Sprintf("%s: %s", re.message, re.err)
+}
+
+func (re *runtimeError) Is(other error) bool {
+	if err, ok := other.(*runtimeError); ok {
+		return re.kind == err.kind
+	}
+
+	return false
+}
+
+func NewErrSchedulerAlreadyExists(schedulerID string) *runtimeError {
+	return &runtimeError{
+		kind:    schedulerAlreadyExists,
+		message: fmt.Sprintf("scheduler '%s' already exists", schedulerID),
+	}
+}
+
+func NewErrSchedulerNotFound(schedulerID string) *runtimeError {
+	return &runtimeError{
+		kind:    schedulerNotFound,
+		message: fmt.Sprintf("scheduler '%s' not found", schedulerID),
+	}
+}
+
+func NewErrGameRoomConversion(err error) *runtimeError {
+	return &runtimeError{
+		kind:    gameRoomConversion,
+		err:     err,
+		message: "room could not be converted to runtime",
+	}
+}
+
+func NewErrGameRoomNotFound(roomID string) *runtimeError {
+	return &runtimeError{
+		kind:    gameRoomNotFound,
+		message: fmt.Sprintf("room '%s' not found", roomID),
+	}
+}
+
+func NewErrInvalidGameRoomSpec(roomID string, err error) *runtimeError {
+	return &runtimeError{
+		kind:    invalidGameRoomSpec,
+		err:     err,
+		message: fmt.Sprintf("room '%s' has an invalid spec", roomID),
+	}
+}
+
+func NewErrUnknown(err error) *runtimeError {
+	return &runtimeError{
+		kind:    unknown,
+		err:     err,
+		message: "unknown error from runtime",
+	}
+}

--- a/internal/services/runtime/kubernetes/game_room.go
+++ b/internal/services/runtime/kubernetes/game_room.go
@@ -1,0 +1,43 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/topfreegames/maestro/internal/entities"
+	"github.com/topfreegames/maestro/internal/services/runtime"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (k *kubernetes) CreateGameRoom(ctx context.Context, gameRoom *entities.GameRoom, gameRoomSpec entities.GameRoomSpec) error {
+	pod, err := convertGameRoomSpec(gameRoom.Scheduler, gameRoomSpec)
+	if err != nil {
+		return fmt.Errorf("%w: %s", runtime.ErrGameRoomConversionError, err)
+	}
+
+	pod, err = k.clientset.CoreV1().Pods(gameRoom.Scheduler.ID).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsInvalid(err) {
+			return fmt.Errorf("%w: %s", runtime.ErrInvalidGameRoomSpec, err)
+		}
+
+		return fmt.Errorf("%w: %s", runtime.ErrUnknown, err)
+	}
+
+	gameRoom.ID = pod.ObjectMeta.Name
+	return nil
+}
+
+func (k *kubernetes) DeleteGameRoom(ctx context.Context, gameRoom *entities.GameRoom) error {
+	err := k.clientset.CoreV1().Pods(gameRoom.Scheduler.ID).Delete(ctx, gameRoom.ID, metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return runtime.ErrGameRoomNotFound
+		}
+
+		return fmt.Errorf("%w: %s", runtime.ErrUnknown, err)
+	}
+
+	return nil
+}

--- a/internal/services/runtime/kubernetes/game_room.go
+++ b/internal/services/runtime/kubernetes/game_room.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/topfreegames/maestro/internal/entities"
 	"github.com/topfreegames/maestro/internal/services/runtime"
@@ -13,16 +12,16 @@ import (
 func (k *kubernetes) CreateGameRoom(ctx context.Context, gameRoom *entities.GameRoom, gameRoomSpec entities.GameRoomSpec) error {
 	pod, err := convertGameRoomSpec(gameRoom.Scheduler, gameRoomSpec)
 	if err != nil {
-		return fmt.Errorf("%w: %s", runtime.ErrGameRoomConversionError, err)
+		return runtime.NewErrGameRoomConversion(err)
 	}
 
 	pod, err = k.clientset.CoreV1().Pods(gameRoom.Scheduler.ID).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsInvalid(err) {
-			return fmt.Errorf("%w: %s", runtime.ErrInvalidGameRoomSpec, err)
+			return runtime.NewErrInvalidGameRoomSpec(gameRoom.ID, err)
 		}
 
-		return fmt.Errorf("%w: %s", runtime.ErrUnknown, err)
+		return runtime.NewErrUnknown(err)
 	}
 
 	gameRoom.ID = pod.ObjectMeta.Name
@@ -33,10 +32,10 @@ func (k *kubernetes) DeleteGameRoom(ctx context.Context, gameRoom *entities.Game
 	err := k.clientset.CoreV1().Pods(gameRoom.Scheduler.ID).Delete(ctx, gameRoom.ID, metav1.DeleteOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return runtime.ErrGameRoomNotFound
+			return runtime.NewErrGameRoomNotFound(gameRoom.ID)
 		}
 
-		return fmt.Errorf("%w: %s", runtime.ErrUnknown, err)
+		return runtime.NewErrUnknown(err)
 	}
 
 	return nil

--- a/internal/services/runtime/kubernetes/game_room_convert.go
+++ b/internal/services/runtime/kubernetes/game_room_convert.go
@@ -1,0 +1,195 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/topfreegames/maestro/internal/entities"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// Toleration constants
+	tolerationKey      = "dedicated"
+	tolerationOperator = v1.TolerationOpEqual
+	tolerationEffect   = v1.TaintEffectNoSchedule
+
+	// Affinity constants
+	affinityOperator = v1.NodeSelectorOpIn
+	affinityValue    = "true"
+
+	// Pod labels
+	maestroLabelKey   = "heritage"
+	maestroLabelValue = "maestro"
+	schedulerLabelKey = "maestro-scheduler"
+	versionLabelKey   = "version"
+)
+
+func convertGameRoomSpec(scheduler entities.Scheduler, gameRoomSpec entities.GameRoomSpec) (*v1.Pod, error) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", scheduler.ID),
+			Namespace:    scheduler.ID,
+			Labels: map[string]string{
+				maestroLabelKey:   maestroLabelValue,
+				schedulerLabelKey: scheduler.ID,
+				versionLabelKey:   gameRoomSpec.Version,
+			},
+		},
+		Spec: v1.PodSpec{
+			TerminationGracePeriodSeconds: convertTerminationGracePeriod(gameRoomSpec),
+			Containers:                    []v1.Container{},
+			Tolerations:                   convertSpecTolerations(gameRoomSpec),
+			Affinity:                      convertSpecAffinity(gameRoomSpec),
+		},
+	}
+
+	for _, container := range gameRoomSpec.Containers {
+		podContainer, err := convertContainer(container)
+		if err != nil {
+			return nil, fmt.Errorf("error with container \"%s\": %w", container.Name, err)
+		}
+
+		pod.Spec.Containers = append(pod.Spec.Containers, podContainer)
+	}
+
+	return pod, nil
+}
+
+func convertContainer(container entities.GameRoomContainer) (v1.Container, error) {
+	podContainer := v1.Container{
+		Name:    container.Name,
+		Image:   container.Image,
+		Command: container.Command,
+		Ports:   []v1.ContainerPort{},
+		Env:     []v1.EnvVar{},
+	}
+
+	for _, port := range container.Ports {
+		containerPort, err := convertContainerPort(port)
+		if err != nil {
+			return v1.Container{}, fmt.Errorf("error with port \"%s\": %w", port.Name, err)
+		}
+
+		podContainer.Ports = append(podContainer.Ports, containerPort)
+	}
+
+	for _, env := range container.Environment {
+		podContainer.Env = append(podContainer.Env, convertContainerEnvironment(env))
+	}
+
+	requestsResources, err := convertContainerResources(container.Requests)
+	if err != nil {
+		return v1.Container{}, fmt.Errorf("error with requests: %w", err)
+	}
+
+	limitsResources, err := convertContainerResources(container.Limits)
+	if err != nil {
+		return v1.Container{}, fmt.Errorf("error with limits: %w", err)
+	}
+
+	podContainer.Resources = v1.ResourceRequirements{
+		Requests: requestsResources,
+		Limits:   limitsResources,
+	}
+
+	return podContainer, nil
+}
+
+func convertContainerPort(port entities.GameRoomContainerPort) (v1.ContainerPort, error) {
+	var kubePortProtocol v1.Protocol
+	switch protocol := strings.ToLower(port.Protocol); protocol {
+	case "tcp":
+		kubePortProtocol = v1.ProtocolTCP
+		break
+	case "udp":
+		kubePortProtocol = v1.ProtocolUDP
+		break
+	default:
+		return v1.ContainerPort{}, fmt.Errorf("invalid port protocol \"%s\"", protocol)
+	}
+
+	return v1.ContainerPort{
+		Name:          port.Name,
+		Protocol:      kubePortProtocol,
+		ContainerPort: int32(port.Port),
+		HostPort:      int32(port.HostPort),
+	}, nil
+}
+
+func convertContainerResources(resources entities.GameRoomContainerResources) (v1.ResourceList, error) {
+	resourceList := v1.ResourceList{}
+
+	if resources.CPU != "" {
+		cpuQuantity, err := resource.ParseQuantity(resources.CPU)
+		if err != nil {
+			return v1.ResourceList{}, fmt.Errorf("failed to parse resource \"cpu\" = \"%s\"", resources.CPU)
+		}
+
+		resourceList[v1.ResourceCPU] = cpuQuantity
+	}
+
+	if resources.Memory != "" {
+		cpuQuantity, err := resource.ParseQuantity(resources.Memory)
+		if err != nil {
+			return v1.ResourceList{}, fmt.Errorf("failed to parse resource \"memory\" = \"%s\"", resources.Memory)
+		}
+
+		resourceList[v1.ResourceMemory] = cpuQuantity
+	}
+
+	return resourceList, nil
+}
+
+func convertContainerEnvironment(env entities.GameRoomContainerEnvironment) v1.EnvVar {
+	return v1.EnvVar{
+		Name:  env.Name,
+		Value: env.Value,
+	}
+}
+
+func convertSpecTolerations(spec entities.GameRoomSpec) []v1.Toleration {
+	if spec.Toleration == "" {
+		return []v1.Toleration{}
+	}
+
+	return []v1.Toleration{
+		{Key: tolerationKey, Operator: tolerationOperator, Effect: tolerationEffect, Value: spec.Toleration},
+	}
+}
+
+func convertSpecAffinity(spec entities.GameRoomSpec) *v1.Affinity {
+	if spec.Affinity == "" {
+		return nil
+	}
+
+	return &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					v1.NodeSelectorTerm{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      spec.Affinity,
+								Operator: affinityOperator,
+								Values:   []string{affinityValue},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func convertTerminationGracePeriod(spec entities.GameRoomSpec) *int64 {
+	seconds := int64(spec.TerminationGracePeriod.Seconds())
+	if seconds == int64(0) {
+		return nil
+	}
+
+	return &seconds
+}

--- a/internal/services/runtime/kubernetes/game_room_convert_test.go
+++ b/internal/services/runtime/kubernetes/game_room_convert_test.go
@@ -1,0 +1,486 @@
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro/internal/entities"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// small helper used to return a pointer to a int64
+func int64Pointer(n int64) *int64 {
+	return &n
+}
+
+func TestConvertContainerResources(t *testing.T) {
+	cases := map[string]struct {
+		containerResources entities.GameRoomContainerResources
+		expectedKubernetes v1.ResourceList
+		withError          bool
+	}{
+		"only with memory": {
+			containerResources: entities.GameRoomContainerResources{
+				Memory: "100Mi",
+			},
+			expectedKubernetes: v1.ResourceList{
+				v1.ResourceMemory: *resource.NewQuantity(100*1024*1024, resource.BinarySI),
+			},
+		},
+		"only with CPU": {
+			containerResources: entities.GameRoomContainerResources{
+				CPU: "100m",
+			},
+			expectedKubernetes: v1.ResourceList{
+				v1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI),
+			},
+		},
+		"with memory and CPU": {
+			containerResources: entities.GameRoomContainerResources{
+				Memory: "100Mi",
+				CPU:    "100m",
+			},
+			expectedKubernetes: v1.ResourceList{
+				v1.ResourceMemory: *resource.NewQuantity(100*1024*1024, resource.BinarySI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+			},
+		},
+		"with invalid memory": {
+			containerResources: entities.GameRoomContainerResources{
+				Memory: "100abc",
+			},
+			withError: true,
+		},
+		"with invalid CPU": {
+			containerResources: entities.GameRoomContainerResources{
+				CPU: "100abc",
+			},
+			withError: true,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			res, err := convertContainerResources(test.containerResources)
+			if test.withError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(t, res[v1.ResourceMemory].Equal(test.expectedKubernetes[v1.ResourceMemory]))
+			require.True(t, res[v1.ResourceCPU].Equal(test.expectedKubernetes[v1.ResourceCPU]))
+		})
+	}
+}
+
+func TestConvertContainerPort(t *testing.T) {
+	cases := map[string]struct {
+		containerPort      entities.GameRoomContainerPort
+		expectedKubernetes v1.ContainerPort
+		withError          bool
+	}{
+		"tcp port": {
+			containerPort: entities.GameRoomContainerPort{
+				Name:     "testtcp",
+				Protocol: "tcp",
+				Port:     5555,
+			},
+			expectedKubernetes: v1.ContainerPort{
+				Name:          "testtcp",
+				Protocol:      v1.ProtocolTCP,
+				ContainerPort: 5555,
+			},
+		},
+		"udp port": {
+			containerPort: entities.GameRoomContainerPort{
+				Name:     "testudp",
+				Protocol: "udp",
+				Port:     5555,
+				HostPort: 25555,
+			},
+			expectedKubernetes: v1.ContainerPort{
+				Name:          "testudp",
+				Protocol:      v1.ProtocolUDP,
+				ContainerPort: 5555,
+				HostPort:      25555,
+			},
+		},
+		"invalid protocol port": {
+			containerPort: entities.GameRoomContainerPort{
+				Name:     "testsctp",
+				Protocol: "sctp",
+				Port:     5555,
+				HostPort: 25555,
+			},
+			withError: true,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			res, err := convertContainerPort(test.containerPort)
+			if test.withError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.expectedKubernetes.Name, res.Name)
+			require.Equal(t, test.expectedKubernetes.Protocol, res.Protocol)
+			require.Equal(t, test.expectedKubernetes.ContainerPort, res.ContainerPort)
+			require.Equal(t, test.expectedKubernetes.HostPort, res.HostPort)
+		})
+	}
+}
+
+func TestConvertContainerEnvironment(t *testing.T) {
+	cases := map[string]struct {
+		containerEnvironment entities.GameRoomContainerEnvironment
+		expectedKubernetes   v1.EnvVar
+	}{
+		"name value environment": {
+			containerEnvironment: entities.GameRoomContainerEnvironment{
+				Name:  "SAMPLE",
+				Value: "value",
+			},
+			expectedKubernetes: v1.EnvVar{
+				Name:  "SAMPLE",
+				Value: "value",
+			},
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := convertContainerEnvironment(test.containerEnvironment)
+			require.Equal(t, test.expectedKubernetes.Name, res.Name)
+			require.Equal(t, test.expectedKubernetes.Value, res.Value)
+		})
+	}
+}
+
+func TestConvertSpecTolerations(t *testing.T) {
+	cases := map[string]struct {
+		spec               entities.GameRoomSpec
+		expectedKubernetes v1.Toleration
+		empty              bool
+	}{
+		"with toleration": {
+			spec: entities.GameRoomSpec{Toleration: "maestro-sample"},
+			expectedKubernetes: v1.Toleration{
+				Key:      tolerationKey,
+				Operator: tolerationOperator,
+				Effect:   tolerationEffect,
+				Value:    "maestro-sample",
+			},
+		},
+		"with no tolerations": {
+			spec:  entities.GameRoomSpec{},
+			empty: true,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := convertSpecTolerations(test.spec)
+			if test.empty {
+				require.Empty(t, res)
+				return
+			}
+
+			require.Len(t, res, 1)
+			require.Equal(t, test.expectedKubernetes.Key, res[0].Key)
+			require.Equal(t, test.expectedKubernetes.Operator, res[0].Operator)
+			require.Equal(t, test.expectedKubernetes.Effect, res[0].Effect)
+			require.Equal(t, test.expectedKubernetes.Value, res[0].Value)
+		})
+	}
+}
+
+func TestConvertSpecAffinity(t *testing.T) {
+	cases := map[string]struct {
+		spec             entities.GameRoomSpec
+		expectedSelector v1.NodeSelectorRequirement
+		empty            bool
+	}{
+		"with affinity": {
+			spec: entities.GameRoomSpec{Affinity: "maestro-sample"},
+			expectedSelector: v1.NodeSelectorRequirement{
+				Key:      "maestro-sample",
+				Operator: affinityOperator,
+				Values:   []string{affinityValue},
+			},
+		},
+		"with no affinity": {
+			spec:  entities.GameRoomSpec{},
+			empty: true,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := convertSpecAffinity(test.spec)
+			if test.empty {
+				require.Empty(t, res)
+				return
+			}
+
+			require.NotNil(t, res)
+			require.Equal(t, test.expectedSelector.Key, res.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Key)
+			require.Equal(t, test.expectedSelector.Operator, res.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Operator)
+			require.Equal(t, test.expectedSelector.Values, res.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Values)
+		})
+	}
+}
+
+func TestConvertTerminationGracePeriod(t *testing.T) {
+	cases := map[string]struct {
+		spec                  entities.GameRoomSpec
+		expectedPeriodSeconds int64
+		empty                 bool
+	}{
+		"with duration": {
+			spec:                  entities.GameRoomSpec{TerminationGracePeriod: 10 * time.Second},
+			expectedPeriodSeconds: 10,
+		},
+		"with 0 duration": {
+			spec:  entities.GameRoomSpec{TerminationGracePeriod: 0},
+			empty: true,
+		},
+		"without duration": {
+			spec:  entities.GameRoomSpec{},
+			empty: true,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := convertTerminationGracePeriod(test.spec)
+			if test.empty {
+				require.Nil(t, res)
+				return
+			}
+
+			require.NotNil(t, res)
+			require.Equal(t, test.expectedPeriodSeconds, *res)
+		})
+	}
+}
+
+func TestConvertContainer(t *testing.T) {
+	cases := map[string]struct {
+		container         entities.GameRoomContainer
+		expectedContainer v1.Container
+		withError         bool
+	}{
+		"with empty container": {
+			container:         entities.GameRoomContainer{},
+			expectedContainer: v1.Container{},
+		},
+		"with simple container": {
+			container:         entities.GameRoomContainer{Name: "simple", Image: "image"},
+			expectedContainer: v1.Container{Name: "simple", Image: "image"},
+		},
+		"with options container": {
+			container: entities.GameRoomContainer{
+				Name:        "complete",
+				Image:       "image",
+				Command:     []string{"some", "command"},
+				Environment: []entities.GameRoomContainerEnvironment{{Name: "env", Value: "value"}},
+				Ports:       []entities.GameRoomContainerPort{{Port: 2222, Protocol: "tcp"}},
+			},
+			expectedContainer: v1.Container{
+				Name:    "complete",
+				Image:   "image",
+				Command: []string{"some", "command"},
+				Env:     []v1.EnvVar{{Name: "env", Value: "value"}},
+				Ports:   []v1.ContainerPort{{ContainerPort: 2222, Protocol: "tcp"}},
+			},
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			res, err := convertContainer(test.container)
+			if test.withError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.expectedContainer.Name, res.Name)
+			require.Equal(t, test.expectedContainer.Image, res.Image)
+			require.Equal(t, test.expectedContainer.Image, res.Image)
+			require.ElementsMatch(t, test.expectedContainer.Command, res.Command)
+			require.Equal(t, len(test.expectedContainer.Ports), len(res.Ports))
+			require.Equal(t, len(test.expectedContainer.Env), len(res.Env))
+		})
+	}
+}
+
+func TestConvertGameSpec(t *testing.T) {
+	cases := map[string]struct {
+		gameRoom    *entities.GameRoom
+		gameSpec    entities.GameRoomSpec
+		expectedPod v1.Pod
+		withError   bool
+	}{
+		"without containers": {
+			gameRoom: &entities.GameRoom{
+				Scheduler: entities.Scheduler{
+					ID: "sample",
+				},
+			},
+			gameSpec: entities.GameRoomSpec{
+				Version: "version",
+			},
+			expectedPod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "sample",
+					Labels: map[string]string{
+						maestroLabelKey:   maestroLabelValue,
+						schedulerLabelKey: "sample",
+						versionLabelKey:   "version",
+					},
+				},
+			},
+		},
+		"with containers": {
+			gameRoom: &entities.GameRoom{
+				Scheduler: entities.Scheduler{
+					ID: "sample",
+				},
+			},
+			gameSpec: entities.GameRoomSpec{
+				Version: "version",
+				Containers: []entities.GameRoomContainer{
+					entities.GameRoomContainer{},
+					entities.GameRoomContainer{},
+				},
+			},
+			expectedPod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "sample",
+					Labels: map[string]string{
+						maestroLabelKey:   maestroLabelValue,
+						schedulerLabelKey: "sample",
+						versionLabelKey:   "version",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						v1.Container{},
+						v1.Container{},
+					},
+				},
+			},
+		},
+		"with toleration": {
+			gameRoom: &entities.GameRoom{
+				Scheduler: entities.Scheduler{
+					ID: "sample",
+				},
+			},
+			gameSpec: entities.GameRoomSpec{
+				Version:    "version",
+				Toleration: "some-toleration",
+			},
+			expectedPod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "sample",
+					Labels: map[string]string{
+						maestroLabelKey:   maestroLabelValue,
+						schedulerLabelKey: "sample",
+						versionLabelKey:   "version",
+					},
+				},
+				Spec: v1.PodSpec{
+					Tolerations: []v1.Toleration{
+						v1.Toleration{},
+					},
+				},
+			},
+		},
+		"with affinity": {
+			gameRoom: &entities.GameRoom{
+				Scheduler: entities.Scheduler{
+					ID: "sample",
+				},
+			},
+			gameSpec: entities.GameRoomSpec{
+				Version:  "version",
+				Affinity: "sample-affinity",
+			},
+			expectedPod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "sample",
+					Labels: map[string]string{
+						maestroLabelKey:   maestroLabelValue,
+						schedulerLabelKey: "sample",
+						versionLabelKey:   "version",
+					},
+				},
+				Spec: v1.PodSpec{
+					Affinity: &v1.Affinity{},
+				},
+			},
+		},
+		"with termination grace period": {
+			gameRoom: &entities.GameRoom{
+				Scheduler: entities.Scheduler{
+					ID: "sample",
+				},
+			},
+			gameSpec: entities.GameRoomSpec{
+				Version:                "version",
+				TerminationGracePeriod: 10 * time.Second,
+			},
+			expectedPod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "sample",
+					Labels: map[string]string{
+						maestroLabelKey:   maestroLabelValue,
+						schedulerLabelKey: "sample",
+						versionLabelKey:   "version",
+					},
+				},
+				Spec: v1.PodSpec{
+					TerminationGracePeriodSeconds: int64Pointer(10),
+				},
+			},
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			res, err := convertGameRoomSpec(test.gameRoom.Scheduler, test.gameSpec)
+			if test.withError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.expectedPod.ObjectMeta.Labels, res.ObjectMeta.Labels)
+			require.Equal(t, test.expectedPod.ObjectMeta.Namespace, res.ObjectMeta.Namespace)
+			require.Equal(t, len(test.expectedPod.Spec.Containers), len(res.Spec.Containers))
+			require.Equal(t, len(test.expectedPod.Spec.Tolerations), len(res.Spec.Tolerations))
+
+			if test.expectedPod.Spec.Affinity != nil {
+				require.NotNil(t, res.Spec.Affinity)
+			} else {
+				require.Nil(t, res.Spec.Affinity)
+			}
+
+			if test.expectedPod.Spec.TerminationGracePeriodSeconds != nil {
+				require.NotNil(t, res.Spec.TerminationGracePeriodSeconds)
+				require.Equal(t, test.expectedPod.Spec.TerminationGracePeriodSeconds, res.Spec.TerminationGracePeriodSeconds)
+			} else {
+				require.Nil(t, res.Spec.TerminationGracePeriodSeconds)
+			}
+		})
+	}
+}

--- a/internal/services/runtime/kubernetes/game_room_convert_test.go
+++ b/internal/services/runtime/kubernetes/game_room_convert_test.go
@@ -1,3 +1,5 @@
+//+build !integration
+
 package kubernetes
 
 import (

--- a/internal/services/runtime/kubernetes/game_room_test.go
+++ b/internal/services/runtime/kubernetes/game_room_test.go
@@ -1,0 +1,155 @@
+//+build integration
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/orlangure/gnomock"
+	"github.com/orlangure/gnomock/preset/k3s"
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro/internal/entities"
+	"github.com/topfreegames/maestro/internal/services/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube "k8s.io/client-go/kubernetes"
+)
+
+func TestGameRoomCreation(t *testing.T) {
+	c, err := gnomock.Start(
+		k3s.Preset(k3s.WithVersion("v1.16.15")),
+	)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, gnomock.Stop(c))
+	}()
+
+	kubeconfig, err := k3s.Config(c)
+	require.NoError(t, err)
+
+	client, err := kube.NewForConfig(kubeconfig)
+	require.NoError(t, err)
+
+	kubernetesRuntime := New(client)
+	ctx := context.Background()
+
+	t.Run("successfully create a room", func(t *testing.T) {
+		// first, create the scheduler
+		scheduler := &entities.Scheduler{ID: "game-room-test"}
+		err := kubernetesRuntime.CreateScheduler(ctx, scheduler)
+		require.NoError(t, err)
+
+		gameRoom := &entities.GameRoom{Scheduler: *scheduler}
+		gameRoomSpec := entities.GameRoomSpec{
+			Containers: []entities.GameRoomContainer{
+				{
+					Name:  "nginx",
+					Image: "nginx:stable-alpine",
+				},
+			},
+		}
+		err = kubernetesRuntime.CreateGameRoom(ctx, gameRoom, gameRoomSpec)
+		require.NoError(t, err)
+
+		pods, err := client.CoreV1().Pods(scheduler.ID).List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, pods.Items, 1)
+		require.Len(t, pods.Items[0].Spec.Containers, 1)
+		require.Equal(t, gameRoomSpec.Containers[0].Name, pods.Items[0].Spec.Containers[0].Name)
+		require.Equal(t, gameRoomSpec.Containers[0].Image, pods.Items[0].Spec.Containers[0].Image)
+	})
+
+	t.Run("fail with wrong game room spec", func(t *testing.T) {
+		// first, create the scheduler
+		scheduler := &entities.Scheduler{ID: "game-room-invalid-spec"}
+		err := kubernetesRuntime.CreateScheduler(ctx, scheduler)
+		require.NoError(t, err)
+
+		gameRoom := &entities.GameRoom{Scheduler: *scheduler}
+		// no containers, meaning it will fail (bacause it can be a pod
+		// without containers).
+		gameRoomSpec := entities.GameRoomSpec{}
+		err = kubernetesRuntime.CreateGameRoom(ctx, gameRoom, gameRoomSpec)
+		require.Error(t, err)
+		require.ErrorIs(t, err, runtime.ErrInvalidGameRoomSpec)
+
+		pods, err := client.CoreV1().Pods(scheduler.ID).List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, pods.Items, 0)
+	})
+}
+
+func TestGameRoomDeletion(t *testing.T) {
+	c, err := gnomock.Start(
+		k3s.Preset(k3s.WithVersion("v1.16.15")),
+	)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, gnomock.Stop(c))
+	}()
+
+	kubeconfig, err := k3s.Config(c)
+	require.NoError(t, err)
+
+	client, err := kube.NewForConfig(kubeconfig)
+	require.NoError(t, err)
+
+	kubernetesRuntime := New(client)
+	ctx := context.Background()
+
+	t.Run("successfully delete a room", func(t *testing.T) {
+		// first, create the scheduler
+		scheduler := &entities.Scheduler{ID: "game-room-delete-test"}
+		err := kubernetesRuntime.CreateScheduler(ctx, scheduler)
+		require.NoError(t, err)
+
+		gameRoom := &entities.GameRoom{Scheduler: *scheduler}
+		gameRoomSpec := entities.GameRoomSpec{
+			Containers: []entities.GameRoomContainer{
+				{
+					Name:  "nginx",
+					Image: "nginx:stable-alpine",
+				},
+			},
+		}
+		err = kubernetesRuntime.CreateGameRoom(ctx, gameRoom, gameRoomSpec)
+		require.NoError(t, err)
+
+		pods, err := client.CoreV1().Pods(scheduler.ID).List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, pods.Items, 1)
+
+		err = kubernetesRuntime.DeleteGameRoom(ctx, gameRoom)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			pods, err := client.CoreV1().Pods(scheduler.ID).List(ctx, metav1.ListOptions{})
+			require.NoError(t, err)
+			if len(pods.Items) == 0 {
+				return true
+			}
+
+			return false
+		}, 30*time.Second, time.Second)
+	})
+
+	t.Run("fail to delete inexistent game room", func(t *testing.T) {
+		// first, create the scheduler
+		scheduler := &entities.Scheduler{ID: "game-room-inexistent-delete"}
+		err := kubernetesRuntime.CreateScheduler(ctx, scheduler)
+		require.NoError(t, err)
+
+		gameRoom := &entities.GameRoom{
+			// force a name, so that the delete can run.
+			ID:        "game-room-inexistent-room-id",
+			Scheduler: *scheduler,
+		}
+
+		err = kubernetesRuntime.DeleteGameRoom(ctx, gameRoom)
+		require.Error(t, err)
+		require.ErrorIs(t, err, runtime.ErrGameRoomNotFound)
+	})
+}

--- a/internal/services/runtime/kubernetes/kubernetes.go
+++ b/internal/services/runtime/kubernetes/kubernetes.go
@@ -1,0 +1,16 @@
+package kubernetes
+
+import (
+	"github.com/topfreegames/maestro/internal/services/runtime"
+	kube "k8s.io/client-go/kubernetes"
+)
+
+var _ runtime.Runtime = (*kubernetes)(nil)
+
+type kubernetes struct {
+	clientset kube.Interface
+}
+
+func New(clientset kube.Interface) *kubernetes {
+	return &kubernetes{clientset}
+}

--- a/internal/services/runtime/kubernetes/scheduler.go
+++ b/internal/services/runtime/kubernetes/scheduler.go
@@ -1,0 +1,45 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/topfreegames/maestro/internal/entities"
+	"github.com/topfreegames/maestro/internal/services/runtime"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (k *kubernetes) CreateScheduler(ctx context.Context, scheduler *entities.Scheduler) error {
+	namespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: scheduler.ID,
+		},
+	}
+
+	_, err := k.clientset.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			return runtime.ErrSchedulerAlreadyExists
+		}
+
+		return fmt.Errorf("%w: %s", runtime.ErrUnknown, err)
+	}
+
+	return nil
+}
+
+func (k *kubernetes) DeleteScheduler(ctx context.Context, scheduler *entities.Scheduler) error {
+	err := k.clientset.CoreV1().Namespaces().Delete(ctx, scheduler.ID, metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return runtime.ErrSchedulerNotFound
+		}
+
+		return fmt.Errorf("%w: %s", runtime.ErrUnknown, err)
+	}
+
+	return nil
+}

--- a/internal/services/runtime/kubernetes/scheduler.go
+++ b/internal/services/runtime/kubernetes/scheduler.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/topfreegames/maestro/internal/entities"
 	"github.com/topfreegames/maestro/internal/services/runtime"
@@ -22,10 +21,10 @@ func (k *kubernetes) CreateScheduler(ctx context.Context, scheduler *entities.Sc
 	_, err := k.clientset.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			return runtime.ErrSchedulerAlreadyExists
+			return runtime.NewErrSchedulerAlreadyExists(scheduler.ID)
 		}
 
-		return fmt.Errorf("%w: %s", runtime.ErrUnknown, err)
+		return runtime.NewErrUnknown(err)
 	}
 
 	return nil
@@ -35,10 +34,10 @@ func (k *kubernetes) DeleteScheduler(ctx context.Context, scheduler *entities.Sc
 	err := k.clientset.CoreV1().Namespaces().Delete(ctx, scheduler.ID, metav1.DeleteOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return runtime.ErrSchedulerNotFound
+			return runtime.NewErrSchedulerNotFound(scheduler.ID)
 		}
 
-		return fmt.Errorf("%w: %s", runtime.ErrUnknown, err)
+		return runtime.NewErrUnknown(err)
 	}
 
 	return nil

--- a/internal/services/runtime/kubernetes/scheduler_test.go
+++ b/internal/services/runtime/kubernetes/scheduler_test.go
@@ -1,0 +1,95 @@
+//+build integration
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube "k8s.io/client-go/kubernetes"
+
+	"github.com/orlangure/gnomock"
+	"github.com/orlangure/gnomock/preset/k3s"
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro/internal/entities"
+	"github.com/topfreegames/maestro/internal/services/runtime"
+)
+
+func TestSchedulerCreation(t *testing.T) {
+	c, err := gnomock.Start(
+		k3s.Preset(k3s.WithVersion("v1.16.15")),
+	)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, gnomock.Stop(c))
+	}()
+
+	kubeconfig, err := k3s.Config(c)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	client, err := kube.NewForConfig(kubeconfig)
+	require.NoError(t, err)
+
+	kubernetesRuntime := New(client)
+	t.Run("create single scheduler", func(t *testing.T) {
+		scheduler := &entities.Scheduler{ID: "single-scheduler-test"}
+		err = kubernetesRuntime.CreateScheduler(ctx, scheduler)
+		require.NoError(t, err)
+
+		_, err := client.CoreV1().Namespaces().Get(ctx, scheduler.ID, metav1.GetOptions{})
+		require.NoError(t, err)
+	})
+
+	t.Run("fail to create scheduler with the same name", func(t *testing.T) {
+		scheduler := &entities.Scheduler{ID: "conflict-scheduler-test"}
+		err = kubernetesRuntime.CreateScheduler(ctx, scheduler)
+		require.NoError(t, err)
+
+		err = kubernetesRuntime.CreateScheduler(ctx, scheduler)
+		require.Error(t, err)
+		require.ErrorIs(t, err, runtime.ErrSchedulerAlreadyExists)
+	})
+}
+
+func TestSchedulerDeletion(t *testing.T) {
+	c, err := gnomock.Start(
+		k3s.Preset(k3s.WithVersion("v1.16.15")),
+	)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, gnomock.Stop(c))
+	}()
+
+	kubeconfig, err := k3s.Config(c)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	client, err := kube.NewForConfig(kubeconfig)
+	require.NoError(t, err)
+
+	kubernetesRuntime := New(client)
+	t.Run("delete scheduler", func(t *testing.T) {
+		scheduler := &entities.Scheduler{ID: "scheduler-test"}
+		err = kubernetesRuntime.CreateScheduler(ctx, scheduler)
+		require.NoError(t, err)
+
+		err = kubernetesRuntime.DeleteScheduler(ctx, scheduler)
+		require.NoError(t, err)
+
+		ns, err := client.CoreV1().Namespaces().Get(ctx, scheduler.ID, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, v1.NamespaceTerminating, ns.Status.Phase)
+	})
+
+	t.Run("fail to delete inexistent scheduler", func(t *testing.T) {
+		scheduler := &entities.Scheduler{ID: "conflict-scheduler-test"}
+		err = kubernetesRuntime.DeleteScheduler(ctx, scheduler)
+		require.Error(t, err)
+		require.ErrorIs(t, err, runtime.ErrSchedulerNotFound)
+	})
+}

--- a/internal/services/runtime/runtime.go
+++ b/internal/services/runtime/runtime.go
@@ -1,0 +1,21 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/topfreegames/maestro/internal/entities"
+)
+
+// Runtime defines an interface implemented by the services that manages
+// containers (game rooms).
+type Runtime interface {
+	// CreateScheduler Creates a scheduler on the runtime.
+	CreateScheduler(ctx context.Context, scheduler *entities.Scheduler) error
+	// CreateScheduler Deletes a scheduler on the runtime.
+	DeleteScheduler(ctx context.Context, scheduler *entities.Scheduler) error
+	// CreateGameRoom Creates a game room on the runtime using the specification
+	// inside the GameRoom.
+	CreateGameRoom(ctx context.Context, gameRoom *entities.GameRoom, spec entities.GameRoomSpec) error
+	// DeleteGameRoom Deletes a game room on the runtime.
+	DeleteGameRoom(ctx context.Context, gameRoom *entities.GameRoom) error
+}


### PR DESCRIPTION
### Motivation

We want to unify all the interactions that Maestro does with Kubernetes into a single package. In this way, we can create easier mocks and make the rest of the codebase less coupled to Kubernetes.

### Solution

We're bringing a new concept called Runtime. The Runtime is the place where the container will be running. Right now, we're adding Kubernetes as the default Runtime, but in the future, we might want to add more runtimes (for example, a Docker runtime to make it easier to run Maestro locally).