### PR TITLE
Room manager wait room status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
 	golang.org/x/text v0.3.5
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.sum
+++ b/go.sum
@@ -650,6 +650,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -3,6 +3,7 @@ package room_manager
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
@@ -10,11 +11,13 @@ import (
 )
 
 type RoomManager struct {
-	clock           ports.Clock
-	portAllocator   ports.PortAllocator
-	roomStorage     ports.RoomStorage
-	instanceStorage ports.GameRoomInstanceStorage
-	runtime         ports.Runtime
+	clock                  ports.Clock
+	portAllocator          ports.PortAllocator
+	roomStorage            ports.RoomStorage
+	instanceStorage        ports.GameRoomInstanceStorage
+	runtime                ports.Runtime
+	roomStatusWatchers     []chan *game_room.GameRoom
+	roomStatusWatchersLock sync.Mutex
 }
 
 func NewRoomManager(clock ports.Clock, portAllocator ports.PortAllocator, roomStorage ports.RoomStorage, instanceStorage ports.GameRoomInstanceStorage, runtime ports.Runtime) *RoomManager {

--- a/internal/core/services/room_manager/status.go
+++ b/internal/core/services/room_manager/status.go
@@ -7,6 +7,8 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 )
 
+const maxRoomStatusEvents = 100
+
 // validStatusTransitions this map has all possible status changes for a game
 // room.
 var validStatusTransitions = map[game_room.GameRoomStatus]map[game_room.GameRoomStatus]struct{}{
@@ -58,5 +60,86 @@ func (m *RoomManager) SetRoomStatus(ctx context.Context, gameRoom *game_room.Gam
 		return fmt.Errorf("failed to update game room status on storage: %w", err)
 	}
 
+	gameRoom.Status = status
+
+	m.roomStatusWatchersLock.Lock()
+	defer m.roomStatusWatchersLock.Unlock()
+	for _, watcher := range m.roomStatusWatchers {
+		// NOTE: this select is necessary to avoid a dead lock caused by a
+		// watcher being canceled and not able to acquire lock to remove itself
+		// from the watchers list while this function (with lock acquired) is
+		// blocked waiting for the watcher to consume it.
+		select {
+		case watcher <- gameRoom:
+		// TODO(gabrielcorado): add logs for the dafault case (where we're
+		// losing events).
+		default:
+		}
+	}
+
 	return nil
+}
+
+// WaitRoomStatus blocks the caller until the context is canceled, an error
+// happens in the process or the game room has the desired status.
+// TODO(gabrielcorado): we might need to find a more "elegant" implementation.
+func (m *RoomManager) WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status game_room.GameRoomStatus) error {
+	var err error
+	watcher := make(chan *game_room.GameRoom, maxRoomStatusEvents)
+	m.addRoomStatusWatcher(watcher)
+
+	fromStorage, err := m.roomStorage.GetRoom(ctx, gameRoom.SchedulerID, gameRoom.ID)
+	if err != nil {
+		m.removeRoomStatusWatcher(watcher)
+		close(watcher)
+
+		return fmt.Errorf("error while retrieving current game room status: %w", err)
+	}
+
+	// the room has the desired state already
+	if fromStorage.Status == status {
+		return nil
+	}
+
+watchLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+			break watchLoop
+		case updatedGameRoom := <-watcher:
+			if updatedGameRoom.ID == gameRoom.ID && updatedGameRoom.Status == status {
+				break watchLoop
+			}
+		}
+	}
+
+	m.removeRoomStatusWatcher(watcher)
+	close(watcher)
+
+	if err != nil {
+		return fmt.Errorf("failed to wait until room has desired status: %w", err)
+	}
+
+	return nil
+}
+
+func (m *RoomManager) addRoomStatusWatcher(watcher chan *game_room.GameRoom) {
+	m.roomStatusWatchersLock.Lock()
+	defer m.roomStatusWatchersLock.Unlock()
+
+	m.roomStatusWatchers = append(m.roomStatusWatchers, watcher)
+}
+
+func (m *RoomManager) removeRoomStatusWatcher(watcher chan *game_room.GameRoom) {
+	m.roomStatusWatchersLock.Lock()
+	defer m.roomStatusWatchersLock.Unlock()
+
+	for watcherIndex, listWatcher := range m.roomStatusWatchers {
+		if listWatcher == watcher {
+			m.roomStatusWatchers[len(m.roomStatusWatchers)-1], m.roomStatusWatchers[watcherIndex] = m.roomStatusWatchers[watcherIndex], m.roomStatusWatchers[len(m.roomStatusWatchers)-1]
+			m.roomStatusWatchers = m.roomStatusWatchers[:len(m.roomStatusWatchers)-1]
+			return
+		}
+	}
 }

--- a/internal/core/services/room_manager/status_test.go
+++ b/internal/core/services/room_manager/status_test.go
@@ -16,6 +16,7 @@ import (
 	rsmock "github.com/topfreegames/maestro/internal/adapters/room_storage/mock"
 	runtimemock "github.com/topfreegames/maestro/internal/adapters/runtime/mock"
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestRoomManager_SetRoomStatus_SuccessTransitions(t *testing.T) {
@@ -79,4 +80,135 @@ func TestRoomManager_SetRoomStatus_StorageFailure(t *testing.T) {
 	roomStorage.EXPECT().SetRoomStatus(context.Background(), gameRoom.SchedulerID, gameRoom.ID, transition).Return(fmt.Errorf("something bad happened"))
 	err := roomManager.SetRoomStatus(context.Background(), gameRoom, transition)
 	require.Error(t, err)
+}
+
+func TestRoomManager_WaitGameRoomStatus(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	roomStorage := rsmock.NewMockRoomStorage(mockCtrl)
+	roomManager := NewRoomManager(
+		clockmock.NewFakeClock(time.Now()),
+		pamock.NewMockPortAllocator(mockCtrl),
+		roomStorage,
+		ismock.NewMockGameRoomInstanceStorage(mockCtrl),
+		runtimemock.NewMockRuntime(mockCtrl),
+	)
+
+	transition := game_room.GameStatusReady
+	gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusPending}
+
+	var group errgroup.Group
+	waitCalled := make(chan struct{})
+	group.Go(func() error {
+		waitCalled <- struct{}{}
+		roomStorage.EXPECT().GetRoom(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(gameRoom, nil)
+		return roomManager.WaitRoomStatus(context.Background(), gameRoom, transition)
+	})
+
+	<-waitCalled
+
+	roomStorage.EXPECT().SetRoomStatus(context.Background(), gameRoom.SchedulerID, gameRoom.ID, transition).Return(nil)
+	err := roomManager.SetRoomStatus(context.Background(), gameRoom, transition)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		err := group.Wait()
+		require.NoError(t, err)
+		return err == nil
+	}, 2*time.Second, time.Second)
+
+	roomStorage.EXPECT().SetRoomStatus(context.Background(), gameRoom.SchedulerID, gameRoom.ID, game_room.GameStatusOccupied).Return(nil)
+	err = roomManager.SetRoomStatus(context.Background(), gameRoom, game_room.GameStatusOccupied)
+	require.NoError(t, err)
+}
+
+func TestRoomManager_WaitGameRoomStatus_Deadline(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	roomStorage := rsmock.NewMockRoomStorage(mockCtrl)
+	roomManager := NewRoomManager(
+		clockmock.NewFakeClock(time.Now()),
+		pamock.NewMockPortAllocator(mockCtrl),
+		roomStorage,
+		ismock.NewMockGameRoomInstanceStorage(mockCtrl),
+		runtimemock.NewMockRuntime(mockCtrl),
+	)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Millisecond))
+	gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusReady}
+
+	var group errgroup.Group
+	waitCalled := make(chan struct{})
+	group.Go(func() error {
+		waitCalled <- struct{}{}
+		defer cancel()
+
+		roomStorage.EXPECT().GetRoom(ctx, gameRoom.SchedulerID, gameRoom.ID).Return(gameRoom, nil)
+		return roomManager.WaitRoomStatus(ctx, gameRoom, game_room.GameStatusOccupied)
+	})
+
+	<-waitCalled
+	require.Eventually(t, func() bool {
+		err := group.Wait()
+		require.Error(t, err)
+		return err != nil
+	}, 2*time.Second, time.Second)
+
+	roomStorage.EXPECT().SetRoomStatus(context.Background(), gameRoom.SchedulerID, gameRoom.ID, game_room.GameStatusOccupied).Return(nil)
+	err := roomManager.SetRoomStatus(context.Background(), gameRoom, game_room.GameStatusOccupied)
+	require.NoError(t, err)
+}
+
+// In this test we're going to guarantee that we can be left with a case where
+// we do have an dead lock.
+func TestRoomManager_WaitGameRoomStatus_PreventDeadlock(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	roomStorage := rsmock.NewMockRoomStorage(mockCtrl)
+	roomManager := NewRoomManager(
+		clockmock.NewFakeClock(time.Now()),
+		pamock.NewMockPortAllocator(mockCtrl),
+		roomStorage,
+		ismock.NewMockGameRoomInstanceStorage(mockCtrl),
+		runtimemock.NewMockRuntime(mockCtrl),
+	)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Millisecond))
+	gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusPending}
+
+	// we're going to make multiple set status to populate our buffer channel
+	// with messages. from ready -> occupied -> ready
+	roomStorage.EXPECT().GetRoom(ctx, gameRoom.SchedulerID, gameRoom.ID).DoAndReturn(func(_ context.Context, _ string, _ string) (*game_room.GameRoom, error) {
+		roomStorage.EXPECT().SetRoomStatus(context.Background(), gameRoom.SchedulerID, gameRoom.ID, game_room.GameStatusReady).Return(nil)
+		err := roomManager.SetRoomStatus(context.Background(), gameRoom, game_room.GameStatusReady)
+		require.NoError(t, err)
+
+		roomStorage.EXPECT().SetRoomStatus(context.Background(), gameRoom.SchedulerID, gameRoom.ID, game_room.GameStatusOccupied).Return(nil)
+		err = roomManager.SetRoomStatus(context.Background(), gameRoom, game_room.GameStatusOccupied)
+		require.NoError(t, err)
+
+		return gameRoom, nil
+	})
+
+	var group errgroup.Group
+	waitCalled := make(chan struct{})
+	group.Go(func() error {
+		waitCalled <- struct{}{}
+		defer cancel()
+		return roomManager.WaitRoomStatus(ctx, gameRoom, game_room.GameStatusTerminating)
+	})
+
+	<-waitCalled
+	require.Eventually(t, func() bool {
+		err := group.Wait()
+		require.Error(t, err)
+		return err != nil
+	}, 2*time.Second, time.Second)
+
+	roomStorage.EXPECT().SetRoomStatus(context.Background(), gameRoom.SchedulerID, gameRoom.ID, game_room.GameStatusTerminating).Return(nil)
+	err := roomManager.SetRoomStatus(context.Background(), gameRoom, game_room.GameStatusTerminating)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Some operations need to wait for the room to be in a specific state when creating. For example, when updating a room, the operation needs to wait until they become ready to update the remaining rooms.

The implementation consists of having a channel for each wait call, and whenever a SetRoomStatus happens, those channels receive a message and check if it is for their room and if the status is the desired. The solution might not be the most elegant one, but we're sticking with it, and we're going to take a look in more depth later.