### PR TITLE
Operation manager get operation

### DIFF
--- a/internal/adapters/operation_storage/mock/mock.go
+++ b/internal/adapters/operation_storage/mock/mock.go
@@ -36,15 +36,31 @@ func (m *MockOperationStorage) EXPECT() *MockOperationStorageMockRecorder {
 }
 
 // CreateOperation mocks base method.
-func (m *MockOperationStorage) CreateOperation(ctx context.Context, operation *operation.Operation) error {
+func (m *MockOperationStorage) CreateOperation(ctx context.Context, operation *operation.Operation, definitionContent []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOperation", ctx, operation)
+	ret := m.ctrl.Call(m, "CreateOperation", ctx, operation, definitionContent)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateOperation indicates an expected call of CreateOperation.
-func (mr *MockOperationStorageMockRecorder) CreateOperation(ctx, operation interface{}) *gomock.Call {
+func (mr *MockOperationStorageMockRecorder) CreateOperation(ctx, operation, definitionContent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOperation", reflect.TypeOf((*MockOperationStorage)(nil).CreateOperation), ctx, operation)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOperation", reflect.TypeOf((*MockOperationStorage)(nil).CreateOperation), ctx, operation, definitionContent)
+}
+
+// GetOperation mocks base method.
+func (m *MockOperationStorage) GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, []byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOperation", ctx, schedulerName, operationID)
+	ret0, _ := ret[0].(*operation.Operation)
+	ret1, _ := ret[1].([]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOperation indicates an expected call of GetOperation.
+func (mr *MockOperationStorageMockRecorder) GetOperation(ctx, schedulerName, operationID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperation", reflect.TypeOf((*MockOperationStorage)(nil).GetOperation), ctx, schedulerName, operationID)
 }

--- a/internal/core/entities/operation/operation.go
+++ b/internal/core/entities/operation/operation.go
@@ -18,8 +18,8 @@ const (
 )
 
 type Operation struct {
-	ID            string
-	Status        Status
-	Definition    Definition
-	SchedulerName string
+	ID             string
+	Status         Status
+	DefinitionName string
+	SchedulerName  string
 }

--- a/internal/core/ports/operation_storage.go
+++ b/internal/core/ports/operation_storage.go
@@ -7,5 +7,7 @@ import (
 )
 
 type OperationStorage interface {
-	CreateOperation(ctx context.Context, operation *operation.Operation) error
+	CreateOperation(ctx context.Context, operation *operation.Operation, definitionContent []byte) error
+	// GetOperation returns the operation and the definition contents.
+	GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, []byte, error)
 }

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -7,27 +7,58 @@ import (
 	"github.com/google/uuid"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/ports"
+	"github.com/topfreegames/maestro/internal/core/services/operations_registry"
 )
 
 type OperationManager struct {
-	storage ports.OperationStorage
+	storage            ports.OperationStorage
+	operationsRegistry operations_registry.Registry
+}
+
+func NewWithRegistry(storage ports.OperationStorage, operationsRegistry operations_registry.Registry) *OperationManager {
+	return &OperationManager{
+		storage:            storage,
+		operationsRegistry: operationsRegistry,
+	}
 }
 
 func New(storage ports.OperationStorage) *OperationManager {
-	return &OperationManager{storage}
+	return &OperationManager{
+		storage:            storage,
+		operationsRegistry: operations_registry.DefaultRegistry,
+	}
 }
 
 func (o *OperationManager) CreateOperation(ctx context.Context, definition operation.Definition) (*operation.Operation, error) {
 	op := &operation.Operation{
-		ID:         uuid.NewString(),
-		Status:     operation.StatusPending,
-		Definition: definition,
+		ID:             uuid.NewString(),
+		Status:         operation.StatusPending,
+		DefinitionName: definition.Name(),
 	}
 
-	err := o.storage.CreateOperation(ctx, op)
+	err := o.storage.CreateOperation(ctx, op, definition.Marshal())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create operation: %w", err)
 	}
 
 	return op, nil
+}
+
+func (o *OperationManager) GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, operation.Definition, error) {
+	op, definitionContents, err := o.storage.GetOperation(ctx, schedulerName, operationID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	definition, err := o.operationsRegistry.Get(op.DefinitionName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get definition: %s", err)
+	}
+
+	err = definition.Unmarshal(definitionContents)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal definition: %s", err)
+	}
+
+	return op, definition, nil
 }

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -2,6 +2,7 @@ package operation_manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -11,12 +12,16 @@ import (
 	opstorage "github.com/topfreegames/maestro/internal/adapters/operation_storage/mock"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
+	"github.com/topfreegames/maestro/internal/core/services/operations_registry"
 )
 
-type testOperationDefinition struct{}
+type testOperationDefinition struct {
+	marshalResult   []byte
+	unmarshalResult error
+}
 
-func (d *testOperationDefinition) Marshal() []byte            { return []byte{} }
-func (d *testOperationDefinition) Unmarshal(raw []byte) error { return nil }
+func (d *testOperationDefinition) Marshal() []byte            { return d.marshalResult }
+func (d *testOperationDefinition) Unmarshal(raw []byte) error { return d.unmarshalResult }
 func (d *testOperationDefinition) Name() string               { return "testOperationDefinition" }
 
 type newOpMatcher struct {
@@ -26,7 +31,7 @@ type newOpMatcher struct {
 func (m *newOpMatcher) Matches(x interface{}) bool {
 	op, _ := x.(*operation.Operation)
 	_, err := uuid.Parse(op.ID)
-	return err == nil && op.Status == operation.StatusPending && m.def.Name() == op.Definition.Name()
+	return err == nil && op.Status == operation.StatusPending && m.def.Name() == op.DefinitionName
 }
 
 func (m *newOpMatcher) String() string {
@@ -39,7 +44,7 @@ func TestCreateOperation(t *testing.T) {
 		storageErr error
 	}{
 		"create without errors": {
-			definition: &testOperationDefinition{},
+			definition: &testOperationDefinition{marshalResult: []byte("test")},
 		},
 		"create with storage errors": {
 			definition: &testOperationDefinition{},
@@ -56,7 +61,8 @@ func TestCreateOperation(t *testing.T) {
 			opManager := New(operationStorage)
 
 			ctx := context.Background()
-			operationStorage.EXPECT().CreateOperation(ctx, &newOpMatcher{test.definition}).Return(test.storageErr)
+			testDefinition, _ := test.definition.(*testOperationDefinition)
+			operationStorage.EXPECT().CreateOperation(ctx, &newOpMatcher{test.definition}, testDefinition.marshalResult).Return(test.storageErr)
 
 			op, err := opManager.CreateOperation(ctx, test.definition)
 			if test.storageErr != nil {
@@ -69,4 +75,103 @@ func TestCreateOperation(t *testing.T) {
 			require.Equal(t, operation.StatusPending, op.Status)
 		})
 	}
+}
+
+func TestGetOperation(t *testing.T) {
+	t.Run("find operation", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		defFunc := func() operation.Definition { return &testOperationDefinition{} }
+		registry := operations_registry.NewRegistry()
+		registry.Register(defFunc().Name(), defFunc)
+
+		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
+		opManager := NewWithRegistry(operationStorage, registry)
+
+		ctx := context.Background()
+		schedulerName := "test-scheduler"
+		operationID := "some-op-id"
+		operationStorage.EXPECT().GetOperation(ctx, schedulerName, operationID).Return(
+			&operation.Operation{ID: operationID, SchedulerName: schedulerName, DefinitionName: defFunc().Name()},
+			[]byte{},
+			nil,
+		)
+
+		op, definition, err := opManager.GetOperation(ctx, schedulerName, operationID)
+		require.NoError(t, err)
+		require.NotNil(t, op)
+		require.Equal(t, operationID, op.ID)
+		require.Equal(t, schedulerName, op.SchedulerName)
+		require.IsType(t, defFunc(), definition)
+	})
+
+	t.Run("defition not found", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		defFunc := func() operation.Definition { return &testOperationDefinition{} }
+		registry := operations_registry.NewRegistry()
+
+		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
+		opManager := NewWithRegistry(operationStorage, registry)
+
+		ctx := context.Background()
+		schedulerName := "test-scheduler"
+		operationID := "some-op-id"
+		operationStorage.EXPECT().GetOperation(ctx, schedulerName, operationID).Return(
+			&operation.Operation{ID: operationID, SchedulerName: schedulerName, DefinitionName: defFunc().Name()},
+			[]byte{},
+			nil,
+		)
+
+		_, _, err := opManager.GetOperation(ctx, schedulerName, operationID)
+		require.Error(t, err)
+	})
+
+	t.Run("operation not found", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		defFunc := func() operation.Definition { return &testOperationDefinition{} }
+		registry := operations_registry.NewRegistry()
+
+		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
+		opManager := NewWithRegistry(operationStorage, registry)
+
+		ctx := context.Background()
+		schedulerName := "test-scheduler"
+		operationID := "some-op-id"
+		operationStorage.EXPECT().GetOperation(ctx, schedulerName, operationID).Return(
+			&operation.Operation{ID: operationID, SchedulerName: schedulerName, DefinitionName: defFunc().Name()},
+			[]byte{},
+			porterrors.ErrNotFound,
+		)
+
+		_, _, err := opManager.GetOperation(ctx, schedulerName, operationID)
+		require.Error(t, err)
+	})
+
+	t.Run("unmarshal error", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		defFunc := func() operation.Definition { return &testOperationDefinition{unmarshalResult: errors.New("invalid")} }
+		registry := operations_registry.NewRegistry()
+
+		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
+		opManager := NewWithRegistry(operationStorage, registry)
+
+		ctx := context.Background()
+		schedulerName := "test-scheduler"
+		operationID := "some-op-id"
+		operationStorage.EXPECT().GetOperation(ctx, schedulerName, operationID).Return(
+			&operation.Operation{ID: operationID, SchedulerName: schedulerName, DefinitionName: defFunc().Name()},
+			[]byte{},
+			porterrors.ErrNotFound,
+		)
+
+		_, _, err := opManager.GetOperation(ctx, schedulerName, operationID)
+		require.Error(t, err)
+	})
 }

--- a/internal/core/services/operations_registry/operations_registry.go
+++ b/internal/core/services/operations_registry/operations_registry.go
@@ -1,0 +1,46 @@
+package operations_registry
+
+import (
+	"fmt"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+)
+
+// OperationDefinitionConstructor defines a function that constructs a new
+// definition.
+type OperationDefinitionConstructor func() operation.Definition
+
+// Registry contains all the operations definitions.
+type Registry map[string]OperationDefinitionConstructor
+
+// NewRegistry initialises a new registry.
+func NewRegistry() Registry {
+	return Registry(map[string]OperationDefinitionConstructor{})
+}
+
+// Register register a new operation definition.
+func (r Registry) Register(name string, constructor OperationDefinitionConstructor) {
+	r[name] = constructor
+}
+
+// Get fetches an operation definition.
+func (r Registry) Get(name string) (operation.Definition, error) {
+	if constructor, ok := r[name]; ok {
+		return constructor(), nil
+	}
+
+	return nil, fmt.Errorf("definition \"%s\" not found", name)
+}
+
+// DefaultRegistry is a shared registry on the package-level.
+var DefaultRegistry Registry = NewRegistry()
+
+// Register register a new definition on the the default registry.
+func Register(name string, constructor OperationDefinitionConstructor) {
+	DefaultRegistry.Register(name, constructor)
+}
+
+// Get fetches a definition on the the default registry.
+func Get(name string) (operation.Definition, error) {
+	return DefaultRegistry.Get(name)
+}

--- a/internal/core/services/operations_registry/operations_registry_test.go
+++ b/internal/core/services/operations_registry/operations_registry_test.go
@@ -1,0 +1,29 @@
+package operations_registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+)
+
+func TestRegistry(t *testing.T) {
+	t.Run("register and get", func(t *testing.T) {
+		registry := NewRegistry()
+
+		var def operation.Definition
+		registry.Register("some", func() operation.Definition { return def })
+
+		defFromRegistry, err := registry.Get("some")
+		require.NoError(t, err)
+		require.Equal(t, def, defFromRegistry)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		registry := NewRegistry()
+
+		defFromRegistry, err := registry.Get("some")
+		require.Error(t, err)
+		require.Nil(t, defFromRegistry)
+	})
+}


### PR DESCRIPTION
Introduces the operations registry, which is used to discover the operations and their definitions. We're also moving the logic of `Marshal/Unmarshal` definitions to the operation manager.