### PR TITLE
Operation Manager start operation

### DIFF
--- a/internal/adapters/operation_storage/mock/mock.go
+++ b/internal/adapters/operation_storage/mock/mock.go
@@ -79,3 +79,17 @@ func (mr *MockOperationStorageMockRecorder) NextSchedulerOperationID(ctx, schedu
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextSchedulerOperationID", reflect.TypeOf((*MockOperationStorage)(nil).NextSchedulerOperationID), ctx, schedulerName)
 }
+
+// SetOperationActive mocks base method.
+func (m *MockOperationStorage) SetOperationActive(ctx context.Context, operation *operation.Operation) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetOperationActive", ctx, operation)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetOperationActive indicates an expected call of SetOperationActive.
+func (mr *MockOperationStorageMockRecorder) SetOperationActive(ctx, operation interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOperationActive", reflect.TypeOf((*MockOperationStorage)(nil).SetOperationActive), ctx, operation)
+}

--- a/internal/core/ports/operation_storage.go
+++ b/internal/core/ports/operation_storage.go
@@ -13,4 +13,6 @@ type OperationStorage interface {
 	// NextSchedulerOperationID fetches the next scheduler operation to be
 	// processed and return its ID.
 	NextSchedulerOperationID(ctx context.Context, schedulerName string) (string, error)
+	// SetActiveOperaiton sets operation as active.
+	SetOperationActive(ctx context.Context, operation *operation.Operation) error
 }

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -72,3 +72,15 @@ func (o *OperationManager) NextSchedulerOperation(ctx context.Context, scheduler
 
 	return o.GetOperation(ctx, schedulerName, operationID)
 }
+
+// StartOperation used when an operation will start executing.
+func (o *OperationManager) StartOperation(ctx context.Context, op *operation.Operation) error {
+	op.Status = operation.StatusInProgress
+
+	err := o.storage.SetOperationActive(ctx, op)
+	if err != nil {
+		return fmt.Errorf("failed to start operation: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This process will be used by the workers to indicate that an operation has started. We're also introducing the `SetOperationActive` on the Operation storage, this will be used to update the operation into the active state.