### PR TITLE
Operation manager finish operation

### DIFF
--- a/internal/adapters/operation_storage/mock/mock.go
+++ b/internal/adapters/operation_storage/mock/mock.go
@@ -80,16 +80,16 @@ func (mr *MockOperationStorageMockRecorder) ListSchedulerActiveOperations(ctx, s
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSchedulerActiveOperations", reflect.TypeOf((*MockOperationStorage)(nil).ListSchedulerActiveOperations), ctx, schedulerName)
 }
 
-// SetOperationActive mocks base method.
-func (m *MockOperationStorage) SetOperationActive(ctx context.Context, operation *operation.Operation) error {
+// UpdateOperationStatus mocks base method.
+func (m *MockOperationStorage) UpdateOperationStatus(ctx context.Context, schedulerName, operationID string, status operation.Status) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetOperationActive", ctx, operation)
+	ret := m.ctrl.Call(m, "UpdateOperationStatus", ctx, schedulerName, operationID, status)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetOperationActive indicates an expected call of SetOperationActive.
-func (mr *MockOperationStorageMockRecorder) SetOperationActive(ctx, operation interface{}) *gomock.Call {
+// UpdateOperationStatus indicates an expected call of UpdateOperationStatus.
+func (mr *MockOperationStorageMockRecorder) UpdateOperationStatus(ctx, schedulerName, operationID, status interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOperationActive", reflect.TypeOf((*MockOperationStorage)(nil).SetOperationActive), ctx, operation)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOperationStatus", reflect.TypeOf((*MockOperationStorage)(nil).UpdateOperationStatus), ctx, schedulerName, operationID, status)
 }

--- a/internal/core/ports/operation_storage.go
+++ b/internal/core/ports/operation_storage.go
@@ -10,8 +10,9 @@ type OperationStorage interface {
 	CreateOperation(ctx context.Context, operation *operation.Operation, definitionContent []byte) error
 	// GetOperation returns the operation and the definition contents.
 	GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, []byte, error)
-	// SetActiveOperaiton sets operation as active.
-	SetOperationActive(ctx context.Context, operation *operation.Operation) error
 	// ListSchedulerActiveOperations list scheduler active operations.
 	ListSchedulerActiveOperations(ctx context.Context, schedulerName string) ([]*operation.Operation, error)
+	// UpdateOperationStatus only updates the operation status for the given
+	// operation ID.
+	UpdateOperationStatus(ctx context.Context, schedulerName, operationID string, status operation.Status) error
 }

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -84,13 +84,12 @@ func (o *OperationManager) NextSchedulerOperation(ctx context.Context, scheduler
 
 // StartOperation used when an operation will start executing.
 func (o *OperationManager) StartOperation(ctx context.Context, op *operation.Operation) error {
-	op.Status = operation.StatusInProgress
-
-	err := o.storage.SetOperationActive(ctx, op)
+	err := o.storage.UpdateOperationStatus(ctx, op.SchedulerName, op.ID, operation.StatusInProgress)
 	if err != nil {
 		return fmt.Errorf("failed to start operation: %w", err)
 	}
 
+	op.Status = operation.StatusInProgress
 	return nil
 }
 
@@ -104,5 +103,10 @@ func (o *OperationManager) ListActiveOperations(ctx context.Context, schedulerNa
 }
 
 func (o *OperationManager) FinishOperation(ctx context.Context, op *operation.Operation) error {
+	err := o.storage.UpdateOperationStatus(ctx, op.SchedulerName, op.ID, op.Status)
+	if err != nil {
+		return fmt.Errorf("failed to finish operation: %w", err)
+	}
+
 	return nil
 }

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -27,7 +27,7 @@ func (d *testOperationDefinition) Name() string               { return "testOper
 
 type opMatcher struct {
 	status operation.Status
-	def operation.Definition
+	def    operation.Definition
 }
 
 func (m *opMatcher) Matches(x interface{}) bool {
@@ -44,7 +44,7 @@ func TestCreateOperation(t *testing.T) {
 	cases := map[string]struct {
 		definition operation.Definition
 		storageErr error
-		flowErr error
+		flowErr    error
 	}{
 		"create without errors": {
 			definition: &testOperationDefinition{marshalResult: []byte("test")},
@@ -55,7 +55,7 @@ func TestCreateOperation(t *testing.T) {
 		},
 		"create with flow errors": {
 			definition: &testOperationDefinition{},
-			flowErr: porterrors.ErrUnexpected,
+			flowErr:    porterrors.ErrUnexpected,
 		},
 	}
 
@@ -281,7 +281,7 @@ func TestNextSchedulerOperation(t *testing.T) {
 }
 
 func TestStartOperation(t *testing.T) {
-	t.Run("sets active", func (t *testing.T) {
+	t.Run("starts operation with succeess", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -292,14 +292,33 @@ func TestStartOperation(t *testing.T) {
 		ctx := context.Background()
 		op := &operation.Operation{ID: uuid.NewString(), DefinitionName: (&testOperationDefinition{}).Name()}
 
-		operationStorage.EXPECT().SetOperationActive(ctx, &opMatcher{operation.StatusInProgress, &testOperationDefinition{}}).Return(nil)
+		operationStorage.EXPECT().UpdateOperationStatus(ctx, op.SchedulerName, op.ID, operation.StatusInProgress).Return(nil)
 		err := opManager.StartOperation(ctx, op)
 		require.NoError(t, err)
 	})
 }
 
+func TestFinishOperation(t *testing.T) {
+	t.Run("finishes operation with success", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
+		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
+		opManager := NewWithRegistry(operationFlow, operationStorage, operations_registry.NewRegistry())
+
+		ctx := context.Background()
+		expectedStatus := operation.StatusError
+		op := &operation.Operation{ID: uuid.NewString(), DefinitionName: (&testOperationDefinition{}).Name(), Status: expectedStatus}
+
+		operationStorage.EXPECT().UpdateOperationStatus(ctx, op.SchedulerName, op.ID, expectedStatus).Return(nil)
+		err := opManager.FinishOperation(ctx, op)
+		require.NoError(t, err)
+	})
+}
+
 func TestListActiveOperations(t *testing.T) {
-	t.Run("lists", func (t *testing.T) {
+	t.Run("lists", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 


### PR DESCRIPTION
This function is responsible for updating the operation status after it finishes.

We're also changing how `StartOperation` works by reusing a new function, `UpdateOperationStatus.`