### PR TITLE
Add dependabot config file

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -1,0 +1,9 @@
+version: 1
+update_configs:
+  - package_manager: "go:modules"
+    directory: "/"
+    update_schedule: "daily"
+    target_branch: "next"
+    default_labels: 
+      - "dependencies"
+      - "dependabot"


### PR DESCRIPTION
This PR aims to add dependabot configuration file with the following data:

```
version: 1
update_configs:
  - package_manager: "go:modules"
    directory: "/"
    update_schedule: "daily"
    target_branch: "next"
    default_labels: 
      - "dependencies"
      - "dependabot"
```