### PR TITLE
Add operation execution worker metrics

### DIFF
--- a/internal/core/monitoring/constants.go
+++ b/internal/core/monitoring/constants.go
@@ -1,0 +1,42 @@
+package monitoring
+
+const (
+	Namespace       = "maestro"
+	SubsystemApi    = "api"
+	SubsystemWorker = "worker"
+)
+
+const (
+	LabelPlatform            = "platform"
+	LabelCompanyID           = "company_id"
+	LabelBundleID            = "bundle_id"
+	LabelProductID           = "product_id"
+	LabelEventType           = "event_type"
+	LabelField               = "field"
+	LabelAnomaly             = "anomaly"
+	LabelTopic               = "topic"
+	LabelPartition           = "partition"
+	LabelSource              = "source"
+	LabelAck                 = "ack"
+	LabelSuccess             = "success"
+	LabelReason              = "reason"
+	LabelErrorText           = "error_text"
+	LabelUnprocessedReceipts = "unprocessed_receipts"
+	LabelLastPhase           = "phase"
+	LabelFallback            = "fallback"
+	LabelServer              = "server"
+	LabelHTTPRoute           = "http_route"
+	LabelStatusCode          = "status_code"
+	LabelScheduler           = "scheduler"
+	LabelOperation           = "operation"
+)
+
+const (
+	IntValueUnknown    = -1
+	StringValueUnknown = "unknown"
+)
+
+// DefBucketsMs is similar to prometheus.DefBuckets, but tailored for milliseconds instead of seconds.
+var DefBucketsMs = []float64{5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000}
+
+var DefaultLatencyObjectives = map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001}

--- a/internal/core/monitoring/constants.go
+++ b/internal/core/monitoring/constants.go
@@ -7,36 +7,9 @@ const (
 )
 
 const (
-	LabelPlatform            = "platform"
-	LabelCompanyID           = "company_id"
-	LabelBundleID            = "bundle_id"
-	LabelProductID           = "product_id"
-	LabelEventType           = "event_type"
-	LabelField               = "field"
-	LabelAnomaly             = "anomaly"
-	LabelTopic               = "topic"
-	LabelPartition           = "partition"
-	LabelSource              = "source"
-	LabelAck                 = "ack"
-	LabelSuccess             = "success"
-	LabelReason              = "reason"
-	LabelErrorText           = "error_text"
-	LabelUnprocessedReceipts = "unprocessed_receipts"
-	LabelLastPhase           = "phase"
-	LabelFallback            = "fallback"
-	LabelServer              = "server"
-	LabelHTTPRoute           = "http_route"
-	LabelStatusCode          = "status_code"
-	LabelScheduler           = "scheduler"
-	LabelOperation           = "operation"
+	LabelPlatform  = "platform"
+	LabelSuccess   = "success"
+	LabelReason    = "reason"
+	LabelScheduler = "scheduler"
+	LabelOperation = "operation"
 )
-
-const (
-	IntValueUnknown    = -1
-	StringValueUnknown = "unknown"
-)
-
-// DefBucketsMs is similar to prometheus.DefBuckets, but tailored for milliseconds instead of seconds.
-var DefBucketsMs = []float64{5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000}
-
-var DefaultLatencyObjectives = map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001}

--- a/internal/core/monitoring/metrics.go
+++ b/internal/core/monitoring/metrics.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // DefBucketsMs is similar to prometheus.DefBuckets, but tailored for milliseconds instead of seconds.
@@ -63,4 +64,13 @@ func ReportLatencyMetricInMillis(metric *prometheus.HistogramVec, start time.Tim
 	metric.
 		WithLabelValues(labels...).
 		Observe(float64(timeElapsed.Nanoseconds() / int64(time.Millisecond)))
+}
+
+func FilterMetric(metrics []*dto.MetricFamily, metricName string) *dto.MetricFamily {
+	for _, m := range metrics {
+		if m.GetName() == metricName {
+			return m
+		}
+	}
+	return nil
 }

--- a/internal/core/monitoring/metrics_test.go
+++ b/internal/core/monitoring/metrics_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +25,7 @@ func TestCounterCreation(t *testing.T) {
 		counter.WithLabelValues("true").Inc()
 
 		metrics, _ := prometheus.DefaultGatherer.Gather()
-		metricFamily := filterMetric(metrics, "maestro_test_counter_test_counter")
+		metricFamily := FilterMetric(metrics, "maestro_test_counter_test_counter")
 		trueMetric := metricFamily.GetMetric()[0]
 		require.Equal(t, float64(1), trueMetric.GetCounter().GetValue())
 
@@ -38,7 +37,7 @@ func TestCounterCreation(t *testing.T) {
 		counter.WithLabelValues("true").Inc()
 
 		metrics, _ = prometheus.DefaultGatherer.Gather()
-		metricFamily = filterMetric(metrics, "maestro_test_counter_test_counter")
+		metricFamily = FilterMetric(metrics, "maestro_test_counter_test_counter")
 
 		trueMetric = metricFamily.GetMetric()[1]
 		require.Equal(t, float64(2), trueMetric.GetCounter().GetValue())
@@ -69,7 +68,7 @@ func TestCounterCreation(t *testing.T) {
 		gauge.WithLabelValues("true").Inc()
 
 		metrics, _ := prometheus.DefaultGatherer.Gather()
-		metricFamily := filterMetric(metrics, "maestro_test_gauge_test_gauge")
+		metricFamily := FilterMetric(metrics, "maestro_test_gauge_test_gauge")
 		trueMetric := metricFamily.GetMetric()[0]
 		require.Equal(t, float64(1), trueMetric.GetGauge().GetValue())
 
@@ -81,7 +80,7 @@ func TestCounterCreation(t *testing.T) {
 		gauge.WithLabelValues("true").Dec()
 
 		metrics, _ = prometheus.DefaultGatherer.Gather()
-		metricFamily = filterMetric(metrics, "maestro_test_gauge_test_gauge")
+		metricFamily = FilterMetric(metrics, "maestro_test_gauge_test_gauge")
 
 		trueMetric = metricFamily.GetMetric()[1]
 		require.Equal(t, float64(0), trueMetric.GetGauge().GetValue())
@@ -112,7 +111,7 @@ func TestCounterCreation(t *testing.T) {
 		ReportLatencyMetricInMillis(latency, time.Now().Add(time.Second*-1), "true")
 
 		metrics, _ := prometheus.DefaultGatherer.Gather()
-		metricFamily := filterMetric(metrics, "maestro_test_latency_test_latency")
+		metricFamily := FilterMetric(metrics, "maestro_test_latency_test_latency")
 		trueMetric := metricFamily.GetMetric()[0]
 		require.Equal(t, uint64(1), trueMetric.GetHistogram().GetSampleCount())
 		require.Equal(t, float64(1000), trueMetric.GetHistogram().GetSampleSum())
@@ -125,7 +124,7 @@ func TestCounterCreation(t *testing.T) {
 		ReportLatencyMetricInMillis(latency, time.Now().Add(time.Second*-5), "true")
 
 		metrics, _ = prometheus.DefaultGatherer.Gather()
-		metricFamily = filterMetric(metrics, "maestro_test_latency_test_latency")
+		metricFamily = FilterMetric(metrics, "maestro_test_latency_test_latency")
 		trueMetric = metricFamily.GetMetric()[1]
 		require.Equal(t, uint64(2), trueMetric.GetHistogram().GetSampleCount())
 		require.Equal(t, float64(6000), trueMetric.GetHistogram().GetSampleSum())
@@ -143,13 +142,4 @@ func TestCounterCreation(t *testing.T) {
 		require.Equal(t, "false", falseLabel.GetValue())
 	})
 
-}
-
-func filterMetric(metrics []*dto.MetricFamily, metricName string) *dto.MetricFamily {
-	for _, m := range metrics {
-		if m.GetName() == metricName {
-			return m
-		}
-	}
-	return nil
 }

--- a/internal/core/services/workers_manager/workers_manager_test.go
+++ b/internal/core/services/workers_manager/workers_manager_test.go
@@ -1,3 +1,5 @@
+//+build unit
+
 package workers_manager
 
 import (

--- a/internal/core/workers/operation_execution_worker/metrics.go
+++ b/internal/core/workers/operation_execution_worker/metrics.go
@@ -9,9 +9,9 @@ import (
 
 const (
 	LabelNoOperationExecutorFound = "no_operation_executor_found"
-	LabelShouldNotExecute = "should_not_execute"
-	LabelNextOperationFailed = "next_operation_failed"
-	LabelStartOperationFailed = "start_operation_failed"
+	LabelShouldNotExecute         = "should_not_execute"
+	LabelNextOperationFailed      = "next_operation_failed"
+	LabelStartOperationFailed     = "start_operation_failed"
 )
 
 var (
@@ -20,7 +20,6 @@ var (
 		Subsystem: monitoring.SubsystemWorker,
 		Name:      "operation_execution",
 		Help:      "An scheduler operation was executed",
-		Buckets:   monitoring.DefBucketsMs,
 		Labels: []string{
 			monitoring.LabelScheduler,
 			monitoring.LabelOperation,
@@ -34,7 +33,6 @@ var (
 		Subsystem: monitoring.SubsystemWorker,
 		Name:      "operation_on_error",
 		Help:      "An scheduler operation on error fallback was executed",
-		Buckets:   monitoring.DefBucketsMs,
 		Labels: []string{
 			monitoring.LabelScheduler,
 			monitoring.LabelOperation,
@@ -48,7 +46,6 @@ var (
 		Subsystem: monitoring.SubsystemWorker,
 		Name:      "operation_evicted",
 		Help:      "An scheduler operation was evicted",
-		Buckets:   monitoring.DefBucketsMs,
 		Labels: []string{
 			monitoring.LabelScheduler,
 			monitoring.LabelOperation,
@@ -62,7 +59,6 @@ var (
 		Subsystem: monitoring.SubsystemWorker,
 		Name:      "operation_execution_worker_failed",
 		Help:      "An scheduler operation execution worker failed and is no longer running",
-		Buckets:   monitoring.DefBucketsMs,
 		Labels: []string{
 			monitoring.LabelScheduler,
 			monitoring.LabelReason,
@@ -73,14 +69,14 @@ var (
 
 func ReportOperationExecutionLatency(start time.Time, schedulerName, operationName string, success bool) {
 	successLabelValue := fmt.Sprint(success)
-	monitoring.ReportLatencyMetric(
+	monitoring.ReportLatencyMetricInMillis(
 		operationExecutionLatencyMetric, start, schedulerName, operationName, successLabelValue,
 	)
 }
 
 func ReportOperationOnErrorLatency(start time.Time, schedulerName, operationName string, success bool) {
 	successLabelValue := fmt.Sprint(success)
-	monitoring.ReportLatencyMetric(
+	monitoring.ReportLatencyMetricInMillis(
 		operationOnErrorLatencyMetric, start, schedulerName, operationName, successLabelValue,
 	)
 }

--- a/internal/core/workers/operation_execution_worker/metrics.go
+++ b/internal/core/workers/operation_execution_worker/metrics.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/topfreegames/maestro/internal/core/monitoring"
 )
 
@@ -16,27 +15,6 @@ const (
 )
 
 var (
-	operationExecutionLatencyMetric           *prometheus.HistogramVec
-	operationOnErrorLatencyMetric             *prometheus.HistogramVec
-	operationEvictedCountMetric               *prometheus.CounterVec
-	operationExecutionWorkerFailedCountMetric *prometheus.CounterVec
-)
-
-func init() {
-	initMetrics()
-}
-
-// Clears all metrics from the package, required on unit tests
-func clearMetrics() {
-	prometheus.Unregister(operationExecutionLatencyMetric)
-	prometheus.Unregister(operationOnErrorLatencyMetric)
-	prometheus.Unregister(operationEvictedCountMetric)
-	prometheus.Unregister(operationExecutionWorkerFailedCountMetric)
-}
-
-// Initialize all metrics from the package
-func initMetrics() {
-
 	operationExecutionLatencyMetric = monitoring.CreateLatencyMetric(&monitoring.MetricOpts{
 		Namespace: monitoring.Namespace,
 		Subsystem: monitoring.SubsystemWorker,
@@ -83,7 +61,7 @@ func initMetrics() {
 			monitoring.LabelReason,
 		},
 	})
-}
+)
 
 func reportOperationExecutionLatency(start time.Time, schedulerName, operationName string, success bool) {
 	successLabelValue := fmt.Sprint(success)

--- a/internal/core/workers/operation_execution_worker/metrics.go
+++ b/internal/core/workers/operation_execution_worker/metrics.go
@@ -1,0 +1,94 @@
+package operation_execution_worker
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/topfreegames/maestro/internal/core/monitoring"
+)
+
+const (
+	LabelNoOperationExecutorFound = "no_operation_executor_found"
+	LabelShouldNotExecute = "should_not_execute"
+	LabelNextOperationFailed = "next_operation_failed"
+	LabelStartOperationFailed = "start_operation_failed"
+)
+
+var (
+	operationExecutionMetricOpts = monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "operation_execution",
+		Help:      "An scheduler operation was executed",
+		Buckets:   monitoring.DefBucketsMs,
+		Labels: []string{
+			monitoring.LabelScheduler,
+			monitoring.LabelOperation,
+			monitoring.LabelSuccess,
+		},
+	}
+	operationExecutionLatencyMetric = monitoring.CreateLatencyMetric(&operationExecutionMetricOpts)
+
+	operationOnErrorMetricOpts = monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "operation_on_error",
+		Help:      "An scheduler operation on error fallback was executed",
+		Buckets:   monitoring.DefBucketsMs,
+		Labels: []string{
+			monitoring.LabelScheduler,
+			monitoring.LabelOperation,
+			monitoring.LabelSuccess,
+		},
+	}
+	operationOnErrorLatencyMetric = monitoring.CreateLatencyMetric(&operationOnErrorMetricOpts)
+
+	operationEvictedCountMetricOpts = monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "operation_evicted",
+		Help:      "An scheduler operation was evicted",
+		Buckets:   monitoring.DefBucketsMs,
+		Labels: []string{
+			monitoring.LabelScheduler,
+			monitoring.LabelOperation,
+			monitoring.LabelReason,
+		},
+	}
+	operationEvictedCountMetric = monitoring.CreateCounterMetric(&operationEvictedCountMetricOpts)
+
+	operationExecutionWorkerFailedCountMetricOpts = monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "operation_execution_worker_failed",
+		Help:      "An scheduler operation execution worker failed and is no longer running",
+		Buckets:   monitoring.DefBucketsMs,
+		Labels: []string{
+			monitoring.LabelScheduler,
+			monitoring.LabelReason,
+		},
+	}
+	operationExecutionWorkerFailedCountMetric = monitoring.CreateCounterMetric(&operationExecutionWorkerFailedCountMetricOpts)
+)
+
+func ReportOperationExecutionLatency(start time.Time, schedulerName, operationName string, success bool) {
+	successLabelValue := fmt.Sprint(success)
+	monitoring.ReportLatencyMetric(
+		operationExecutionLatencyMetric, start, schedulerName, operationName, successLabelValue,
+	)
+}
+
+func ReportOperationOnErrorLatency(start time.Time, schedulerName, operationName string, success bool) {
+	successLabelValue := fmt.Sprint(success)
+	monitoring.ReportLatencyMetric(
+		operationOnErrorLatencyMetric, start, schedulerName, operationName, successLabelValue,
+	)
+}
+
+func ReportOperationEvicted(schedulerName, operationName, reason string) {
+	operationEvictedCountMetric.WithLabelValues(schedulerName, operationName, reason).Inc()
+}
+
+func ReportOperationExecutionWorkerFailed(schedulerName, reason string) {
+	operationExecutionWorkerFailedCountMetric.WithLabelValues(schedulerName, reason).Inc()
+}

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -24,6 +24,10 @@ import (
 
 func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 	t.Run("successfully runs a single operation", func(t *testing.T) {
+
+		clearMetrics()
+		initMetrics()
+
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -78,6 +82,10 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 	})
 
 	t.Run("execute OnError when a Execute fails", func(t *testing.T) {
+
+		clearMetrics()
+		initMetrics()
+
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -133,6 +141,10 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 	})
 
 	t.Run("evict operation if there is no executor", func(t *testing.T) {
+
+		clearMetrics()
+		initMetrics()
+
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -186,6 +198,10 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 	})
 
 	t.Run("evict operation if ShouldExecute returns false", func(t *testing.T) {
+
+		clearMetrics()
+		initMetrics()
+
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -228,7 +244,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		require.False(t, workerService.IsRunning(context.Background()))
 
 		metrics, _ := prometheus.DefaultGatherer.Gather()
-		counter := monitoring.FilterMetric(metrics, "maestro_worker_operation_evicted_counter").GetMetric()[1]
+		counter := monitoring.FilterMetric(metrics, "maestro_worker_operation_evicted_counter").GetMetric()[0]
 		require.Equal(t, float64(1), counter.GetCounter().GetValue())
 
 		operationLabel := counter.GetLabel()[0]

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -6,12 +6,15 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	opflow "github.com/topfreegames/maestro/internal/adapters/operation_flow/mock"
 	opstorage "github.com/topfreegames/maestro/internal/adapters/operation_storage/mock"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/monitoring"
 	"github.com/topfreegames/maestro/internal/core/operations"
 	mockoperation "github.com/topfreegames/maestro/internal/core/operations/mock"
 	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
@@ -49,7 +52,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationDefinition.EXPECT().Unmarshal(gomock.Any()).Return(nil)
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
-		operationExecutor.EXPECT().Execute(gomock.Any(), expectedOperation, operationDefinition).Return(nil)
+		operationExecutor.EXPECT().Execute(gomock.Any(), expectedOperation, operationDefinition).
+			Do(func(ctx, operation, definition interface{}) {
+				time.Sleep(time.Second * 1)
+			}).
+			Return(nil)
 
 		operationFlow.EXPECT().NextOperationID(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation.ID, nil)
 		operationStorage.EXPECT().GetOperation(gomock.Any(), expectedOperation.SchedulerName, expectedOperation.ID).Return(expectedOperation, []byte{}, nil)
@@ -63,6 +70,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		workerService.Stop(context.Background())
 		require.False(t, workerService.IsRunning(context.Background()))
+
+		metrics, _ := prometheus.DefaultGatherer.Gather()
+		latency := monitoring.FilterMetric(metrics, "maestro_worker_operation_execution_latency").GetMetric()[0]
+		require.Equal(t, uint64(1), latency.GetHistogram().GetSampleCount())
+		require.GreaterOrEqual(t, latency.GetHistogram().GetSampleSum(), float64(1000))
 	})
 
 	t.Run("execute OnError when a Execute fails", func(t *testing.T) {
@@ -96,7 +108,10 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
 		executionErr := fmt.Errorf("failed to execute operation")
 		operationExecutor.EXPECT().Execute(gomock.Any(), expectedOperation, operationDefinition).Return(executionErr)
-		operationExecutor.EXPECT().OnError(gomock.Any(), expectedOperation, operationDefinition, executionErr).Return(nil)
+		operationExecutor.EXPECT().OnError(gomock.Any(), expectedOperation, operationDefinition, executionErr).
+			Do(func(ctx, operation, definition, executeErr interface{}) {
+				time.Sleep(time.Second * 1)
+			}).Return(nil)
 
 		operationFlow.EXPECT().NextOperationID(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation.ID, nil)
 		operationStorage.EXPECT().GetOperation(gomock.Any(), expectedOperation.SchedulerName, expectedOperation.ID).Return(expectedOperation, []byte{}, nil)
@@ -110,6 +125,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		workerService.Stop(context.Background())
 		require.False(t, workerService.IsRunning(context.Background()))
+
+		metrics, _ := prometheus.DefaultGatherer.Gather()
+		latency := monitoring.FilterMetric(metrics, "maestro_worker_operation_on_error_latency").GetMetric()[0]
+		require.Equal(t, uint64(1), latency.GetHistogram().GetSampleCount())
+		require.GreaterOrEqual(t, latency.GetHistogram().GetSampleSum(), float64(1000))
 	})
 
 	t.Run("evict operation if there is no executor", func(t *testing.T) {
@@ -147,6 +167,22 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		err := workerService.Start(context.Background())
 		require.NoError(t, err)
+
+		metrics, _ := prometheus.DefaultGatherer.Gather()
+		counter := monitoring.FilterMetric(metrics, "maestro_worker_operation_evicted_counter").GetMetric()[0]
+		require.Equal(t, float64(1), counter.GetCounter().GetValue())
+
+		operationLabel := counter.GetLabel()[0]
+		require.Equal(t, "operation", operationLabel.GetName())
+		require.Equal(t, "test_operation", operationLabel.GetValue())
+
+		reasonLabel := counter.GetLabel()[1]
+		require.Equal(t, "reason", reasonLabel.GetName())
+		require.Equal(t, "no_operation_executor_found", reasonLabel.GetValue())
+
+		schedulerLabel := counter.GetLabel()[2]
+		require.Equal(t, "scheduler", schedulerLabel.GetName())
+		require.Equal(t, "random-scheduler", schedulerLabel.GetValue())
 	})
 
 	t.Run("evict operation if ShouldExecute returns false", func(t *testing.T) {
@@ -190,5 +226,21 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		workerService.Stop(context.Background())
 		require.False(t, workerService.IsRunning(context.Background()))
+
+		metrics, _ := prometheus.DefaultGatherer.Gather()
+		counter := monitoring.FilterMetric(metrics, "maestro_worker_operation_evicted_counter").GetMetric()[1]
+		require.Equal(t, float64(1), counter.GetCounter().GetValue())
+
+		operationLabel := counter.GetLabel()[0]
+		require.Equal(t, "operation", operationLabel.GetName())
+		require.Equal(t, "test_operation", operationLabel.GetValue())
+
+		reasonLabel := counter.GetLabel()[1]
+		require.Equal(t, "reason", reasonLabel.GetName())
+		require.Equal(t, "should_not_execute", reasonLabel.GetValue())
+
+		schedulerLabel := counter.GetLabel()[2]
+		require.Equal(t, "scheduler", schedulerLabel.GetName())
+		require.Equal(t, "random-scheduler", schedulerLabel.GetValue())
 	})
 }


### PR DESCRIPTION
This PR aims to add metrics of latency and count for the operation execution worker.

There are 4 main metrics:
* `operation_execution`: Latency metric to measure how long a operation execution is taking;
    * Contains 3 metadatas: Scheduler, Operation, Success
* `operation_on_error`: Latency metric to measure how long a operation error fallback is taking;
    * Contains 3 metadatas: Scheduler, Operation, Success
* `operation_evicted`: Count metric to measure how many operations are being evicted;
    * Contains 3 metadatas: Scheduler, Operation, Reason
* `operation_execution_worker_failed`: Count metric to measure how many operations workers are failing;
    * Contains 2 metadatas: Scheduler, Reason