### PR TITLE
Add missing unit test build tags

### DIFF
--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -1,3 +1,5 @@
+//+build unit
+
 package operation_manager
 
 import (

--- a/internal/core/services/operations_registry/operations_registry_test.go
+++ b/internal/core/services/operations_registry/operations_registry_test.go
@@ -1,3 +1,5 @@
+//+build unit
+
 package operations_registry
 
 import (


### PR DESCRIPTION
This PR aims to add missing unit test build tags to the following test files:

* internal/core/services/operations_registry/operations_registry_test.go
* internal/core/services/operation_manager/operation_manager_test.go