### PR TITLE
Add worker manager metrics

### DIFF
--- a/internal/core/services/workers_manager/metrics.go
+++ b/internal/core/services/workers_manager/metrics.go
@@ -10,9 +10,22 @@ var (
 		Subsystem: monitoring.SubsystemWorker,
 		Name:      "current_workers",
 		Help:      "Current number of alive workers",
-		Labels:    []string{},
+		Labels: []string{
+			monitoring.LabelScheduler,
+		},
 	}
-	currentWorkersGaugeMetric = monitoring.CreateGaugeMetric(&currentWorkersGaugeMetricOpts).WithLabelValues()
+	currentWorkersGaugeMetric = monitoring.CreateGaugeMetric(&currentWorkersGaugeMetricOpts)
+
+	restartedWorkersCounterMetricOpts = monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "restarted_workers",
+		Help:      "Number of restarted workers",
+		Labels: []string{
+			monitoring.LabelScheduler,
+		},
+	}
+	restartedWorkersCounterMetric = monitoring.CreateCounterMetric(&restartedWorkersCounterMetricOpts)
 
 	workersSyncCounterMetricOpts = monitoring.MetricOpts{
 		Namespace: monitoring.Namespace,
@@ -24,12 +37,16 @@ var (
 	workersSyncCounterMetric = monitoring.CreateCounterMetric(&workersSyncCounterMetricOpts).WithLabelValues()
 )
 
-func ReportWorkerStarted() {
-	currentWorkersGaugeMetric.Inc()
+func ReportWorkerStart(schedulerName string) {
+	currentWorkersGaugeMetric.WithLabelValues(schedulerName).Inc()
 }
 
-func ReportWorkerStopped() {
-	currentWorkersGaugeMetric.Dec()
+func ReportWorkerStop(schedulerName string) {
+	currentWorkersGaugeMetric.WithLabelValues(schedulerName).Dec()
+}
+
+func ReportWorkerRestart(schedulerName string) {
+	restartedWorkersCounterMetric.WithLabelValues(schedulerName).Inc()
 }
 
 func ReportWorkersSynced() {

--- a/internal/core/services/workers_manager/metrics.go
+++ b/internal/core/services/workers_manager/metrics.go
@@ -1,0 +1,37 @@
+package workers_manager
+
+import (
+	"github.com/topfreegames/maestro/internal/core/monitoring"
+)
+
+var (
+	currentWorkersGaugeMetricOpts = monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "current_workers",
+		Help:      "Current number of alive workers",
+		Labels:    []string{},
+	}
+	currentWorkersGaugeMetric = monitoring.CreateGaugeMetric(&currentWorkersGaugeMetricOpts).WithLabelValues()
+
+	workersSyncCounterMetricOpts = monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "workers_sync",
+		Help:      "Times of the workers sync processes",
+		Labels:    []string{},
+	}
+	workersSyncCounterMetric = monitoring.CreateCounterMetric(&workersSyncCounterMetricOpts).WithLabelValues()
+)
+
+func ReportWorkerStarted() {
+	currentWorkersGaugeMetric.Inc()
+}
+
+func ReportWorkerStopped() {
+	currentWorkersGaugeMetric.Dec()
+}
+
+func ReportWorkersSynced() {
+	workersSyncCounterMetric.Inc()
+}

--- a/internal/core/services/workers_manager/metrics.go
+++ b/internal/core/services/workers_manager/metrics.go
@@ -1,21 +1,10 @@
 package workers_manager
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/topfreegames/maestro/internal/core/monitoring"
 )
 
 var (
-	currentWorkersGaugeMetric     *prometheus.GaugeVec
-	restartedWorkersCounterMetric *prometheus.CounterVec
-	workersSyncCounterMetric      *prometheus.CounterVec
-)
-
-func init() {
-	initMetrics()
-}
-
-func initMetrics() {
 	currentWorkersGaugeMetric = monitoring.CreateGaugeMetric(&monitoring.MetricOpts{
 		Namespace: monitoring.Namespace,
 		Subsystem: monitoring.SubsystemWorker,
@@ -43,13 +32,7 @@ func initMetrics() {
 		Help:      "Times of the workers sync processes",
 		Labels:    []string{},
 	})
-}
-
-func clearMetrics() {
-	prometheus.Unregister(currentWorkersGaugeMetric)
-	prometheus.Unregister(restartedWorkersCounterMetric)
-	prometheus.Unregister(workersSyncCounterMetric)
-}
+)
 
 func reportWorkerStart(schedulerName string) {
 	currentWorkersGaugeMetric.WithLabelValues(schedulerName).Inc()

--- a/internal/core/services/workers_manager/workers_manager.go
+++ b/internal/core/services/workers_manager/workers_manager.go
@@ -119,20 +119,21 @@ func (w *WorkersManager) SyncWorkers(ctx context.Context) error {
 		go worker.Start(ctx)
 		w.CurrentWorkers[name] = worker
 		zap.L().Info("new operation worker running", zap.Int("scheduler", len(name)))
-		ReportWorkerStarted()
+		ReportWorkerStart(name)
 	}
 
 	for name, worker := range w.getDispensableWorkers(ctx, schedulers) {
 		worker.Stop(ctx)
 		delete(w.CurrentWorkers, name)
 		zap.L().Info("canceling operation worker", zap.Int("scheduler", len(name)))
-		ReportWorkerStopped()
+		ReportWorkerStop(name)
 	}
 
 	for name, worker := range w.getDeadWorkers(ctx) {
 		worker.Start(ctx)
 		w.CurrentWorkers[name] = worker
 		zap.L().Info("restarting dead operation worker", zap.Int("scheduler", len(name)))
+		ReportWorkerRestart(name)
 	}
 
 	ReportWorkersSynced()

--- a/internal/core/services/workers_manager/workers_manager.go
+++ b/internal/core/services/workers_manager/workers_manager.go
@@ -98,6 +98,7 @@ func (w *WorkersManager) stop(ctx context.Context) {
 	for name, worker := range w.CurrentWorkers {
 		worker.Stop(ctx)
 		delete(w.CurrentWorkers, name)
+		reportWorkerStop(name)
 	}
 	w.RunSyncWorkers = false
 }
@@ -119,24 +120,24 @@ func (w *WorkersManager) SyncWorkers(ctx context.Context) error {
 		go worker.Start(ctx)
 		w.CurrentWorkers[name] = worker
 		zap.L().Info("new operation worker running", zap.Int("scheduler", len(name)))
-		ReportWorkerStart(name)
+		reportWorkerStart(name)
 	}
 
 	for name, worker := range w.getDispensableWorkers(ctx, schedulers) {
 		worker.Stop(ctx)
 		delete(w.CurrentWorkers, name)
 		zap.L().Info("canceling operation worker", zap.Int("scheduler", len(name)))
-		ReportWorkerStop(name)
+		reportWorkerStop(name)
 	}
 
 	for name, worker := range w.getDeadWorkers(ctx) {
 		worker.Start(ctx)
 		w.CurrentWorkers[name] = worker
 		zap.L().Info("restarting dead operation worker", zap.Int("scheduler", len(name)))
-		ReportWorkerRestart(name)
+		reportWorkerRestart(name)
 	}
 
-	ReportWorkersSynced()
+	reportWorkersSynced()
 	return nil
 }
 

--- a/internal/core/services/workers_manager/workers_manager.go
+++ b/internal/core/services/workers_manager/workers_manager.go
@@ -119,12 +119,14 @@ func (w *WorkersManager) SyncWorkers(ctx context.Context) error {
 		go worker.Start(ctx)
 		w.CurrentWorkers[name] = worker
 		zap.L().Info("new operation worker running", zap.Int("scheduler", len(name)))
+		ReportWorkerStarted()
 	}
 
 	for name, worker := range w.getDispensableWorkers(ctx, schedulers) {
 		worker.Stop(ctx)
 		delete(w.CurrentWorkers, name)
 		zap.L().Info("canceling operation worker", zap.Int("scheduler", len(name)))
+		ReportWorkerStopped()
 	}
 
 	for name, worker := range w.getDeadWorkers(ctx) {
@@ -133,6 +135,7 @@ func (w *WorkersManager) SyncWorkers(ctx context.Context) error {
 		zap.L().Info("restarting dead operation worker", zap.Int("scheduler", len(name)))
 	}
 
+	ReportWorkersSynced()
 	return nil
 }
 


### PR DESCRIPTION
This PR aims to add metrics of gauge and count for the worker manager events.

There are 3 main metrics:
* `current_workers`: Gauge metric to measure how many workers are alive;
    * Contains 1 metadata: Scheduler
* `restarted_workers`: Counter metric to measure how many workers has been restarted;
    * Contains 1 metadata: Scheduler
* `workers_sync`: Count metric to measure how many workers sync has been executed;
    * Contains no metadata