### PR TITLE
Workers manager context cancelation

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -12,3 +12,6 @@ adapters:
   operationStorage:
     redis:
       url: "redis://localhost:6379/0"
+workers:
+  syncInterval: 10s
+  stopTimeoutDuration: 1m


### PR DESCRIPTION
We're changing the worker's manager to `Start` block the execution and be responsible for returning any runtime error. And stop to be done through context cancelation.

Also, the following changes were made:
* Added workers configuration to `config/config.yaml`;
* Changed tests to not rely on `time.Sleep`;