### PR TITLE
Fix create scheduler e2e local flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ mocks:
 ################################################################################
 
 .PHONY: build/worker
-build:
+build/worker:
 	@rm -f ./bin/worker
 	@go build -o ./bin/worker ./cmd/worker
 

--- a/cmd/management_api/management_api.go
+++ b/cmd/management_api/management_api.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	logConfig  = flag.String("log-config", "development", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
-	configPath = flag.String("config-path", "config/local.yaml", "path of the configuration YAML file")
+	configPath = flag.String("config-path", "config/management-api.local.yaml", "path of the configuration YAML file")
 )
 
 func main() {

--- a/cmd/management_api/wire.go
+++ b/cmd/management_api/wire.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/topfreegames/maestro/internal/api/handlers"
 	"github.com/topfreegames/maestro/internal/config"
+	"github.com/topfreegames/maestro/internal/core/operations/providers"
 	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
 	"github.com/topfreegames/maestro/internal/core/services/scheduler_manager"
 	"github.com/topfreegames/maestro/internal/service"
@@ -20,6 +21,7 @@ func initializeManagementMux(ctx context.Context, conf config.Config) (*runtime.
 		service.NewClockTime,
 		service.NewOperationFlowRedis,
 		service.NewOperationStorageRedis,
+		providers.ProvideDefinitionConstructors,
 		operation_manager.New,
 		service.NewSchedulerStoragePg,
 		scheduler_manager.NewSchedulerManager,

--- a/cmd/management_api/wire_gen.go
+++ b/cmd/management_api/wire_gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/topfreegames/maestro/internal/api/handlers"
 	"github.com/topfreegames/maestro/internal/config"
+	"github.com/topfreegames/maestro/internal/core/operations/providers"
 	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
 	"github.com/topfreegames/maestro/internal/core/services/scheduler_manager"
 	"github.com/topfreegames/maestro/internal/service"
@@ -34,7 +35,8 @@ func initializeManagementMux(ctx context.Context, conf config.Config) (*runtime.
 	if err != nil {
 		return nil, err
 	}
-	operationManager := operation_manager.New(operationFlow, operationStorage)
+	v := providers.ProvideDefinitionConstructors()
+	operationManager := operation_manager.New(operationFlow, operationStorage, v)
 	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 	schedulerHandler := handlers.ProvideSchedulerHandler(schedulerManager)
 	serveMux := provideManagementMux(ctx, pingHandler, schedulerHandler)

--- a/cmd/utils/cmd/root.go
+++ b/cmd/utils/cmd/root.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	logConfig  = flag.String("log-config", "development", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
-	configPath = flag.String("config-path", "config/local.yaml", "path of the configuration YAML file")
+	configPath = flag.String("config-path", "config/utils.local.yaml", "path of the configuration YAML file")
 	rootCmd    = &cobra.Command{
 		Use:   "migrate",
 		Short: "Migrates datasources of maestro",

--- a/cmd/worker/wire.go
+++ b/cmd/worker/wire.go
@@ -5,6 +5,7 @@ package main
 import (
 	"github.com/google/wire"
 	"github.com/topfreegames/maestro/internal/config"
+	"github.com/topfreegames/maestro/internal/core/operations/providers"
 	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
 	"github.com/topfreegames/maestro/internal/core/services/workers_manager"
 	"github.com/topfreegames/maestro/internal/core/workers"
@@ -13,11 +14,15 @@ import (
 
 func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_manager.WorkersManager, error) {
 	wire.Build(
+		service.NewRuntimeKubernetes,
 		service.NewSchedulerStoragePg,
 		service.NewOperationFlowRedis,
 		service.NewClockTime,
 		service.NewOperationStorageRedis,
+		providers.ProvideDefinitionConstructors,
+		providers.ProvideExecutors,
 		operation_manager.New,
+		workers.ProvideWorkerOptions,
 		workers_manager.NewWorkersManager,
 	)
 

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	logConfig  = flag.String("log-config", "development", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
-	configPath = flag.String("config-path", "config/local.yaml", "path of the configuration YAML file")
+	configPath = flag.String("config-path", "config/worker.local.yaml", "path of the configuration YAML file")
 )
 
 func main() {

--- a/config/management-api.local.yaml
+++ b/config/management-api.local.yaml
@@ -1,0 +1,20 @@
+internal_api:
+  port: 8081
+  gracefulShutdownTimeout: 10s
+  metrics:
+    enabled: true
+  healthcheck:
+    enabled: true
+management_api:
+  port: 8080
+  gracefulShutdownTimeout: 10s
+adapters:
+  schedulerStorage:
+    postgres:
+      url: "postgres://maestro:maestro@localhost:5432/maestro?sslmode=disable"
+  operationFlow:
+    redis:
+      url: "redis://localhost:6379/0"
+  operationStorage:
+    redis:
+      url: "redis://localhost:6379/0"

--- a/config/utils.local.yaml
+++ b/config/utils.local.yaml
@@ -1,0 +1,6 @@
+adapters:
+  schedulerStorage:
+    postgres:
+      url: "postgres://maestro:maestro@localhost:5432/maestro?sslmode=disable"
+migration:
+  path: "file://internal/adapters/scheduler_storage/pg/migrations"

--- a/config/worker.local.yaml
+++ b/config/worker.local.yaml
@@ -1,13 +1,10 @@
 internal_api:
-  port: 8081
+  port: 8082
   gracefulShutdownTimeout: 10s
   metrics:
     enabled: true
   healthcheck:
     enabled: true
-management_api:
-  port: 8080
-  gracefulShutdownTimeout: 10s
 adapters:
   schedulerStorage:
     postgres:
@@ -18,8 +15,10 @@ adapters:
   operationStorage:
     redis:
       url: "redis://localhost:6379/0"
+  runtime:
+    kubernetes:
+      masterUrl: "https://127.0.0.1:6443"
+      kubeconfig: "./kubeconfig.yaml"
 workers:
   syncInterval: 10s
   stopTimeoutDuration: 1m
-migration:
-  path: "file://internal/adapters/scheduler_storage/pg/migrations"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,7 +58,7 @@ services:
     - POSTGRES_PASSWORD=maestro
 
   redis:
-    image: redis:3.2-alpine
+    image: redis:5.0.10-alpine
     ports:
     - "6379:6379"
 

--- a/internal/api/handlers/scheduler_handler_test.go
+++ b/internal/api/handlers/scheduler_handler_test.go
@@ -18,6 +18,7 @@ import (
 	schedulerStorageMock "github.com/topfreegames/maestro/internal/adapters/scheduler_storage/mock"
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+	"github.com/topfreegames/maestro/internal/core/operations"
 	"github.com/topfreegames/maestro/internal/core/ports/errors"
 	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
 	"github.com/topfreegames/maestro/internal/core/services/scheduler_manager"
@@ -133,7 +134,7 @@ func TestCreateScheduler(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		scheduler := &entities.Scheduler{

--- a/internal/core/operations/create_scheduler/create_scheduler_executor.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor.go
@@ -22,7 +22,7 @@ func NewExecutor(runtime ports.Runtime, storage ports.SchedulerStorage) *CreateS
 	}
 }
 
-func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op operation.Operation, definition operations.Definition) error {
+func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
 	err := e.runtime.CreateScheduler(ctx, &entities.Scheduler{Name: op.SchedulerName})
 	if err != nil {
 		return fmt.Errorf("failed to create scheduler in runtime: %w", err)
@@ -31,7 +31,7 @@ func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op operation.Oper
 	return nil
 }
 
-func (e *CreateSchedulerExecutor) OnError(ctx context.Context, op operation.Operation, definition operations.Definition, executeErr error) error {
+func (e *CreateSchedulerExecutor) OnError(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
 	scheduler, err := e.storage.GetScheduler(ctx, op.SchedulerName)
 	if err != nil {
 		return fmt.Errorf("failed to find scheduler by id: %w", err)

--- a/internal/core/operations/create_scheduler/create_scheduler_executor_test.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor_test.go
@@ -34,7 +34,7 @@ func TestExecute(t *testing.T) {
 
 		runtime.EXPECT().CreateScheduler(context.Background(), &entities.Scheduler{Name: op.SchedulerName}).Return(nil)
 
-		err := NewExecutor(runtime, storage).Execute(context.Background(), op, &definition)
+		err := NewExecutor(runtime, storage).Execute(context.Background(), &op, &definition)
 		require.NoError(t, err)
 	})
 
@@ -55,7 +55,7 @@ func TestExecute(t *testing.T) {
 
 		runtime.EXPECT().CreateScheduler(context.Background(), &entities.Scheduler{Name: op.SchedulerName}).Return(errors.ErrUnexpected)
 
-		err := NewExecutor(runtime, storage).Execute(context.Background(), op, &definition)
+		err := NewExecutor(runtime, storage).Execute(context.Background(), &op, &definition)
 		require.ErrorIs(t, err, errors.ErrUnexpected)
 	})
 }
@@ -93,7 +93,7 @@ func TestOnError(t *testing.T) {
 		storage.EXPECT().GetScheduler(context.Background(), op.SchedulerName).Return(&scheduler, nil)
 		storage.EXPECT().UpdateScheduler(context.Background(), &updatedScheduler).Return(nil)
 
-		err := NewExecutor(runtime, storage).OnError(context.Background(), op, definition, errors.ErrUnexpected)
+		err := NewExecutor(runtime, storage).OnError(context.Background(), &op, definition, errors.ErrUnexpected)
 		require.NoError(t, err)
 	})
 
@@ -114,7 +114,7 @@ func TestOnError(t *testing.T) {
 
 		storage.EXPECT().GetScheduler(context.Background(), op.SchedulerName).Return(nil, errors.ErrNotFound)
 
-		err := NewExecutor(runtime, storage).OnError(context.Background(), op, &definition, errors.ErrUnexpected)
+		err := NewExecutor(runtime, storage).OnError(context.Background(), &op, &definition, errors.ErrUnexpected)
 		require.ErrorIs(t, err, errors.ErrNotFound)
 	})
 }

--- a/internal/core/operations/definition.go
+++ b/internal/core/operations/definition.go
@@ -7,10 +7,10 @@ import (
 )
 
 type DefinitionConstructor func() Definition
-type DefintionConstructors map[string]DefinitionConstructor
+type DefinitionConstructors map[string]DefinitionConstructor
 
-func NewDefinitionConstructors() DefintionConstructors {
-	return DefintionConstructors{}
+func NewDefinitionConstructors() DefinitionConstructors {
+	return DefinitionConstructors{}
 }
 
 // Definition is the operation parameters. It must be able to encode/decode

--- a/internal/core/operations/definition.go
+++ b/internal/core/operations/definition.go
@@ -6,6 +6,13 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 )
 
+type DefinitionConstructor func() Definition
+type DefintionConstructors map[string]DefinitionConstructor
+
+func NewDefinitionConstructors() DefintionConstructors {
+	return DefintionConstructors{}
+}
+
 // Definition is the operation parameters. It must be able to encode/decode
 // itself.
 type Definition interface {

--- a/internal/core/operations/executor.go
+++ b/internal/core/operations/executor.go
@@ -12,10 +12,10 @@ type Executor interface {
 	// This is where the operation logic will live; it will receive a context
 	// that will be used for deadline and cancelation. This function has only
 	// one return which is the operation error (if any);
-	Execute(ctx context.Context, operation *operation.Operation, definition Definition) error
+	Execute(ctx context.Context, op *operation.Operation, definition Definition) error
 	// This function is called if Execute returns an error. This will be used
 	// for operations that need to do some cleanup or any process if it fails.
-	OnError(ctx context.Context, operation *operation.Operation, definition Definition, executeErr error) error
+	OnError(ctx context.Context, op *operation.Operation, definition Definition, executeErr error) error
 	// Name returns the executor name. This is used to identify a executor for a
 	// definition.
 	Name() string

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -1,0 +1,29 @@
+package providers
+
+import (
+	"github.com/topfreegames/maestro/internal/core/operations"
+	"github.com/topfreegames/maestro/internal/core/operations/create_scheduler"
+	"github.com/topfreegames/maestro/internal/core/ports"
+)
+
+var createSchedulerOperationName = "create_scheduler"
+
+func ProvideDefinitionConstructors() map[string]operations.DefinitionConstructor {
+
+	definitionConstructors := map[string]operations.DefinitionConstructor{}
+	definitionConstructors[createSchedulerOperationName] = func() operations.Definition {
+		return &create_scheduler.CreateSchedulerDefinition{}
+	}
+
+	return definitionConstructors
+
+}
+
+func ProvideExecutors(runtime ports.Runtime, schedulerStorage ports.SchedulerStorage) map[string]operations.Executor {
+
+	executors := map[string]operations.Executor{}
+	executors[createSchedulerOperationName] = create_scheduler.NewExecutor(runtime, schedulerStorage)
+
+	return executors
+
+}

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/operations"
 	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
-	"github.com/topfreegames/maestro/internal/core/services/operations_registry"
 )
 
 type testOperationDefinition struct {
@@ -73,7 +72,8 @@ func TestCreateOperation(t *testing.T) {
 			schedulerName := "scheduler_name"
 			operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 			operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-			opManager := New(operationFlow, operationStorage)
+			definitionConstructors := operations.NewDefinitionConstructors()
+			opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 			ctx := context.Background()
 			testDefinition, _ := test.definition.(*testOperationDefinition)
@@ -109,12 +109,12 @@ func TestGetOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		defFunc := func() operations.Definition { return &testOperationDefinition{} }
-		registry := operations_registry.NewRegistry()
-		registry.Register(defFunc().Name(), defFunc)
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := NewWithRegistry(operationFlow, operationStorage, registry)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[defFunc().Name()] = defFunc
+		opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -138,11 +138,11 @@ func TestGetOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		defFunc := func() operations.Definition { return &testOperationDefinition{} }
-		registry := operations_registry.NewRegistry()
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := NewWithRegistry(operationFlow, operationStorage, registry)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -162,11 +162,11 @@ func TestGetOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		defFunc := func() operations.Definition { return &testOperationDefinition{} }
-		registry := operations_registry.NewRegistry()
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := NewWithRegistry(operationFlow, operationStorage, registry)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -186,11 +186,11 @@ func TestGetOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		defFunc := func() operations.Definition { return &testOperationDefinition{unmarshalResult: errors.New("invalid")} }
-		registry := operations_registry.NewRegistry()
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := NewWithRegistry(operationFlow, operationStorage, registry)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -212,12 +212,12 @@ func TestNextSchedulerOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		defFunc := func() operations.Definition { return &testOperationDefinition{} }
-		registry := operations_registry.NewRegistry()
-		registry.Register(defFunc().Name(), defFunc)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[defFunc().Name()] = defFunc
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := NewWithRegistry(operationFlow, operationStorage, registry)
+		opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -243,12 +243,12 @@ func TestNextSchedulerOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		defFunc := func() operations.Definition { return &testOperationDefinition{} }
-		registry := operations_registry.NewRegistry()
-		registry.Register(defFunc().Name(), defFunc)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[defFunc().Name()] = defFunc
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := NewWithRegistry(operationFlow, operationStorage, registry)
+		opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -263,12 +263,12 @@ func TestNextSchedulerOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		defFunc := func() operations.Definition { return &testOperationDefinition{} }
-		registry := operations_registry.NewRegistry()
-		registry.Register(defFunc().Name(), defFunc)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[defFunc().Name()] = defFunc
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := NewWithRegistry(operationFlow, operationStorage, registry)
+		opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -293,7 +293,8 @@ func TestStartOperation(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := NewWithRegistry(operationFlow, operationStorage, operations_registry.NewRegistry())
+		definitionConstructors := operations.NewDefinitionConstructors()
+		opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 		ctx := context.Background()
 		op := &operation.Operation{ID: uuid.NewString(), DefinitionName: (&testOperationDefinition{}).Name()}
@@ -311,7 +312,8 @@ func TestFinishOperation(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := NewWithRegistry(operationFlow, operationStorage, operations_registry.NewRegistry())
+		definitionConstructors := operations.NewDefinitionConstructors()
+		opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 		ctx := context.Background()
 		expectedStatus := operation.StatusError
@@ -330,7 +332,8 @@ func TestListActiveOperations(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := NewWithRegistry(operationFlow, operationStorage, operations_registry.NewRegistry())
+		definitionConstructors := operations.NewDefinitionConstructors()
+		opManager := New(operationFlow, operationStorage, definitionConstructors)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{

--- a/internal/core/services/workers_manager/workers_manager.go
+++ b/internal/core/services/workers_manager/workers_manager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/topfreegames/maestro/internal/config"
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/ports"
-	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
 	"github.com/topfreegames/maestro/internal/core/workers"
 	"go.uber.org/zap"
 )
@@ -30,7 +29,6 @@ type WorkersManager struct {
 	builder                    workers.WorkerBuilder
 	configs                    config.Config
 	schedulerStorage           ports.SchedulerStorage
-	operationManager           *operation_manager.OperationManager
 	CurrentWorkers             map[string]workers.Worker
 	syncWorkersInterval        time.Duration
 	workerOptions              *workers.WorkerOptions
@@ -39,18 +37,12 @@ type WorkersManager struct {
 }
 
 // Default constructor of WorkersManager
-func NewWorkersManager(builder workers.WorkerBuilder, configs config.Config, schedulerStorage ports.SchedulerStorage, operationManager *operation_manager.OperationManager) *WorkersManager {
-	// options passed to build the workers.
-	// NOTE: we might need to add more options as the workers need.
-	workerOptions := &workers.WorkerOptions{
-		OperationManager: operationManager,
-	}
+func NewWorkersManager(builder workers.WorkerBuilder, configs config.Config, schedulerStorage ports.SchedulerStorage, workerOptions *workers.WorkerOptions) *WorkersManager {
 
 	return &WorkersManager{
 		builder:                    builder,
 		configs:                    configs,
 		schedulerStorage:           schedulerStorage,
-		operationManager:           operationManager,
 		CurrentWorkers:             map[string]workers.Worker{},
 		syncWorkersInterval:        configs.GetDuration(syncWorkersIntervalPath),
 		workerOptions:              workerOptions,

--- a/internal/core/services/workers_manager/workers_manager_test.go
+++ b/internal/core/services/workers_manager/workers_manager_test.go
@@ -19,10 +19,8 @@ import (
 	configMock "github.com/topfreegames/maestro/internal/config/mock"
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/ports/errors"
-	workerMock "github.com/topfreegames/maestro/internal/core/workers/mock"
-
-	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
 	"github.com/topfreegames/maestro/internal/core/workers"
+	workerMock "github.com/topfreegames/maestro/internal/core/workers/mock"
 )
 
 var (
@@ -46,7 +44,6 @@ func TestStart(t *testing.T) {
 
 		configs := configMock.NewMockConfig(mockCtrl)
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, nil)
 		workerStopCh := make(chan struct{})
 		workerBuilder := func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
 			return &workerMock.MockWorker{Run: false, StopCh: workerStopCh}
@@ -68,7 +65,7 @@ func TestStart(t *testing.T) {
 			},
 		}, nil)
 
-		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, operationManager)
+		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, nil)
 
 		done := make(chan struct{})
 		go func() {
@@ -111,7 +108,6 @@ func TestStart(t *testing.T) {
 
 		configs := configMock.NewMockConfig(mockCtrl)
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, nil)
 
 		configs.EXPECT().GetDuration(syncWorkersIntervalPath).Return(time.Second)
 		configs.EXPECT().GetDuration(workersStopTimeoutDurationPath).Return(10 * time.Second)
@@ -120,7 +116,7 @@ func TestStart(t *testing.T) {
 			return &workerMock.MockWorker{Run: false}
 		}
 
-		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, operationManager)
+		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, nil)
 
 		done := make(chan struct{})
 		go func() {
@@ -147,7 +143,7 @@ func TestStart(t *testing.T) {
 
 		configs := configMock.NewMockConfig(mockCtrl)
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, nil)
+
 		workerStopCh := make(chan struct{})
 		workerBuilder := func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
 			return &workerMock.MockWorker{
@@ -172,7 +168,7 @@ func TestStart(t *testing.T) {
 			},
 		}, nil)
 
-		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, operationManager)
+		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, nil)
 
 		done := make(chan struct{})
 		go func() {
@@ -214,7 +210,7 @@ func TestStart(t *testing.T) {
 
 		configs := configMock.NewMockConfig(mockCtrl)
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, nil)
+
 		workerStopCh := make(chan struct{})
 		workerBuilder := func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
 			return &workerMock.MockWorker{Run: false, StopCh: workerStopCh}
@@ -224,7 +220,7 @@ func TestStart(t *testing.T) {
 		configs.EXPECT().GetDuration(syncWorkersIntervalPath).Return(time.Second)
 		configs.EXPECT().GetDuration(workersStopTimeoutDurationPath).Return(10 * time.Second)
 
-		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, operationManager)
+		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, nil)
 		require.Empty(t, workersManager.CurrentWorkers)
 
 		// first call channel handler
@@ -299,7 +295,7 @@ func TestStart(t *testing.T) {
 
 		configs := configMock.NewMockConfig(mockCtrl)
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, nil)
+
 		workerStopCh := make(chan struct{})
 		workerBuilder := func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
 			return &workerMock.MockWorker{Run: false, StopCh: workerStopCh}
@@ -321,7 +317,7 @@ func TestStart(t *testing.T) {
 			},
 		}, nil)
 
-		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, operationManager)
+		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, nil)
 
 		done := make(chan struct{})
 		go func() {

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -31,16 +31,9 @@ type OperationExecutionWorker struct {
 }
 
 func NewOperationExecutionWorker(scheduler *entities.Scheduler, opts *workers.WorkerOptions) workers.Worker {
-	executors := make(map[string]operations.Executor)
-	for _, executor := range opts.Executors {
-		// TODO(gabrielcorado): are we going to receive the executor
-		// initialized?
-		executors[executor.Name()] = executor
-	}
-
 	return &OperationExecutionWorker{
 		operationManager: opts.OperationManager,
-		executorsByName:  executors,
+		executorsByName:  opts.OperationExecutors,
 		schedulerName:    scheduler.Name,
 		logger:           zap.L().With(zap.String("service", "worker"), zap.String("scheduler_name", scheduler.Name)),
 	}

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/topfreegames/maestro/internal/core/operations"
 	mockoperation "github.com/topfreegames/maestro/internal/core/operations/mock"
 	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
-	"github.com/topfreegames/maestro/internal/core/services/operations_registry"
 	"github.com/topfreegames/maestro/internal/core/workers"
 )
 
@@ -37,10 +36,10 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationDefinition.EXPECT().Name().Return(operationName).AnyTimes()
 
 		defFunc := func() operations.Definition { return operationDefinition }
-		registry := operations_registry.NewRegistry()
-		registry.Register(operationName, defFunc)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[operationName] = defFunc
 
-		operationManager := operation_manager.NewWithRegistry(operationFlow, operationStorage, registry)
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",
@@ -49,7 +48,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 			DefinitionName: operationName,
 		}
 
-		workerService := NewOperationExecutionWorker(scheduler, &workers.WorkerOptions{operationManager, []operations.Executor{operationExecutor}})
+		executors := map[string]operations.Executor{}
+		executors[operationName] = operationExecutor
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors))
 
 		operationDefinition.EXPECT().Unmarshal(gomock.Any()).Return(nil)
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
@@ -88,10 +89,10 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationDefinition.EXPECT().Name().Return(operationName).AnyTimes()
 
 		defFunc := func() operations.Definition { return operationDefinition }
-		registry := operations_registry.NewRegistry()
-		registry.Register(operationName, defFunc)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[operationName] = defFunc
 
-		operationManager := operation_manager.NewWithRegistry(operationFlow, operationStorage, registry)
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",
@@ -100,7 +101,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 			DefinitionName: operationName,
 		}
 
-		workerService := NewOperationExecutionWorker(scheduler, &workers.WorkerOptions{operationManager, []operations.Executor{operationExecutor}})
+		executors := map[string]operations.Executor{}
+		executors[operationName] = operationExecutor
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors))
 
 		operationDefinition.EXPECT().Unmarshal(gomock.Any()).Return(nil)
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
@@ -138,10 +141,10 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationDefinition.EXPECT().Name().Return(operationName).AnyTimes()
 
 		defFunc := func() operations.Definition { return operationDefinition }
-		registry := operations_registry.NewRegistry()
-		registry.Register(operationName, defFunc)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[operationName] = defFunc
 
-		operationManager := operation_manager.NewWithRegistry(operationFlow, operationStorage, registry)
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",
@@ -150,7 +153,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 			DefinitionName: operationName,
 		}
 
-		workerService := NewOperationExecutionWorker(scheduler, &workers.WorkerOptions{operationManager, []operations.Executor{}})
+		executors := map[string]operations.Executor{}
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors))
 
 		operationDefinition.EXPECT().Unmarshal(gomock.Any()).Return(nil)
 
@@ -179,10 +183,10 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationDefinition.EXPECT().Name().Return(operationName).AnyTimes()
 
 		defFunc := func() operations.Definition { return operationDefinition }
-		registry := operations_registry.NewRegistry()
-		registry.Register(operationName, defFunc)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[operationName] = defFunc
 
-		operationManager := operation_manager.NewWithRegistry(operationFlow, operationStorage, registry)
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",
@@ -191,7 +195,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 			DefinitionName: operationName,
 		}
 
-		workerService := NewOperationExecutionWorker(scheduler, &workers.WorkerOptions{operationManager, []operations.Executor{operationExecutor}})
+		executors := map[string]operations.Executor{}
+		executors[operationName] = operationExecutor
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors))
 
 		operationDefinition.EXPECT().Unmarshal(gomock.Any()).Return(nil)
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(false)

--- a/internal/core/workers/worker.go
+++ b/internal/core/workers/worker.go
@@ -23,8 +23,15 @@ type Worker interface {
 // its construction. This struct is going to be used to inject the worker
 // dependencies like ports.
 type WorkerOptions struct {
-	OperationManager *operation_manager.OperationManager
-	Executors        []operations.Executor
+	OperationManager   *operation_manager.OperationManager
+	OperationExecutors map[string]operations.Executor
+}
+
+func ProvideWorkerOptions(operationManager *operation_manager.OperationManager, operationExecutors map[string]operations.Executor) *WorkerOptions {
+	return &WorkerOptions{
+		OperationManager:   operationManager,
+		OperationExecutors: operationExecutors,
+	}
 }
 
 // WorkerBuilder defines a function that nows how to construct a worker.


### PR DESCRIPTION
This PR aims to fix some major problems found when trying to run the NEXT branch locally in order to create a scheduler successfully. The major problems were:

* Operation registry was not being populated, then operation manager was not able to marshal/unmarshal operation definitions;
* Operation executors were not being inject into operation execution worker correctly, then no operation was being executed;
* Missing k3s configuration when running locally was breaking the k8s client;