### PR TITLE
Change remove dead rooms to be async

### DIFF
--- a/api/scheduler_locks_handler_test.go
+++ b/api/scheduler_locks_handler_test.go
@@ -64,6 +64,7 @@ var _ = Describe("SchedulerLocksHandler", func() {
 				"maestro-lock-key-scheduler-name-config",
 				"maestro-lock-key-scheduler-name-downscaling",
 				"maestro-lock-key-scheduler-name-termination",
+				"maestro-lock-key-scheduler-name-remove-dead-rooms",
 			} {
 				mockPipeline.EXPECT().TTL(lockKey).
 					Return(redis.NewDurationResult(9*time.Second, nil))
@@ -76,12 +77,13 @@ var _ = Describe("SchedulerLocksHandler", func() {
 			Expect(recorder.Code).To(Equal(http.StatusOK))
 			var locks []models.SchedulerLock
 			json.Unmarshal(recorder.Body.Bytes(), &locks)
-			Expect(locks).To(HaveLen(3))
+			Expect(locks).To(HaveLen(4))
 
 			for i, lockKey := range []string{
 				"maestro-lock-key-scheduler-name-config",
 				"maestro-lock-key-scheduler-name-downscaling",
 				"maestro-lock-key-scheduler-name-termination",
+				"maestro-lock-key-scheduler-name-remove-dead-rooms",
 			} {
 				Expect(locks[i].Key).To(Equal(lockKey))
 				Expect(locks[i].TTLInSec).To(Equal(int64(9)))
@@ -94,6 +96,7 @@ var _ = Describe("SchedulerLocksHandler", func() {
 				"maestro-lock-key-scheduler-name-config",
 				"maestro-lock-key-scheduler-name-downscaling",
 				"maestro-lock-key-scheduler-name-termination",
+				"maestro-lock-key-scheduler-name-remove-dead-rooms",
 			} {
 				mockPipeline.EXPECT().TTL(lockKey).
 					Return(redis.NewDurationResult(time.Duration(0), redis.Nil))
@@ -111,6 +114,7 @@ var _ = Describe("SchedulerLocksHandler", func() {
 				"maestro-lock-key-scheduler-name-config",
 				"maestro-lock-key-scheduler-name-downscaling",
 				"maestro-lock-key-scheduler-name-termination",
+				"maestro-lock-key-scheduler-name-remove-dead-rooms",
 			} {
 				Expect(locks[i].Key).To(Equal(lockKey))
 				Expect(locks[i].TTLInSec).To(Equal(int64(0)))

--- a/models/scheduler.go
+++ b/models/scheduler.go
@@ -535,6 +535,7 @@ func ListSchedulerLocksKeys(prefix, schedulerName string) []string {
 		GetSchedulerConfigLockKey(prefix, schedulerName),
 		GetSchedulerDownScalingLockKey(prefix, schedulerName),
 		GetSchedulerTerminationLockKey(prefix, schedulerName),
+		GetSchedulerRemoveDeadRoomsKey(prefix, schedulerName),
 	}
 }
 
@@ -559,6 +560,11 @@ func GetSchedulerDownScalingLockKey(prefix, schedulerName string) string {
 // GetSchedulerTerminationLockKey returns the key of the downscaling lock
 func GetSchedulerTerminationLockKey(prefix, schedulerName string) string {
 	return fmt.Sprintf("%s-%s-termination", prefix, schedulerName)
+}
+
+// GetSchedulerRemoveDeadRoomsKey returns the key of the downscaling lock
+func GetSchedulerRemoveDeadRoomsKey(prefix, schedulerName string) string {
+	return fmt.Sprintf("%s-%s-remove-dead-rooms", prefix, schedulerName)
 }
 
 // ListSchedulerReleases returns the list of releases of a scheduler

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -288,18 +288,18 @@ func (w *Watcher) reportRoomsStatusesRoutine() {
 }
 
 func (w *Watcher) watchRooms() error {
-	_, _ = w.WithDownscalingLock(
-		w.Logger.WithFields(logrus.Fields{
-			"operation": "watcher.watchRooms.EnsureCorrectRooms",
-		}),
-		w.EnsureCorrectRooms,
-	)
-
 	go w.WithRemoveDeadRoomsLock(
 		w.Logger.WithFields(logrus.Fields{
 			"operation": "watcher.watchRooms.RemoveDeadRooms",
 		}),
 		w.RemoveDeadRooms,
+	)
+
+	_, _ = w.WithDownscalingLock(
+		w.Logger.WithFields(logrus.Fields{
+			"operation": "watcher.watchRooms.EnsureCorrectRooms",
+		}),
+		w.EnsureCorrectRooms,
 	)
 
 	_, _ = w.WithTerminationLock(

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -430,11 +430,15 @@ var _ = Describe("Watcher", func() {
 			// EnterCriticalSection (lock done by redis-lock)
 			terminationLockKey := fmt.Sprintf("maestro-lock-key-%s-termination", configYaml.Name)
 			downscalingLockKey := fmt.Sprintf("maestro-lock-key-%s-downscaling", configYaml.Name)
+			removeDeadRoomsLockKey := fmt.Sprintf("maestro-lock-key-%s-remove-dead-rooms", configYaml.Name)
 			mockRedisClient.EXPECT().
 				SetNX(terminationLockKey, gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(true, nil)).
 				AnyTimes()
 			mockRedisClient.EXPECT().
 				SetNX(downscalingLockKey, gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(true, nil)).
+				AnyTimes()
+			mockRedisClient.EXPECT().
+				SetNX(removeDeadRoomsLockKey, gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(true, nil)).
 				AnyTimes()
 
 			// DeleteRoomsNoPingSince
@@ -512,6 +516,7 @@ var _ = Describe("Watcher", func() {
 			// LeaveCriticalSection (unlock done by redis-lock)
 			mockRedisClient.EXPECT().Eval(gomock.Any(), []string{terminationLockKey}, gomock.Any()).Return(redis.NewCmdResult(nil, nil)).AnyTimes()
 			mockRedisClient.EXPECT().Eval(gomock.Any(), []string{downscalingLockKey}, gomock.Any()).Return(redis.NewCmdResult(nil, nil)).AnyTimes()
+			mockRedisClient.EXPECT().Eval(gomock.Any(), []string{removeDeadRoomsLockKey}, gomock.Any()).Return(redis.NewCmdResult(nil, nil)).AnyTimes()
 
 			Expect(func() {
 				go func() {
@@ -539,6 +544,8 @@ var _ = Describe("Watcher", func() {
 				SetNX("maestro-lock-key-my-scheduler-termination", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, errors.New("some error in lock"))).AnyTimes()
 			mockRedisClient.EXPECT().
 				SetNX("maestro-lock-key-my-scheduler-downscaling", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, errors.New("some error in lock"))).AnyTimes()
+			mockRedisClient.EXPECT().
+				SetNX("maestro-lock-key-my-scheduler-remove-dead-rooms", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, errors.New("some error in lock"))).AnyTimes()
 
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline).AnyTimes()
 			creating := models.GetRoomStatusSetRedisKey(name, "creating")
@@ -579,6 +586,7 @@ var _ = Describe("Watcher", func() {
 			// EnterCriticalSection (lock done by redis-lock)
 			mockRedisClient.EXPECT().SetNX("maestro-lock-key-my-scheduler-downscaling", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, nil)).AnyTimes()
 			mockRedisClient.EXPECT().SetNX("maestro-lock-key-my-scheduler-termination", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, nil)).AnyTimes()
+			mockRedisClient.EXPECT().SetNX("maestro-lock-key-my-scheduler-remove-dead-rooms", gomock.Any(), gomock.Any()).Return(redis.NewBoolResult(false, nil)).AnyTimes()
 
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline).AnyTimes()
 			creating := models.GetRoomStatusSetRedisKey(name, "creating")


### PR DESCRIPTION
Context: The RemoveDeadRooms flow is responsible for removing rooms that haven't send ping information or hit the occupied timeout. In some cases, deleting those "malfunctioning" rooms can take a long time, making the entire scheduler very unstable (having a low number of rooms or not being able to update the scheduler).

Since the RemoveDeadRooms don't affect the other parts of the flow (AutoScale and EnsureCorrectRooms), we're making it not block the `watchRooms` flow. In addition to making it async, we're creating a new lock specific for the `RemoveDeadRooms` flow to prevent multiple of them from running in parallel and enable the other parts of the flow to execute.