### PR TITLE
Add "preventRoomsCreationWithError" option to scheduler

### DIFF
--- a/api/scheduler_diff_handler_test.go
+++ b/api/scheduler_diff_handler_test.go
@@ -67,7 +67,7 @@ image: image2`
 
 			Expect(response["version1"]).To(Equal("v1.0"))
 			Expect(response["version2"]).To(Equal("v0.1"))
-			Expect(response["diff"]).To(Equal("name: scheduler-name\ngame: \"\"\nshutdownTimeout: 0\nautoscaling: null\naffinity: \"\"\ntoleration: \"\"\noccupiedTimeout: 0\nforwarders: {}\nauthorizedUsers: []\nportRange: null\nimage: image\x1b[31m2\x1b[0m\x1b[32m1\x1b[0m\nimagePullPolicy: \"\"\nports: []\nlimits: null\nrequests: null\nenv: []\ncmd: []\ncontainers: []\n"))
+			Expect(response["diff"]).To(Equal("name: scheduler-name\ngame: \"\"\nshutdownTimeout: 0\nautoscaling: null\naffinity: \"\"\ntoleration: \"\"\noccupiedTimeout: 0\nforwarders: {}\nauthorizedUsers: []\nportRange: null\npreventRoomsCreationWithError: true\nimage: image\x1b[31m2\x1b[0m\x1b[32m1\x1b[0m\nimagePullPolicy: \"\"\nports: []\nlimits: null\nrequests: null\nenv: []\ncmd: []\ncontainers: []\n"))
 		})
 
 		It("should return schedulers diff between v2 and previous", func() {
@@ -86,7 +86,7 @@ image: image2`
 
 			Expect(response["version1"]).To(Equal("v2.0"))
 			Expect(response["version2"]).To(Equal("v1.0"))
-			Expect(response["diff"]).To(Equal("name: scheduler-name\ngame: \"\"\nshutdownTimeout: 0\nautoscaling: null\naffinity: \"\"\ntoleration: \"\"\noccupiedTimeout: 0\nforwarders: {}\nauthorizedUsers: []\nportRange: null\nimage: image\x1b[31m2\x1b[0m\x1b[32m1\x1b[0m\nimagePullPolicy: \"\"\nports: []\nlimits: null\nrequests: null\nenv: []\ncmd: []\ncontainers: []\n"))
+			Expect(response["diff"]).To(Equal("name: scheduler-name\ngame: \"\"\nshutdownTimeout: 0\nautoscaling: null\naffinity: \"\"\ntoleration: \"\"\noccupiedTimeout: 0\nforwarders: {}\nauthorizedUsers: []\nportRange: null\npreventRoomsCreationWithError: true\nimage: image\x1b[31m2\x1b[0m\x1b[32m1\x1b[0m\nimagePullPolicy: \"\"\nports: []\nlimits: null\nrequests: null\nenv: []\ncmd: []\ncontainers: []\n"))
 		})
 
 		It("should return schedulers diff between v2 and v1", func() {
@@ -106,7 +106,7 @@ image: image2`
 
 			Expect(response["version1"]).To(Equal("v2.0"))
 			Expect(response["version2"]).To(Equal("v1.0"))
-			Expect(response["diff"]).To(Equal("name: scheduler-name\ngame: \"\"\nshutdownTimeout: 0\nautoscaling: null\naffinity: \"\"\ntoleration: \"\"\noccupiedTimeout: 0\nforwarders: {}\nauthorizedUsers: []\nportRange: null\nimage: image\x1b[31m2\x1b[0m\x1b[32m1\x1b[0m\nimagePullPolicy: \"\"\nports: []\nlimits: null\nrequests: null\nenv: []\ncmd: []\ncontainers: []\n"))
+			Expect(response["diff"]).To(Equal("name: scheduler-name\ngame: \"\"\nshutdownTimeout: 0\nautoscaling: null\naffinity: \"\"\ntoleration: \"\"\noccupiedTimeout: 0\nforwarders: {}\nauthorizedUsers: []\nportRange: null\npreventRoomsCreationWithError: true\nimage: image\x1b[31m2\x1b[0m\x1b[32m1\x1b[0m\nimagePullPolicy: \"\"\nports: []\nlimits: null\nrequests: null\nenv: []\ncmd: []\ncontainers: []\n"))
 		})
 
 		It("should return error if version1 not found", func() {

--- a/api/scheduler_handler_test.go
+++ b/api/scheduler_handler_test.go
@@ -1442,6 +1442,7 @@ containers:
   env: []
   cmd: []
 portRange: null
+preventRoomsCreationWithError: true
 `))
 			})
 

--- a/api/scheduler_rollback_handler_test.go
+++ b/api/scheduler_rollback_handler_test.go
@@ -156,7 +156,7 @@ autoscaling:
 			var response map[string]interface{}
 			json.Unmarshal(recorder.Body.Bytes(), &response)
 			Expect(response).To(HaveKeyWithValue("code", "MAE-002"))
-			Expect(response).To(HaveKeyWithValue("description", "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `invalid...` into models.ConfigYAML"))
+			Expect(response).To(HaveKeyWithValue("description", "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `invalid...` into models.rawConfig"))
 			Expect(response).To(HaveKeyWithValue("error", "parse yaml error"))
 			Expect(response).To(HaveKeyWithValue("success", false))
 		})

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -395,13 +395,13 @@ func ScaleUp(
 		return fmt.Errorf("failed to load scheduler configuration: %w", err)
 	}
 
-	hasNotReadyPods, err := checkNotReadyPods(config, redisClient, scheduler.Name, configYAML.PreventRoomsCreationWithError, mr)
+	notReadyPods, err := hasNotReadyPods(config, redisClient, scheduler.Name, configYAML.PreventRoomsCreationWithError, mr)
 	if err != nil {
 		return fmt.Errorf("failed to list pending or failed pods: %w", err)
 	}
 
-	if hasNotReadyPods {
-		return errors.New("scheduler has pods not ready (pending or with error)")
+	if notReadyPods {
+		return errors.New("scheduler has not ready pods (pending or with error)")
 	}
 
 	amount, err = SetScalingAmount(

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1657,7 +1657,7 @@ cmd:
 
 			err = controller.ScaleUp(logger, roomManager, mr, mockDb, mockRedisClient, clientset, scheduler, amount, timeoutSec, true, config, true)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("scheduler has pods not ready (pending or with error)"))
+			Expect(err.Error()).To(Equal("scheduler has not ready pods (pending or with error)"))
 		})
 
 		It("should return error and not scale up if there are failed pods and preventRoomsCreationWithError = true", func() {
@@ -1699,7 +1699,7 @@ cmd:
 
 			err = controller.ScaleUp(logger, roomManager, mr, mockDb, mockRedisClient, clientset, scheduler, amount, timeoutSec, true, config, true)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("scheduler has pods not ready (pending or with error)"))
+			Expect(err.Error()).To(Equal("scheduler has not ready pods (pending or with error)"))
 		})
 
 		It("should scale up if there are failed pods and scheduler has preventRoomsCreationWithError = false", func() {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -325,6 +325,69 @@ autoscaling:
       time: 200
     cooldown: 60
 `
+	yamlWithPreventPodsCreationOnErrorFalse = `
+name: controller-name
+game: controller
+affinity: maestro-dedicated
+toleration: maestro
+shutdownTimeout: 20
+autoscaling:
+  min: 5
+  up:
+    delta: 2
+    trigger:
+      usage: 60
+      time: 100
+    cooldown: 200
+  down:
+    delta: 1
+    trigger:
+      usage: 30
+      time: 500
+    cooldown: 500
+containers:
+- name: container1
+  image: controller/controller:v123
+  ports:
+    - containerPort: 1234
+      protocol: UDP
+      name: port1
+    - containerPort: 7654
+      protocol: TCP
+      name: port2
+  limits:
+    memory: "66Mi"
+    cpu: "2"
+  requests:
+    memory: "66Mi"
+    cpu: "2"
+  env:
+    - name: MY_ENV_VAR
+      value: myvalue
+  cmd:
+    - "./room"
+- name: container2
+  image: helper/helper:v1
+  ports:
+    - containerPort: 1235
+      protocol: UDP
+      name: port3
+    - containerPort: 7655
+      protocol: TCP
+      name: port4
+  limits:
+    memory: "66Mi"
+    cpu: "2"
+  requests:
+    memory: "66Mi"
+    cpu: "2"
+  env:
+    - name: MY_ENV_VAR
+      value: myvalue
+  cmd:
+    - "./helper"
+preventRoomsCreationWithError: false
+`
 )
 
 var _ = Describe("Controller", func() {
@@ -1594,10 +1657,10 @@ cmd:
 
 			err = controller.ScaleUp(logger, roomManager, mr, mockDb, mockRedisClient, clientset, scheduler, amount, timeoutSec, true, config, true)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("there are pending or failed pods"))
+			Expect(err.Error()).To(Equal("scheduler has pods not ready (pending or with error)"))
 		})
 
-		It("should return error and not scale up if there are failed pods", func() {
+		It("should return error and not scale up if there are failed pods and preventRoomsCreationWithError = true", func() {
 			amount := 5
 			var configYaml1 models.ConfigYAML
 			err := yaml.Unmarshal([]byte(yaml1), &configYaml1)
@@ -1620,9 +1683,12 @@ cmd:
 						},
 					}
 				}
+
+
 				jsonBytes, err := pod.MarshalToRedis()
 				Expect(err).NotTo(HaveOccurred())
 				pods = append(pods, pod.Name, string(jsonBytes))
+
 			}
 
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
@@ -1633,7 +1699,56 @@ cmd:
 
 			err = controller.ScaleUp(logger, roomManager, mr, mockDb, mockRedisClient, clientset, scheduler, amount, timeoutSec, true, config, true)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("there are pending or failed pods"))
+			Expect(err.Error()).To(Equal("scheduler has pods not ready (pending or with error)"))
+		})
+
+		It("should scale up if there are failed pods and scheduler has preventRoomsCreationWithError = false", func() {
+			amount := 5
+			currentNumPods := 5
+			var configYaml1 models.ConfigYAML
+			err := yaml.Unmarshal([]byte(yamlWithPreventPodsCreationOnErrorFalse), &configYaml1)
+			Expect(err).NotTo(HaveOccurred())
+			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, yamlWithPreventPodsCreationOnErrorFalse)
+
+			err = mt.MockSetScallingAmount(
+				mockRedisClient,
+				mockPipeline,
+				mockDb,
+				clientset,
+				&configYaml1,
+				currentNumPods,
+				yamlWithPreventPodsCreationOnErrorFalse,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			pods := make([]*models.Pod, currentNumPods)
+			for i := 0; i < currentNumPods; i++ {
+				pod := &models.Pod{}
+				pod.Name = fmt.Sprintf("room-%d", i)
+				pod.Status.Phase = v1.PodRunning
+				if i == 0 {
+					pod.Status.ContainerStatuses = []v1.ContainerStatus{
+						{
+							State: v1.ContainerState{
+								Waiting: &v1.ContainerStateWaiting{
+									Reason: "ErrImagePull",
+								},
+							},
+						},
+					}
+				}
+
+				pods[i] = pod
+			}
+
+			mt.MockScaleUpWithCurrentPods(mockPipeline, mockRedisClient, configYaml1.Name, amount, pods)
+
+			err = controller.ScaleUp(logger, roomManager, mr, mockDb, mockRedisClient, clientset, scheduler, amount, timeoutSec, true, config, true)
+			Expect(err).NotTo(HaveOccurred())
+
+			podsList, err := clientset.CoreV1().Pods(configYaml1.Name).List(metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podsList.Items).To(HaveLen(amount))
 		})
 
 		It("should scale up to max if scaling amount is higher than max", func() {
@@ -6903,7 +7018,7 @@ containers:
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should return error when a pod is with error", func() {
+		It("should return error when a pod is with error and preventRoomsCreationWithError = true", func() {
 			pods := []*models.Pod{
 				&models.Pod{Name: "room-1"},
 			}
@@ -6944,6 +7059,86 @@ containers:
 			Expect(timeoutErr).ToNot(HaveOccurred())
 			Expect(cancelErr).ToNot(HaveOccurred())
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not return error when it suceeds with error pods and preventRoomsCreationWithError = false", func() {
+			pods := []*models.Pod{
+				&models.Pod{Name: "room-1"},
+			}
+
+			var configYaml1 models.ConfigYAML
+			_ = yaml.Unmarshal([]byte(yamlWithPreventPodsCreationOnErrorFalse), &configYaml1)
+
+			scheduler := models.NewScheduler(configYaml1.Name, configYaml1.Game, string(configYaml1.ToYAML()))
+
+			mockRedisClient.EXPECT().
+				HGetAll(opManager.GetOperationKey()).
+				Return(goredis.NewStringStringMapResult(map[string]string{
+					"description": models.OpManagerRollingUpdate,
+				}, nil)).AnyTimes()
+
+			mt.MockCreateRoomsAnyTimes(mockRedisClient, mockPipeline, &configYaml1, 1)
+			mt.MockGetPortsFromPoolAnyTimes(&configYaml1, mockRedisClient, mockPortChooser, workerPortRange, portStart, portEnd)
+
+			runningPodJSON := `{"name":"room-1", "status":{"phase":"Pending", "containerStatuses": [{"state": {"waiting": {"reason": "ErrImagePull"}}}]}}`
+			mockRedisClient.EXPECT().
+				HGet(models.GetPodMapRedisKey(configYaml1.Name), gomock.Any()).
+				Return(goredis.NewStringResult(runningPodJSON, nil)).
+				Times(2)
+
+			mt.MockAnyRunningPod(mockRedisClient, configYaml1.Name, 2)
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().
+				SIsMember(models.GetRoomStatusSetRedisKey(configYaml1.Name, "ready"), gomock.Any()).
+				Return(goredis.NewBoolResult(true, nil))
+			mockPipeline.EXPECT().
+				SIsMember(models.GetRoomStatusSetRedisKey(configYaml1.Name, "occupied"), gomock.Any()).
+				Return(goredis.NewBoolResult(false, nil))
+			mockPipeline.EXPECT().Exec().Return(nil, nil)
+
+			runningPod := mt.MockRunningPod(mockRedisClient, configYaml1.Name, "room-1")
+
+			for _, pod := range pods {
+				podv1 := &v1.Pod{}
+				podv1.SetName(pod.Name)
+				podv1.SetNamespace(configYaml1.Name)
+				podv1.SetLabels(map[string]string{"version": "v1.0"})
+				_, err := clientset.CoreV1().Pods(configYaml1.Name).Create(podv1)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// Delete old rooms
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().HDel(models.GetPodMapRedisKey(configYaml1.Name), "room-1")
+			mockPipeline.EXPECT().Exec()
+
+			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline)
+			mockPipeline.EXPECT().SRem(models.GetInvalidRoomsKey(configYaml1.Name), []string{"room-1"})
+			mockPipeline.EXPECT().Exec()
+
+			mt.MockRemoveAnyRoomsFromRedisAnyTimes(mockRedisClient, mockPipeline, &configYaml1, nil, 1)
+			mt.MockPodNotFound(mockRedisClient, configYaml1.Name, "room-1").After(runningPod)
+
+			timeoutErr, cancelErr, err := controller.SegmentAndReplacePods(
+				logger,
+				roomManager,
+				mr,
+				clientset,
+				mockDb,
+				mockRedisClient,
+				time.Now().Add(time.Minute),
+				&configYaml1,
+				pods,
+				scheduler,
+				opManager,
+				10*time.Second,
+				10,
+				1,
+			)
+			Expect(timeoutErr).ToNot(HaveOccurred())
+			Expect(cancelErr).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -813,7 +813,7 @@ func waitForPods(
 	return nil
 }
 
-func checkNotReadyPods(
+func hasNotReadyPods(
 	config *viper.Viper,
 	redisClient redisinterfaces.RedisClient,
 	namespace string,

--- a/models/config_yaml_test.go
+++ b/models/config_yaml_test.go
@@ -94,7 +94,7 @@ containers:
     value: VALUE_1
 `)
 
-			result := `{"yaml":"name: scheduler-name\ngame: game\nshutdownTimeout: 0\nautoscaling: null\naffinity: \"\"\ntoleration: \"\"\noccupiedTimeout: 0\nforwarders: {}\nauthorizedUsers: []\ncontainers:\n- name: container1\n  image: nginx:alpine\n  imagePullPolicy: \"\"\n  ports:\n  - containerPort: 8080\n    protocol: TCP\n    name: tcp\n  limits:\n    cpu: 100m\n    memory: 100Mi\n  requests:\n    cpu: 50m\n    memory: 50Mi\n  env:\n  - name: ENV_1\n    value: VALUE_1\n  cmd:\n  - /bin/bash\n  - -c\n  - ./start.sh\nportRange: null\n"}`
+			result := `{"yaml":"name: scheduler-name\ngame: game\nshutdownTimeout: 0\nautoscaling: null\naffinity: \"\"\ntoleration: \"\"\noccupiedTimeout: 0\nforwarders: {}\nauthorizedUsers: []\ncontainers:\n- name: container1\n  image: nginx:alpine\n  imagePullPolicy: \"\"\n  ports:\n  - containerPort: 8080\n    protocol: TCP\n    name: tcp\n  limits:\n    cpu: 100m\n    memory: 100Mi\n  requests:\n    cpu: 50m\n    memory: 50Mi\n  env:\n  - name: ENV_1\n    value: VALUE_1\n  cmd:\n  - /bin/bash\n  - -c\n  - ./start.sh\nportRange: null\npreventRoomsCreationWithError: true\n"}`
 
 			Expect(string(configYaml.ToYAML())).To(Equal(result))
 		})
@@ -123,7 +123,7 @@ containers:
         fieldPath: status.IP
 `)
 
-			result := `{"yaml":"name: scheduler-name\ngame: game\nshutdownTimeout: 0\nautoscaling: null\naffinity: \"\"\ntoleration: \"\"\noccupiedTimeout: 0\nforwarders: {}\nauthorizedUsers: []\ncontainers:\n- name: container1\n  image: nginx:alpine\n  imagePullPolicy: \"\"\n  ports:\n  - containerPort: 8080\n    protocol: TCP\n    name: tcp\n  limits:\n    cpu: 100m\n    memory: 100Mi\n  requests:\n    cpu: 50m\n    memory: 50Mi\n  env:\n  - name: ENV_1\n    valueFrom:\n      fieldRef:\n        fieldPath: status.IP\n  cmd:\n  - /bin/bash\n  - -c\n  - ./start.sh\nportRange: null\n"}`
+			result := `{"yaml":"name: scheduler-name\ngame: game\nshutdownTimeout: 0\nautoscaling: null\naffinity: \"\"\ntoleration: \"\"\noccupiedTimeout: 0\nforwarders: {}\nauthorizedUsers: []\ncontainers:\n- name: container1\n  image: nginx:alpine\n  imagePullPolicy: \"\"\n  ports:\n  - containerPort: 8080\n    protocol: TCP\n    name: tcp\n  limits:\n    cpu: 100m\n    memory: 100Mi\n  requests:\n    cpu: 50m\n    memory: 50Mi\n  env:\n  - name: ENV_1\n    valueFrom:\n      fieldRef:\n        fieldPath: status.IP\n  cmd:\n  - /bin/bash\n  - -c\n  - ./start.sh\nportRange: null\npreventRoomsCreationWithError: true\n"}`
 
 			Expect(string(configYaml.ToYAML())).To(Equal(result))
 		})


### PR DESCRIPTION
Context: In #120, we introduced a behavior where Maestro would stop scaling or updating if it finds any pod with an error. In practice, we've seen that this is not desired in some situations, like when having an incident where some rooms could be in an error state while the rest keeps working.

We're adding a new configuration option for the scheduler called `preventRoomsCreationWithError`, which has two possible values:
* `true` (which is the default value): Will keep the current behavior of stopping pods creation when there is any error;
* `false`: Will do like previous versions of Maestro, keep scaling and updating the scheduler even if there are pods with error;