### PR TITLE
Fix: add rooms definition executor injection

### DIFF
--- a/internal/core/operations/add_rooms/add_rooms_definition.go
+++ b/internal/core/operations/add_rooms/add_rooms_definition.go
@@ -31,7 +31,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const operationName = "add_rooms"
+const OperationName = "add_rooms"
 
 type AddRoomsDefinition struct {
 	Amount int32 `json:"amount"`
@@ -42,7 +42,7 @@ func (d *AddRoomsDefinition) ShouldExecute(_ context.Context, _ []*operation.Ope
 }
 
 func (d *AddRoomsDefinition) Name() string {
-	return operationName
+	return OperationName
 }
 
 func (d *AddRoomsDefinition) Marshal() []byte {

--- a/internal/core/operations/add_rooms/add_rooms_executor.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor.go
@@ -46,5 +46,5 @@ func (e *AddRoomsExecutor) OnError(ctx context.Context, op *operation.Operation,
 }
 
 func (e *AddRoomsExecutor) Name() string {
-	return operationName
+	return OperationName
 }

--- a/internal/core/operations/create_scheduler/create_scheduler_definition.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_definition.go
@@ -28,7 +28,7 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 )
 
-const operationName = "create_scheduler"
+const OperationName = "create_scheduler"
 
 type CreateSchedulerDefinition struct{}
 
@@ -38,7 +38,7 @@ func (d *CreateSchedulerDefinition) ShouldExecute(_ context.Context, _ []*operat
 }
 
 func (d *CreateSchedulerDefinition) Name() string {
-	return operationName
+	return OperationName
 }
 
 func (d *CreateSchedulerDefinition) Marshal() []byte {

--- a/internal/core/operations/create_scheduler/create_scheduler_executor.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor.go
@@ -66,5 +66,5 @@ func (e *CreateSchedulerExecutor) OnError(ctx context.Context, op *operation.Ope
 }
 
 func (e *CreateSchedulerExecutor) Name() string {
-	return operationName
+	return OperationName
 }

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -24,17 +24,19 @@ package providers
 
 import (
 	"github.com/topfreegames/maestro/internal/core/operations"
+	"github.com/topfreegames/maestro/internal/core/operations/add_rooms"
 	"github.com/topfreegames/maestro/internal/core/operations/create_scheduler"
 	"github.com/topfreegames/maestro/internal/core/ports"
 )
 
-var createSchedulerOperationName = "create_scheduler"
-
 func ProvideDefinitionConstructors() map[string]operations.DefinitionConstructor {
 
 	definitionConstructors := map[string]operations.DefinitionConstructor{}
-	definitionConstructors[createSchedulerOperationName] = func() operations.Definition {
+	definitionConstructors[create_scheduler.OperationName] = func() operations.Definition {
 		return &create_scheduler.CreateSchedulerDefinition{}
+	}
+	definitionConstructors[add_rooms.OperationName] = func() operations.Definition {
+		return &add_rooms.AddRoomsDefinition{}
 	}
 
 	return definitionConstructors
@@ -44,7 +46,8 @@ func ProvideDefinitionConstructors() map[string]operations.DefinitionConstructor
 func ProvideExecutors(runtime ports.Runtime, schedulerStorage ports.SchedulerStorage) map[string]operations.Executor {
 
 	executors := map[string]operations.Executor{}
-	executors[createSchedulerOperationName] = create_scheduler.NewExecutor(runtime, schedulerStorage)
+	executors[create_scheduler.OperationName] = create_scheduler.NewExecutor(runtime, schedulerStorage)
+	executors[add_rooms.OperationName] = add_rooms.NewExecutor()
 
 	return executors
 


### PR DESCRIPTION
## Description

This PR aims to add `add_rooms` operation definition constructor and executor to wire in order to run the mocked operation in maestro worker.