### PR TITLE
Remove rooms executor

### DIFF
--- a/internal/core/operations/remove_rooms/metrics.go
+++ b/internal/core/operations/remove_rooms/metrics.go
@@ -22,44 +22,21 @@
 
 package remove_rooms
 
-import (
-	"context"
-	"encoding/json"
-	"fmt"
+import "github.com/topfreegames/maestro/internal/core/monitoring"
 
-	"github.com/topfreegames/maestro/internal/core/entities/operation"
-	"go.uber.org/zap"
+var (
+	deletionFailedTotal = monitoring.CreateCounterMetric(&monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "remove_rooms_operation_deletion_failed_total",
+		Help:      "Count of number of deletions failed on a remove rooms operation",
+		Labels: []string{
+			monitoring.LabelScheduler,
+			monitoring.LabelOperation,
+		},
+	})
 )
 
-const OperationName = "remove_rooms"
-
-type RemoveRoomsDefinition struct {
-	Amount int `json:"amount"`
-}
-
-func (d *RemoveRoomsDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
-	return true
-}
-
-func (d *RemoveRoomsDefinition) Name() string {
-	return OperationName
-}
-
-func (d *RemoveRoomsDefinition) Marshal() []byte {
-	bytes, err := json.Marshal(d)
-	if err != nil {
-		zap.L().With(zap.Error(err)).Error("error marshalling remove rooms operation definition")
-		return nil
-	}
-
-	return bytes
-}
-
-func (d *RemoveRoomsDefinition) Unmarshal(raw []byte) error {
-	err := json.Unmarshal(raw, d)
-	if err != nil {
-		return fmt.Errorf("error marshalling remove rooms operation definition: %w", err)
-	}
-
-	return nil
+func reportDeletionFailedTotal(schedulerName, operationID string) {
+	deletionFailedTotal.WithLabelValues(schedulerName, operationID).Inc()
 }

--- a/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
@@ -54,7 +54,7 @@ func TestExecute(t *testing.T) {
 	instanceStorageMock := instance_storage_mock.NewMockGameRoomInstanceStorage(mockCtrl)
 	runtimeMock := runtime_mock.NewMockRuntime(mockCtrl)
 
-	roomsManager := room_manager.NewRoomManager(clockMock, portAllocatorMock, roomStorageMock, instanceStorageMock, runtimeMock)
+	roomsManager := room_manager.NewRoomManager(clockMock, portAllocatorMock, roomStorageMock, instanceStorageMock, runtimeMock, room_manager.RoomManagerConfig{})
 	executor := NewExecutor(roomsManager)
 
 	t.Run("when there are no rooms to be deleted it returns without error", func(t *testing.T) {

--- a/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
@@ -90,7 +90,7 @@ func TestExecute(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("when any room failed to delete it returns without", func(t *testing.T) {
+	t.Run("when any room failed to delete it returns without error", func(t *testing.T) {
 		schedulerName := "test-scheduler"
 		definition := &RemoveRoomsDefinition{Amount: 2}
 		operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}

--- a/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
@@ -26,6 +26,7 @@ package remove_rooms
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -117,5 +118,16 @@ func TestExecute(t *testing.T) {
 
 		err := executor.Execute(ctx, operation, definition)
 		require.NoError(t, err)
+	})
+
+	t.Run("when list rooms has error returns with error", func(t *testing.T) {
+		definition := &RemoveRoomsDefinition{Amount: 2}
+		operation := &operation.Operation{ID: "random-uuid", SchedulerName: "test-scheduler"}
+
+		ctx := context.Background()
+		roomStorageMock.EXPECT().GetAllRoomIDs(ctx, operation.SchedulerName).Return(nil, errors.New("failed to list rooms"))
+
+		err := executor.Execute(ctx, operation, definition)
+		require.Error(t, err)
 	})
 }

--- a/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
@@ -1,0 +1,121 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//+build unit
+
+package remove_rooms
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	clock_mock "github.com/topfreegames/maestro/internal/adapters/clock/mock"
+	instance_storage_mock "github.com/topfreegames/maestro/internal/adapters/instance_storage/mock"
+	port_allocator_mock "github.com/topfreegames/maestro/internal/adapters/port_allocator/mock"
+	"github.com/topfreegames/maestro/internal/adapters/room_storage/mock"
+	runtime_mock "github.com/topfreegames/maestro/internal/adapters/runtime/mock"
+
+	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
+	"github.com/topfreegames/maestro/internal/core/services/room_manager"
+)
+
+func TestExecute(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	clockMock := clock_mock.NewFakeClock(time.Now())
+	portAllocatorMock := port_allocator_mock.NewMockPortAllocator(mockCtrl)
+	roomStorageMock := mock.NewMockRoomStorage(mockCtrl)
+	instanceStorageMock := instance_storage_mock.NewMockGameRoomInstanceStorage(mockCtrl)
+	runtimeMock := runtime_mock.NewMockRuntime(mockCtrl)
+
+	roomsManager := room_manager.NewRoomManager(clockMock, portAllocatorMock, roomStorageMock, instanceStorageMock, runtimeMock)
+	executor := NewExecutor(roomsManager)
+
+	t.Run("when there are no rooms to be deleted it returns without error", func(t *testing.T) {
+		definition := &RemoveRoomsDefinition{Amount: 2}
+		operation := &operation.Operation{ID: "random-uuid", SchedulerName: "test-scheduler"}
+
+		ctx := context.Background()
+		roomStorageMock.EXPECT().GetAllRoomIDs(ctx, operation.SchedulerName).Return([]string{}, nil)
+
+		err := executor.Execute(ctx, operation, definition)
+		require.NoError(t, err)
+	})
+
+	t.Run("when rooms are successfully deleted it returns without error", func(t *testing.T) {
+		schedulerName := "test-scheduler"
+		definition := &RemoveRoomsDefinition{Amount: 1}
+		operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+
+		availableRooms := []*game_room.GameRoom{
+			{ID: "first-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady},
+			{ID: "second-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady},
+		}
+		gameRoomInstance := &game_room.Instance{}
+
+		ctx := context.Background()
+		roomStorageMock.EXPECT().GetAllRoomIDs(ctx, operation.SchedulerName).Return([]string{availableRooms[0].ID, availableRooms[1].ID}, nil)
+		roomStorageMock.EXPECT().GetRoom(ctx, schedulerName, availableRooms[0].ID).Return(availableRooms[0], nil)
+
+		instanceStorageMock.EXPECT().GetInstance(ctx, schedulerName, availableRooms[0].ID).Return(gameRoomInstance, nil)
+		runtimeMock.EXPECT().DeleteGameRoomInstance(ctx, gameRoomInstance).Return(nil)
+		roomStorageMock.EXPECT().UpdateRoom(ctx, availableRooms[0]).Return(nil)
+
+		err := executor.Execute(ctx, operation, definition)
+		require.NoError(t, err)
+	})
+
+	t.Run("when any room failed to delete it returns without", func(t *testing.T) {
+		schedulerName := "test-scheduler"
+		definition := &RemoveRoomsDefinition{Amount: 2}
+		operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+
+		availableRooms := []*game_room.GameRoom{
+			{ID: "first-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady},
+			{ID: "second-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady},
+		}
+		gameRoomInstance := &game_room.Instance{}
+
+		ctx := context.Background()
+		roomStorageMock.EXPECT().GetAllRoomIDs(ctx, operation.SchedulerName).Return([]string{availableRooms[0].ID, availableRooms[1].ID}, nil)
+		roomStorageMock.EXPECT().GetRoom(ctx, schedulerName, availableRooms[0].ID).Return(availableRooms[0], nil)
+		roomStorageMock.EXPECT().GetRoom(ctx, schedulerName, availableRooms[1].ID).Return(availableRooms[1], nil)
+
+		// first one is successfull
+		instanceStorageMock.EXPECT().GetInstance(ctx, schedulerName, availableRooms[0].ID).Return(gameRoomInstance, nil)
+		runtimeMock.EXPECT().DeleteGameRoomInstance(ctx, gameRoomInstance).Return(nil)
+		roomStorageMock.EXPECT().UpdateRoom(ctx, availableRooms[0]).Return(nil)
+
+		// second one fails on runtime
+		instanceStorageMock.EXPECT().GetInstance(ctx, schedulerName, availableRooms[1].ID).Return(gameRoomInstance, nil)
+		runtimeMock.EXPECT().DeleteGameRoomInstance(ctx, gameRoomInstance).Return(porterrors.ErrUnexpected)
+
+		err := executor.Execute(ctx, operation, definition)
+		require.NoError(t, err)
+	})
+}

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -152,7 +152,7 @@ func (m *RoomManager) UpdateRoom(ctx context.Context, gameRoom *game_room.GameRo
 // function can return less rooms than the `amount` since it might not have
 // enough rooms on the scheduler.
 func (m *RoomManager) ListRoomsWithDeletionPriority(ctx context.Context, schedulerName string, amount int) ([]*game_room.GameRoom, error) {
-	// TODO(gabrielcorado): implement the priority. for now, we're list all
+	// TODO(gabrielcorado): implement the priority. for now, we're listing all
 	// rooms and taking the necessary "amount".
 	schedulerRoomsIDs, err := m.roomStorage.GetAllRoomIDs(ctx, schedulerName)
 	if err != nil {

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -138,7 +138,7 @@ func TestRoomManager_CreateRoom(t *testing.T) {
 		portAllocator.EXPECT().Allocate(nil, 2).Return([]int32{5000, 6000}, nil)
 		runtime.EXPECT().CreateGameRoomInstance(context.Background(), scheduler.Name, game_room.Spec{
 			Containers: []game_room.Container{container1, container2},
-		}).Return(nil, errors.NewErrUnexpected("error create game room instance"))
+		}).Return(nil, porterrors.NewErrUnexpected("error create game room instance"))
 
 		room, instance, err := roomManager.CreateRoom(context.Background(), scheduler)
 		require.Error(t, err)
@@ -152,7 +152,7 @@ func TestRoomManager_CreateRoom(t *testing.T) {
 			Containers: []game_room.Container{container1, container2},
 		}).Return(&gameRoomInstance, nil)
 
-		roomStorage.EXPECT().CreateRoom(context.Background(), &gameRoom).Return(errors.NewErrUnexpected("error storing room on redis"))
+		roomStorage.EXPECT().CreateRoom(context.Background(), &gameRoom).Return(porterrors.NewErrUnexpected("error storing room on redis"))
 
 		room, instance, err := roomManager.CreateRoom(context.Background(), scheduler)
 		require.Error(t, err)
@@ -161,7 +161,7 @@ func TestRoomManager_CreateRoom(t *testing.T) {
 	})
 
 	t.Run("when game room creation fails while allocating ports then it returns nil with proper error", func(t *testing.T) {
-		portAllocator.EXPECT().Allocate(nil, 2).Return(nil, errors.NewErrInvalidArgument("not enough ports to allocate"))
+		portAllocator.EXPECT().Allocate(nil, 2).Return(nil, porterrors.NewErrInvalidArgument("not enough ports to allocate"))
 
 		room, instance, err := roomManager.CreateRoom(context.Background(), scheduler)
 		require.Error(t, err)
@@ -284,6 +284,7 @@ func TestRoomManager_ListRoomsWithDeletionPriority(t *testing.T) {
 		roomStorage,
 		instanceStorage,
 		runtime,
+		RoomManagerConfig{},
 	)
 
 	t.Run("when there are enough rooms it should return the specified number", func(t *testing.T) {

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -286,7 +286,7 @@ func TestRoomManager_ListRoomsWithDeletionPriority(t *testing.T) {
 		runtime,
 	)
 
-	t.Run("when there enough rooms it should return the specified number", func(t *testing.T) {
+	t.Run("when there are enough rooms it should return the specified number", func(t *testing.T) {
 		schedulerName := "test-scheduler"
 		availableRooms := []*game_room.GameRoom{
 			{ID: "first-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady},
@@ -312,7 +312,7 @@ func TestRoomManager_ListRoomsWithDeletionPriority(t *testing.T) {
 		require.Len(t, rooms, 2)
 	})
 
-	t.Run("when there error while fetch a room it returns error", func(t *testing.T) {
+	t.Run("when error happens while fetch a room it returns error", func(t *testing.T) {
 		schedulerName := "test-scheduler"
 		availableRooms := []*game_room.GameRoom{
 			{ID: "first-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady},


### PR DESCRIPTION
This is the first version of the `RemoveRooms` executor, where it will receive an `amount` of rooms to be removed/deleted, and it won't wait until they are completely removed.

This PR also introduces the `ListRoomsWithDeletionPriority`, which will be responsible for returning the rooms that should be deleted first. For now, this function has a simple implementation that returns all rooms without any rule on it.