### PR TITLE
Add auto scale events

### DIFF
--- a/models/scheduler_event.go
+++ b/models/scheduler_event.go
@@ -11,6 +11,22 @@ import (
 	"time"
 )
 
+const (
+	// AutoScale events.
+	StartAutoScaleEventName    = "AUTO_SCALE_START"
+	FinishedAutoScaleEventName = "AUTO_SCALE_FINISHED"
+	FailedAutoScaleEventName   = "AUTO_SCALE_FAILED"
+
+	// Metadata attributes name.
+
+	// ErrorMetadaName metadata containing an error.
+	ErrorMetadataName  = "error"
+	// TypeMetadataName type of the operation. For example, AutoScale has "up"
+	// and "down" types.
+	TypeMetadataName   = "type"
+	// AmountMetadataName amount of rooms that are going to be manipulated.
+	AmountMetadataName = "amount"
+)
 
 // SchedulerEvent is the struct that defines a maestro scheduler event
 type SchedulerEvent struct {
@@ -21,7 +37,7 @@ type SchedulerEvent struct {
 }
 
 // NewSchedulerEvent is the scheduler event constructor
-func NewSchedulerEvent(eventName, schedulerName string , metadata map[string]interface{}) *SchedulerEvent {
+func NewSchedulerEvent(eventName, schedulerName string, metadata map[string]interface{}) *SchedulerEvent {
 	return &SchedulerEvent{
 		Name:          eventName,
 		SchedulerName: schedulerName,

--- a/storage/mock/mock_scheduler_event_storage.go
+++ b/storage/mock/mock_scheduler_event_storage.go
@@ -33,7 +33,7 @@ func (_m *MockSchedulerEventStorage) EXPECT() *MockSchedulerEventStorageMockReco
 }
 
 // PersistSchedulerEvent mocks base method
-func (_m *MockSchedulerEventStorage) PersistSchedulerEvent(event models.SchedulerEvent) error {
+func (_m *MockSchedulerEventStorage) PersistSchedulerEvent(event *models.SchedulerEvent) error {
 	ret := _m.ctrl.Call(_m, "PersistSchedulerEvent", event)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/testing/models.go
+++ b/testing/models.go
@@ -7,6 +7,12 @@
 
 package testing
 
+import (
+	"fmt"
+
+	"github.com/topfreegames/maestro/models"
+)
+
 //FakeMetricsReporter is a fake metric reporter for testing
 type FakeMetricsReporter struct{}
 
@@ -33,3 +39,42 @@ func (mr FakeMetricsReporter) StartExternalSegment(key string) map[string]interf
 
 //EndExternalSegment mocks a metric reporter
 func (mr FakeMetricsReporter) EndExternalSegment(m map[string]interface{}) {}
+
+// SchedulerEventMatcher matches SchedulerEvent based on the information passed.
+type SchedulerEventMatcher struct {
+	ExpectedName          string
+	ExpectedSchedulerName string
+	ExpectedMetadata      map[string]interface{}
+}
+
+func (sem *SchedulerEventMatcher) Matches(x interface{}) bool {
+	event := x.(*models.SchedulerEvent)
+
+	if sem.ExpectedName != "" && event.Name != sem.ExpectedName {
+		return false
+	}
+
+	if sem.ExpectedSchedulerName != "" && event.SchedulerName != sem.ExpectedSchedulerName {
+		return false
+	}
+
+	if len(sem.ExpectedMetadata) > 0 {
+		for name, value := range sem.ExpectedMetadata {
+			eventMetadataValue, ok := event.Metadata[name]
+			if !ok || eventMetadataValue != value {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func (sem *SchedulerEventMatcher) String() string {
+	return fmt.Sprintf(
+		"expected event \"%s\", schedulerName \"%s\" and metadata %v",
+		sem.ExpectedName,
+		sem.ExpectedSchedulerName,
+		sem.ExpectedMetadata,
+	)
+}

--- a/watcher/watcher_suite_test.go
+++ b/watcher/watcher_suite_test.go
@@ -26,6 +26,7 @@ import (
 	eventforwardermock "github.com/topfreegames/maestro/eventforwarder/mock"
 	"github.com/topfreegames/maestro/mocks"
 	"github.com/topfreegames/maestro/models"
+	storagemock "github.com/topfreegames/maestro/storage/mock"
 	mtesting "github.com/topfreegames/maestro/testing"
 )
 
@@ -45,6 +46,7 @@ var (
 	mockEventForwarder    *eventforwardermock.MockEventForwarder
 	mr                    *models.MixedMetricsReporter
 	redisClient           *redis.Client
+	eventsStorage         *storagemock.MockSchedulerEventStorage
 	allStatus             = []string{
 		models.StatusCreating,
 		models.StatusReady,
@@ -86,6 +88,7 @@ var _ = BeforeEach(func() {
 	redisClient, err = redis.NewClient("extensions.redis", config, mockRedisClient, mockRedisTraceWrapper)
 	Expect(err).NotTo(HaveOccurred())
 	roomManager = &models.GameRoom{}
+	eventsStorage = storagemock.NewMockSchedulerEventStorage(mockCtrl)
 })
 
 var _ = AfterEach(func() {

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -368,7 +368,7 @@ var _ = Describe("Watcher", func() {
 				Do(func(scheduler *models.Scheduler, query string, modifier string) {
 					scheduler.YAML = yaml1
 				})
-			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, name, gameName, occupiedTimeout, []*eventforwarder.Info{})
+			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, name, gameName, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 			Expect(w.AutoScalingPeriod).To(Equal(autoScalingPeriod))
 			Expect(w.Config).To(Equal(config))
 			Expect(w.DB).To(Equal(mockDb))
@@ -387,7 +387,7 @@ var _ = Describe("Watcher", func() {
 				Do(func(scheduler *models.Scheduler, query string, modifier string) {
 					scheduler.YAML = yaml1
 				})
-			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, name, gameName, occupiedTimeout, []*eventforwarder.Info{})
+			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, name, gameName, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 			Expect(w.AutoScalingPeriod).To(Equal(10))
 			Expect(w.LockTimeoutMS).To(Equal(180000))
 		})
@@ -424,7 +424,7 @@ var _ = Describe("Watcher", func() {
 				configYaml.Name, [][]string{}, nil)
 
 			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset,
-				configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 			Expect(w).NotTo(BeNil())
 
 			// EnterCriticalSection (lock done by redis-lock)
@@ -491,6 +491,7 @@ var _ = Describe("Watcher", func() {
 			}
 
 			// ScaleUp
+			testing.MockScaleSchedulerEvents(eventsStorage, "up", 2, nil)
 			testing.MockScaleUp(mockPipeline, mockRedisClient, configYaml.Name, configYaml.AutoScaling.Up.Delta)
 
 			// UpdateScheduler
@@ -535,7 +536,7 @@ var _ = Describe("Watcher", func() {
 				Do(func(scheduler *models.Scheduler, query string, modifier string) {
 					scheduler.YAML = yaml1
 				}).AnyTimes()
-			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, name, gameName, occupiedTimeout, []*eventforwarder.Info{})
+			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, name, gameName, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 			Expect(w).NotTo(BeNil())
 			defer func() { w.Run = false }()
 
@@ -579,7 +580,7 @@ var _ = Describe("Watcher", func() {
 				Do(func(scheduler *models.Scheduler, query string, modifier string) {
 					scheduler.YAML = yaml1
 				}).AnyTimes()
-			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, name, gameName, occupiedTimeout, []*eventforwarder.Info{})
+			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, name, gameName, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 			Expect(w).NotTo(BeNil())
 			defer func() { w.Run = false }()
 
@@ -625,7 +626,7 @@ var _ = Describe("Watcher", func() {
 					scheduler.YAML = yaml1
 				})
 
-			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 			Expect(w).NotTo(BeNil())
 
 			mockCtrl = gomock.NewController(GinkgoT())
@@ -825,6 +826,7 @@ var _ = Describe("Watcher", func() {
 				configYaml.Game,
 				occupiedTimeout,
 				[]*eventforwarder.Info{},
+				eventsStorage,
 			)
 			Expect(w).NotTo(BeNil())
 
@@ -925,7 +927,7 @@ var _ = Describe("Watcher", func() {
 					Do(func(scheduler *models.Scheduler, query string, modifier string) {
 						scheduler.YAML = yaml1
 					})
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 				testing.CopyAutoScaling(configYaml.AutoScaling, mockAutoScaling)
 				testing.TransformLegacyInMetricsTrigger(mockAutoScaling)
@@ -967,6 +969,7 @@ var _ = Describe("Watcher", func() {
 				}
 
 				// ScaleUp
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 2, nil)
 				testing.MockScaleUp(mockPipeline, mockRedisClient, configYaml.Name, configYaml.AutoScaling.Up.Delta)
 
 				// UpdateScheduler
@@ -1004,6 +1007,7 @@ var _ = Describe("Watcher", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// ScaleUp
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 1, nil)
 				testing.MockScaleUp(mockPipeline, mockRedisClient, configYaml.Name, 1)
 
 				// UpdateScheduler
@@ -1050,6 +1054,7 @@ var _ = Describe("Watcher", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// ScaleUp
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 2, nil)
 				testing.MockScaleUp(mockPipeline, mockRedisClient, configYaml.Name, configYaml.AutoScaling.Up.Delta)
 
 				// UpdateScheduler
@@ -1077,6 +1082,7 @@ var _ = Describe("Watcher", func() {
 				testing.MockRoomDistribution(&configYaml, mockPipeline, mockRedisClient, expC)
 
 				// EnterCriticalSection (lock done by redis-lock)
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 1, nil)
 				downScalingLockKey := models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), configYaml.Name)
 				testing.MockRedisLock(mockRedisClient, downScalingLockKey, 5, true, nil)
 				testing.MockReturnRedisLock(mockRedisClient, downScalingLockKey, nil)
@@ -1252,6 +1258,7 @@ var _ = Describe("Watcher", func() {
 
 				scaleUpAmount := 5
 
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 1, nil)
 				testing.MockScaleUp(mockPipeline, mockRedisClient, configYaml.Name, 5)
 
 				err = testing.MockSetScallingAmount(
@@ -1420,6 +1427,7 @@ var _ = Describe("Watcher", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 2, nil)
 				testing.MockScaleUp(mockPipeline, mockRedisClient, configYaml.Name, configYaml.AutoScaling.Up.Delta)
 
 				// UpdateScheduler
@@ -1502,6 +1510,7 @@ var _ = Describe("Watcher", func() {
 					)
 				}
 
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 2, nil)
 				testing.MockScaleUp(mockPipeline, mockRedisClient, configYaml.Name, configYaml.AutoScaling.Up.Delta)
 
 				// UpdateScheduler
@@ -1570,6 +1579,7 @@ var _ = Describe("Watcher", func() {
 				downScalingLockKey := models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), configYaml.Name)
 				testing.MockRedisLock(mockRedisClient, downScalingLockKey, 5, true, nil)
 				testing.MockReturnRedisLock(mockRedisClient, downScalingLockKey, nil)
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 1, nil)
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
 					mockRedisClient,
@@ -1630,6 +1640,7 @@ var _ = Describe("Watcher", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 2, nil)
 				testing.MockScaleUp(mockPipeline, mockRedisClient, configYaml.Name, configYaml.AutoScaling.Up.Delta)
 
 				// UpdateScheduler
@@ -1665,6 +1676,7 @@ var _ = Describe("Watcher", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 2, nil)
 				testing.MockScaleUp(mockPipeline, mockRedisClient, configYaml.Name, configYaml.AutoScaling.Up.Delta)
 
 				// UpdateScheduler
@@ -1691,7 +1703,7 @@ var _ = Describe("Watcher", func() {
 					Do(func(scheduler *models.Scheduler, query string, modifier string) {
 						scheduler.YAML = yaml1
 					})
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 				testing.CopyAutoScaling(configYaml.AutoScaling, mockAutoScaling)
 				testing.TransformLegacyInMetricsTrigger(mockAutoScaling)
@@ -1753,7 +1765,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -1782,6 +1794,8 @@ var _ = Describe("Watcher", func() {
 					)
 				}
 
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 2, nil)
+
 				// Mock removal from redis ready set
 				testing.MockRedisReadyPop(mockPipeline, mockRedisClient, configYaml.Name, configYaml.AutoScaling.Down.Delta)
 				testing.MockPodsNotFound(mockRedisClient, configYaml.Name, configYaml.AutoScaling.Down.Delta)
@@ -1806,7 +1820,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -1840,7 +1854,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -1864,13 +1878,14 @@ var _ = Describe("Watcher", func() {
 				downScalingLockKey := models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), configYaml.Name)
 				testing.MockRedisLock(mockRedisClient, downScalingLockKey, 5, true, nil)
 				testing.MockReturnRedisLock(mockRedisClient, downScalingLockKey, nil)
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 2, nil)
 
 				// Mock scheduler
 				lastChangedAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -1924,7 +1939,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateOverdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -1957,13 +1972,14 @@ var _ = Describe("Watcher", func() {
 				downScalingLockKey := models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), configYaml.Name)
 				testing.MockRedisLock(mockRedisClient, downScalingLockKey, 5, true, nil)
 				testing.MockReturnRedisLock(mockRedisClient, downScalingLockKey, nil)
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 2, nil)
 
 				// Mock scheduler
 				lastChangedAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -1999,7 +2015,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2028,6 +2044,7 @@ var _ = Describe("Watcher", func() {
 				delta := occupied - threshold*total
 				delta = delta / threshold
 
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 3, nil)
 				// ScaleUp
 				testing.MockScaleUp(
 					mockPipeline, mockRedisClient,
@@ -2055,7 +2072,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -2089,7 +2106,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Down get usage percentages
@@ -2114,7 +2131,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2133,6 +2150,8 @@ var _ = Describe("Watcher", func() {
 						trigger.Time/w.AutoScalingPeriod, trigger.Usage, 90, 1,
 					)
 				}
+
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 3, nil)
 
 				// ScaleUp
 				testing.MockScaleUp(
@@ -2162,7 +2181,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateSubdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -2187,7 +2206,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateSubdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2197,6 +2216,8 @@ var _ = Describe("Watcher", func() {
 					expC,
 				)
 				Expect(err).NotTo(HaveOccurred())
+
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 6, nil)
 
 				// ScaleUp
 				testing.MockScaleUp(
@@ -2225,7 +2246,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateSubdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2235,6 +2256,8 @@ var _ = Describe("Watcher", func() {
 					expC,
 				)
 				Expect(err).NotTo(HaveOccurred())
+
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 1, nil)
 
 				// ScaleUp
 				testing.MockScaleUp(
@@ -2282,13 +2305,14 @@ var _ = Describe("Watcher", func() {
 				downScalingLockKey := models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), configYaml.Name)
 				testing.MockRedisLock(mockRedisClient, downScalingLockKey, 5, true, nil)
 				testing.MockReturnRedisLock(mockRedisClient, downScalingLockKey, nil)
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 2, nil)
 
 				// Mock scheduler
 				lastChangedAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2352,7 +2376,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -2386,7 +2410,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -2412,13 +2436,14 @@ var _ = Describe("Watcher", func() {
 				downScalingLockKey := models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), configYaml.Name)
 				testing.MockRedisLock(mockRedisClient, downScalingLockKey, 5, true, nil)
 				testing.MockReturnRedisLock(mockRedisClient, downScalingLockKey, nil)
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 2, nil)
 
 				// Mock scheduler
 				lastChangedAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2473,7 +2498,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateOverdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -2506,13 +2531,14 @@ var _ = Describe("Watcher", func() {
 				downScalingLockKey := models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), configYaml.Name)
 				testing.MockRedisLock(mockRedisClient, downScalingLockKey, 5, true, nil)
 				testing.MockReturnRedisLock(mockRedisClient, downScalingLockKey, nil)
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 2, nil)
 
 				// Mock scheduler
 				lastChangedAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2549,7 +2575,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2569,6 +2595,7 @@ var _ = Describe("Watcher", func() {
 					)
 				}
 
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 2, nil)
 				// ScaleUp
 				testing.MockScaleUp(
 					mockPipeline, mockRedisClient,
@@ -2596,7 +2623,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -2630,7 +2657,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Down get usage percentages
@@ -2655,7 +2682,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2674,6 +2701,8 @@ var _ = Describe("Watcher", func() {
 						trigger.Time/w.AutoScalingPeriod, trigger.Usage, 90, 1,
 					)
 				}
+
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 2, nil)
 
 				// ScaleUp
 				testing.MockScaleUp(
@@ -2703,7 +2732,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateSubdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -2728,7 +2757,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateSubdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2738,6 +2767,8 @@ var _ = Describe("Watcher", func() {
 					expC,
 				)
 				Expect(err).NotTo(HaveOccurred())
+
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 2, nil)
 
 				// ScaleUp
 				testing.MockScaleUp(
@@ -2766,7 +2797,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateSubdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2776,6 +2807,8 @@ var _ = Describe("Watcher", func() {
 					expC,
 				)
 				Expect(err).NotTo(HaveOccurred())
+
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 1, nil)
 
 				// ScaleUp
 				testing.MockScaleUp(
@@ -2820,13 +2853,14 @@ var _ = Describe("Watcher", func() {
 				downScalingLockKey := models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), configYaml.Name)
 				testing.MockRedisLock(mockRedisClient, downScalingLockKey, 5, true, nil)
 				testing.MockReturnRedisLock(mockRedisClient, downScalingLockKey, nil)
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 2, nil)
 
 				// Mock scheduler
 				lastChangedAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -2890,7 +2924,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -2924,7 +2958,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -2950,13 +2984,14 @@ var _ = Describe("Watcher", func() {
 				downScalingLockKey := models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), configYaml.Name)
 				testing.MockRedisLock(mockRedisClient, downScalingLockKey, 5, true, nil)
 				testing.MockReturnRedisLock(mockRedisClient, downScalingLockKey, nil)
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 2, nil)
 
 				// Mock scheduler
 				lastChangedAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -3011,7 +3046,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateOverdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -3044,13 +3079,14 @@ var _ = Describe("Watcher", func() {
 				downScalingLockKey := models.GetSchedulerDownScalingLockKey(config.GetString("watcher.lockKey"), configYaml.Name)
 				testing.MockRedisLock(mockRedisClient, downScalingLockKey, 5, true, nil)
 				testing.MockReturnRedisLock(mockRedisClient, downScalingLockKey, nil)
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 3, nil)
 
 				// Mock scheduler
 				lastChangedAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -3087,7 +3123,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -3116,6 +3152,7 @@ var _ = Describe("Watcher", func() {
 				delta := occupied - threshold*total
 				delta = delta / threshold
 
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 3, nil)
 				// ScaleUp
 				testing.MockScaleUp(
 					mockPipeline, mockRedisClient,
@@ -3143,7 +3180,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -3177,7 +3214,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Down get usage percentages
@@ -3202,7 +3239,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now().Add(-1 * time.Duration(configYaml.AutoScaling.Down.Cooldown+1) * time.Second)
 				testing.MockGetScheduler(mockDb, configYaml, models.StateInSync, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -3221,6 +3258,8 @@ var _ = Describe("Watcher", func() {
 						trigger.Time/w.AutoScalingPeriod, trigger.Usage, 90, 1,
 					)
 				}
+
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 10, nil)
 
 				// ScaleUp
 				testing.MockScaleUp(
@@ -3250,7 +3289,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateSubdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				// Mock MetricsTrigger Up get usage percentages
@@ -3275,7 +3314,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateSubdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -3294,6 +3333,8 @@ var _ = Describe("Watcher", func() {
 				threshold := float64(metricTrigger.Usage) / 100
 				delta := occupied - threshold*total
 				delta = delta / threshold
+
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 9, nil)
 
 				// ScaleUp
 				testing.MockScaleUp(
@@ -3322,7 +3363,7 @@ var _ = Describe("Watcher", func() {
 				lastScaleOpAt := time.Now()
 				testing.MockGetScheduler(mockDb, configYaml, models.StateSubdimensioned, yamlActive, lastChangedAt, lastScaleOpAt, 2)
 
-				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{})
+				w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 				Expect(w).NotTo(BeNil())
 
 				err := testing.MockSetScallingAmountWithRoomStatusCount(
@@ -3332,6 +3373,8 @@ var _ = Describe("Watcher", func() {
 					expC,
 				)
 				Expect(err).NotTo(HaveOccurred())
+
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 1, nil)
 
 				// ScaleUp
 				testing.MockScaleUp(
@@ -3410,6 +3453,7 @@ var _ = Describe("Watcher", func() {
 				}
 
 				// CPU
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 1, nil)
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Down.MetricsTrigger[0],
 					simSpec,
@@ -3419,6 +3463,7 @@ var _ = Describe("Watcher", func() {
 				simulateMetricsAutoscaling(simSpec, configYaml, yamlActive, models.StateInSync)
 
 				// Mem
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 1, nil)
 				simSpec.metricTypeToScale = models.MemAutoScalingPolicyType
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Down.MetricsTrigger[1],
@@ -3521,6 +3566,7 @@ var _ = Describe("Watcher", func() {
 				}
 
 				// CPU
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 3, nil)
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Down.MetricsTrigger[0],
 					simSpec,
@@ -3530,6 +3576,7 @@ var _ = Describe("Watcher", func() {
 				simulateMetricsAutoscaling(simSpec, configYaml, yamlActive, models.StateInSync)
 
 				// Mem
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 3, nil)
 				simSpec.metricTypeToScale = models.MemAutoScalingPolicyType
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Down.MetricsTrigger[1],
@@ -3590,6 +3637,7 @@ var _ = Describe("Watcher", func() {
 				}
 
 				// CPU
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 3, nil)
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Down.MetricsTrigger[0],
 					simSpec,
@@ -3599,6 +3647,7 @@ var _ = Describe("Watcher", func() {
 				simulateMetricsAutoscaling(simSpec, configYaml, yamlActive, models.StateInSync)
 
 				// Mem
+				testing.MockScaleSchedulerEvents(eventsStorage, "down", 3, nil)
 				simSpec.metricTypeToScale = models.MemAutoScalingPolicyType
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Down.MetricsTrigger[1],
@@ -3628,6 +3677,7 @@ var _ = Describe("Watcher", func() {
 				}
 
 				// CPU
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 1, nil)
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Up.MetricsTrigger[0],
 					simSpec,
@@ -3636,7 +3686,9 @@ var _ = Describe("Watcher", func() {
 				)
 				simulateMetricsAutoscaling(simSpec, configYaml, yamlActive, models.StateInSync)
 
+
 				// Mem
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 1, nil)
 				simSpec.metricTypeToScale = models.MemAutoScalingPolicyType
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Up.MetricsTrigger[1],
@@ -3730,6 +3782,7 @@ var _ = Describe("Watcher", func() {
 				}
 
 				// CPU
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 9, nil)
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Up.MetricsTrigger[0],
 					simSpec,
@@ -3739,6 +3792,7 @@ var _ = Describe("Watcher", func() {
 				simulateMetricsAutoscaling(simSpec, configYaml, yamlActive, models.StateInSync)
 
 				// Mem
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 7, nil)
 				simSpec.metricTypeToScale = models.MemAutoScalingPolicyType
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Up.MetricsTrigger[1],
@@ -3792,6 +3846,7 @@ var _ = Describe("Watcher", func() {
 				}
 
 				// CPU
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 11, nil)
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Up.MetricsTrigger[0],
 					simSpec,
@@ -3801,6 +3856,7 @@ var _ = Describe("Watcher", func() {
 				simulateMetricsAutoscaling(simSpec, configYaml, yamlActive, models.StateSubdimensioned)
 
 				// Mem
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 10, nil)
 				simSpec.metricTypeToScale = models.MemAutoScalingPolicyType
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Up.MetricsTrigger[1],
@@ -3829,6 +3885,7 @@ var _ = Describe("Watcher", func() {
 				}
 
 				// CPU
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 1, nil)
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Up.MetricsTrigger[0],
 					simSpec,
@@ -3838,6 +3895,7 @@ var _ = Describe("Watcher", func() {
 				simulateMetricsAutoscaling(simSpec, configYaml, yamlActive, models.StateInSync)
 
 				// Mem
+				testing.MockScaleSchedulerEvents(eventsStorage, "up", 1, nil)
 				simSpec.metricTypeToScale = models.MemAutoScalingPolicyType
 				simSpec.deltaExpected = calculateExpectedDelta(
 					configYaml.AutoScaling.Up.MetricsTrigger[1],
@@ -3890,6 +3948,7 @@ var _ = Describe("Watcher", func() {
 						Forwarder: mockEventForwarder,
 					},
 				},
+				eventsStorage,
 			)
 			Expect(w).NotTo(BeNil())
 
@@ -4196,7 +4255,9 @@ var _ = Describe("Watcher", func() {
 					configYaml.Name,
 					configYaml.Game,
 					occupiedTimeout,
-					[]*eventforwarder.Info{})
+					[]*eventforwarder.Info{},
+					eventsStorage,
+				)
 
 				Expect(func() { w.AddUtilizationMetricsToRedis() }).ShouldNot(Panic())
 			})
@@ -4267,7 +4328,9 @@ var _ = Describe("Watcher", func() {
 					configYaml.Name,
 					configYaml.Game,
 					occupiedTimeout,
-					[]*eventforwarder.Info{})
+					[]*eventforwarder.Info{},
+					eventsStorage,
+				)
 
 				Expect(func() { w.AddUtilizationMetricsToRedis() }).ShouldNot(Panic())
 			})
@@ -4315,7 +4378,9 @@ var _ = Describe("Watcher", func() {
 					configYaml.Name,
 					configYaml.Game,
 					occupiedTimeout,
-					[]*eventforwarder.Info{})
+					[]*eventforwarder.Info{},
+					eventsStorage,
+				)
 
 				Expect(func() { w.AddUtilizationMetricsToRedis() }).ShouldNot(Panic())
 			})
@@ -4338,7 +4403,7 @@ var _ = Describe("Watcher", func() {
 			w = watcher.NewWatcher(
 				config, logger, mr, mockDb, redisClient, clientset, metricsClientset,
 				configYaml.Name, configYaml.Game, occupiedTimeout,
-				[]*eventforwarder.Info{})
+				[]*eventforwarder.Info{}, eventsStorage)
 			Expect(w).NotTo(BeNil())
 
 			mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient).AnyTimes()
@@ -4568,7 +4633,7 @@ var _ = Describe("Watcher", func() {
 				})
 			w = watcher.NewWatcher(config, logger, mr, mockDb, redisClient,
 				clientset, metricsClientset, configYaml.Name, configYaml.Game, occupiedTimeout,
-				[]*eventforwarder.Info{})
+				[]*eventforwarder.Info{}, eventsStorage)
 			Expect(w).NotTo(BeNil())
 
 			r := reporters.GetInstance()

--- a/worker/worker_suite_test.go
+++ b/worker/worker_suite_test.go
@@ -24,6 +24,7 @@ import (
 	pgmocks "github.com/topfreegames/extensions/pg/mocks"
 	redismocks "github.com/topfreegames/extensions/redis/mocks"
 	"github.com/topfreegames/maestro/models"
+	storagemock "github.com/topfreegames/maestro/storage/mock"
 	mtesting "github.com/topfreegames/maestro/testing"
 )
 
@@ -39,6 +40,7 @@ var (
 	mockRedisClient  *redismocks.MockRedisClient
 	mr               *models.MixedMetricsReporter
 	redisClient      *redis.Client
+	eventsStorage    *storagemock.MockSchedulerEventStorage
 )
 
 func TestWorker(t *testing.T) {
@@ -64,6 +66,7 @@ var _ = BeforeEach(func() {
 	mockRedisClient.EXPECT().Ping()
 	redisClient, err = redis.NewClient("extensions.redis", config, mockRedisClient)
 	Expect(err).NotTo(HaveOccurred())
+	eventsStorage = storagemock.NewMockSchedulerEventStorage(mockCtrl)
 })
 
 var _ = AfterEach(func() {

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -161,7 +161,7 @@ cmd:
 						scheduler.YAML = yaml1
 					})
 			}
-			watcher1 := watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, schedulerNames[0], "", occupiedTimeout, []*eventforwarder.Info{})
+			watcher1 := watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, schedulerNames[0], "", occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 			w.Watchers[watcher1.SchedulerName] = watcher1
 			Expect(w.Watchers[schedulerNames[0]].Run).To(BeFalse())
 
@@ -189,10 +189,10 @@ cmd:
 						scheduler.YAML = yaml1
 					})
 			}
-			watcher1 := watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, schedulerNames[0], "", occupiedTimeout, []*eventforwarder.Info{})
+			watcher1 := watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, schedulerNames[0], "", occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 			w.Watchers[watcher1.SchedulerName] = watcher1
 			Expect(w.Watchers[schedulerNames[0]].Run).To(BeFalse())
-			watcher2 := watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, schedulerNames[1], "", occupiedTimeout, []*eventforwarder.Info{})
+			watcher2 := watcher.NewWatcher(config, logger, mr, mockDb, redisClient, clientset, metricsClientset, schedulerNames[1], "", occupiedTimeout, []*eventforwarder.Info{}, eventsStorage)
 			watcher2.Run = true
 			w.Watchers[watcher2.SchedulerName] = watcher2
 			Expect(w.Watchers[schedulerNames[1]].Run).To(BeTrue())


### PR DESCRIPTION
The following events were added to the `AutoScale` process:
* `AUTO_SCALE_STARTED`: sent when a new autoscale is going to happen. There is a `type` to define if it is a scale `down` or `up`, and `amount` with the number of rooms that will be added or removed;
* `AUTO_SCALE_FINISHED`: sent when a scale finishes with success;
* `AUTO_SCALE_FAILED`: when a scale fails, there is an `error` with the error itself;

Most of the PR is changing the tests to support the events.

Also, this PR changes the Watcher and Worker constructors to start receiving and creating the `SchedulerEventStorage`.