### PR TITLE
Respect `preventRoomsCreationWithError` before rising an error

### DIFF
--- a/controller/utils.go
+++ b/controller/utils.go
@@ -609,7 +609,7 @@ func waitCreatingPods(
 					logger.WithField("pod", createdPod.Name).Debug("pod not ready yet, waiting...")
 					err = models.ValidatePodWaitingState(createdPod)
 
-					if err != nil {
+					if config.PreventRoomsCreationWithError && err != nil {
 						logger.WithField("pod", pod.GetName()).WithError(err).Error("invalid pod waiting state")
 						return false, err
 					}


### PR DESCRIPTION
On the `waitCreatingPods`, there is a case where the pod is `Running`, but it is with an invalid state (for instance, `CrashLoopBackOff`). In those scenarios, the flag `preventRoomsCreationWithError` should be respected the same way as other cases do.

This PR also adds a test for the case described.

NOTE: This PR is also fixing the `storage/redis` tests.