### PR TITLE
Feature: remove dead rooms scheduler events

### DIFF
--- a/models/scheduler_event.go
+++ b/models/scheduler_event.go
@@ -17,6 +17,10 @@ const (
 	FinishedAutoScaleEventName = "AUTO_SCALE_FINISHED"
 	FailedAutoScaleEventName   = "AUTO_SCALE_FAILED"
 
+	// Remove dead rooms.
+	StartRemoveDeadRoomsEventName    = "REMOVE_DEAD_ROOMS_START"
+	FinishedRemoveDeadRoomsEventName = "REMOVE_DEAD_ROOMS_FINISHED"
+
 	// Metadata attributes name.
 
 	// ErrorMetadaName metadata containing an error.
@@ -26,6 +30,8 @@ const (
 	TypeMetadataName   = "type"
 	// AmountMetadataName amount of rooms that are going to be manipulated.
 	AmountMetadataName = "amount"
+	// SucessMetadataName indicates if the remove dead rooms finished successfully.
+	SuccessMetadataName = "success"
 )
 
 // SchedulerEvent is the struct that defines a maestro scheduler event

--- a/testing/common.go
+++ b/testing/common.go
@@ -1428,6 +1428,28 @@ func MockScaleSchedulerEvents(eventsStorage *storagemock.MockSchedulerEventStora
 	eventsStorage.EXPECT().PersistSchedulerEvent(&SchedulerEventMatcher{ExpectedName: models.FinishedAutoScaleEventName}).Return(nil)
 }
 
+func MockRemoveDeadRoomsStartEvent(eventsStorage *storagemock.MockSchedulerEventStorage, amount int) {
+
+	eventsStorage.EXPECT().PersistSchedulerEvent(
+		&SchedulerEventMatcher{
+			ExpectedName: models.StartRemoveDeadRoomsEventName,
+			ExpectedMetadata: map[string]interface{}{
+				models.AmountMetadataName: amount,
+			},
+		},
+	).Return(nil)
+}
+
+func MockRemoveDeadRoomsFinishEvent(eventsStorage *storagemock.MockSchedulerEventStorage, err error) {
+
+	eventsStorage.EXPECT().PersistSchedulerEvent(&SchedulerEventMatcher{
+		ExpectedName: models.FinishedRemoveDeadRoomsEventName,
+		ExpectedMetadata: map[string]interface{}{
+			models.SuccessMetadataName: err == nil,
+		},
+	}).Return(nil)
+}
+
 func MockScaleUpWithCurrentPods(
 	mockPipeline *redismocks.MockPipeliner,
 	mockRedisClient *redismocks.MockRedisClient,

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -4052,6 +4052,8 @@ var _ = Describe("Watcher", func() {
 					scheduler.Game = schedulerName
 				}).Times(4)
 
+			mockSchedulerEventStorage.EXPECT().PersistSchedulerEvent(gomock.Any()).AnyTimes()
+
 			Expect(func() { w.RemoveDeadRooms() }).ShouldNot(Panic())
 		})
 
@@ -4128,6 +4130,8 @@ var _ = Describe("Watcher", func() {
 					scheduler.YAML = yaml1
 				}).Times(4)
 
+			mockSchedulerEventStorage.EXPECT().PersistSchedulerEvent(gomock.Any()).AnyTimes()
+
 			Expect(func() { w.RemoveDeadRooms() }).ShouldNot(Panic())
 			Expect(hook.Entries).To(testing.ContainLogMessage("error listing rooms with no ping since"))
 		})
@@ -4163,6 +4167,8 @@ var _ = Describe("Watcher", func() {
 				Expect(max).To(BeNumerically("~", ts, 1*time.Second))
 			}).Return(redis.NewStringSliceResult(nil, errors.New("redis error")))
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline).AnyTimes()
+
+			mockSchedulerEventStorage.EXPECT().PersistSchedulerEvent(gomock.Any()).AnyTimes()
 
 			Expect(func() { w.RemoveDeadRooms() }).ShouldNot(Panic())
 			Expect(hook.Entries).To(testing.ContainLogMessage("error listing rooms with no occupied timeout"))

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -4052,7 +4052,8 @@ var _ = Describe("Watcher", func() {
 					scheduler.Game = schedulerName
 				}).Times(4)
 
-			mockSchedulerEventStorage.EXPECT().PersistSchedulerEvent(gomock.Any()).AnyTimes()
+			testing.MockRemoveDeadRoomsStartEvent(eventsStorage, 3)
+			testing.MockRemoveDeadRoomsFinishEvent(eventsStorage, nil)
 
 			Expect(func() { w.RemoveDeadRooms() }).ShouldNot(Panic())
 		})
@@ -4130,7 +4131,8 @@ var _ = Describe("Watcher", func() {
 					scheduler.YAML = yaml1
 				}).Times(4)
 
-			mockSchedulerEventStorage.EXPECT().PersistSchedulerEvent(gomock.Any()).AnyTimes()
+			testing.MockRemoveDeadRoomsStartEvent(eventsStorage, 0)
+			testing.MockRemoveDeadRoomsFinishEvent(eventsStorage, nil)
 
 			Expect(func() { w.RemoveDeadRooms() }).ShouldNot(Panic())
 			Expect(hook.Entries).To(testing.ContainLogMessage("error listing rooms with no ping since"))
@@ -4167,8 +4169,6 @@ var _ = Describe("Watcher", func() {
 				Expect(max).To(BeNumerically("~", ts, 1*time.Second))
 			}).Return(redis.NewStringSliceResult(nil, errors.New("redis error")))
 			mockRedisClient.EXPECT().TxPipeline().Return(mockPipeline).AnyTimes()
-
-			mockSchedulerEventStorage.EXPECT().PersistSchedulerEvent(gomock.Any()).AnyTimes()
 
 			Expect(func() { w.RemoveDeadRooms() }).ShouldNot(Panic())
 			Expect(hook.Entries).To(testing.ContainLogMessage("error listing rooms with no occupied timeout"))

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/topfreegames/maestro/storage"
 	storageredis "github.com/topfreegames/maestro/storage/redis"
 	"github.com/topfreegames/maestro/watcher"
-	storageredis "github.com/topfreegames/maestro/storage/redis"
 	"k8s.io/client-go/kubernetes"
 	metricsClient "k8s.io/metrics/pkg/client/clientset/versioned"
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -28,12 +28,14 @@ import (
 	"github.com/topfreegames/maestro/storage"
 	storageredis "github.com/topfreegames/maestro/storage/redis"
 	"github.com/topfreegames/maestro/watcher"
+	storageredis "github.com/topfreegames/maestro/storage/redis"
 	"k8s.io/client-go/kubernetes"
 	metricsClient "k8s.io/metrics/pkg/client/clientset/versioned"
 
 	pginterfaces "github.com/topfreegames/extensions/pg/interfaces"
 	"github.com/topfreegames/extensions/redis"
 	redisinterfaces "github.com/topfreegames/extensions/redis/interfaces"
+
 )
 
 type gracefulShutdown struct {

--- a/worker/worker_suite_test.go
+++ b/worker/worker_suite_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/topfreegames/maestro/models"
 	storagemock "github.com/topfreegames/maestro/storage/mock"
 	mtesting "github.com/topfreegames/maestro/testing"
-	storagemock "github.com/topfreegames/maestro/storage/mock"
 )
 
 var (

--- a/worker/worker_suite_test.go
+++ b/worker/worker_suite_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/topfreegames/maestro/models"
 	storagemock "github.com/topfreegames/maestro/storage/mock"
 	mtesting "github.com/topfreegames/maestro/testing"
+	storagemock "github.com/topfreegames/maestro/storage/mock"
 )
 
 var (


### PR DESCRIPTION
## Description

This PR aims to add 2 new scheduler events:

* REMOVE_DEAD_ROOMS_STARTED: when there are dead rooms and they are about to be removed by our service;
* REMOVE_DEAD_ROOMS_FINISHED: when the service has removed dead rooms;