### PR TITLE
Ensure correct rooms events

### DIFF
--- a/models/scheduler_event.go
+++ b/models/scheduler_event.go
@@ -21,6 +21,14 @@ const (
 	StartRemoveDeadRoomsEventName    = "REMOVE_DEAD_ROOMS_START"
 	FinishedRemoveDeadRoomsEventName = "REMOVE_DEAD_ROOMS_FINISHED"
 
+	// Worker update events.
+	StartWorkerUpdateEventName   = "WORKER_UPDATE_STARTED"
+	FailedWorkerUpdateEventName   = "WORKER_UPDATE_FAILED"
+	FinishedWorkerUpdateEventName   = "WORKER_UPDATE_FINISHED"
+
+	// Rollback events.
+	TriggerRollbackEventName   = "ROLLBACK_TRIGGERED"
+
 	// Metadata attributes name.
 
 	// ErrorMetadaName metadata containing an error.
@@ -32,6 +40,13 @@ const (
 	AmountMetadataName = "amount"
 	// SucessMetadataName indicates if the remove dead rooms finished successfully.
 	SuccessMetadataName = "success"
+	// SchedulerVersionMetadataName current scheduler version.
+	SchedulerVersionMetadataName = "scheduler_version"
+	// InvalidVersionAmountMetadataName amount of rooms with invalid version.
+	InvalidVersionAmountMetadataName = "invalid_version_amount"
+	// UnregisteredAmountMetadataName amount of rooms that are not present on
+	// Maestro's state.
+	UnregisteredAmountMetadataName = "unregistered_amount"
 )
 
 // SchedulerEvent is the struct that defines a maestro scheduler event

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -4501,6 +4501,18 @@ var _ = Describe("Watcher", func() {
 			mockPipeline.EXPECT().Del(room.GetRoomRedisKey()).AnyTimes()
 			mockPipeline.EXPECT().Exec().Return(nil, errDB).After(exec2)
 
+			eventsStorage.EXPECT().PersistSchedulerEvent(
+				&testing.SchedulerEventMatcher{
+					ExpectedName: models.StartWorkerUpdateEventName,
+					ExpectedMetadata: map[string]interface{}{
+						models.SchedulerVersionMetadataName:     "v1.0",
+						models.InvalidVersionAmountMetadataName: 0,
+						models.UnregisteredAmountMetadataName:   1,
+					},
+				},
+			).Return(nil)
+			eventsStorage.EXPECT().PersistSchedulerEvent(&testing.SchedulerEventMatcher{ExpectedName: models.FinishedWorkerUpdateEventName}).Return(nil)
+
 			err := w.EnsureCorrectRooms()
 
 			Expect(err).ToNot(HaveOccurred())
@@ -4582,6 +4594,18 @@ var _ = Describe("Watcher", func() {
 			testing.MockRemoveAnyRoomsFromRedisAnyTimes(mockRedisClient, mockPipeline, &configYaml, nil, 1)
 			testing.MockPodNotFound(mockRedisClient, w.SchedulerName, "room-2").After(runningPod)
 
+			eventsStorage.EXPECT().PersistSchedulerEvent(
+				&testing.SchedulerEventMatcher{
+					ExpectedName: models.StartWorkerUpdateEventName,
+					ExpectedMetadata: map[string]interface{}{
+						models.SchedulerVersionMetadataName:     "v1.0",
+						models.InvalidVersionAmountMetadataName: 0,
+						models.UnregisteredAmountMetadataName:   1,
+					},
+				},
+			).Return(nil)
+			eventsStorage.EXPECT().PersistSchedulerEvent(&testing.SchedulerEventMatcher{ExpectedName: models.FinishedWorkerUpdateEventName}).Return(nil)
+
 			err := w.EnsureCorrectRooms()
 
 			Expect(err).ToNot(HaveOccurred())
@@ -4619,6 +4643,18 @@ var _ = Describe("Watcher", func() {
 				models.NewPortRange(5000, 6000).String(), 5000, 6000)
 
 			testing.MockPodNotFound(mockRedisClient, w.SchedulerName, gomock.Any()).AnyTimes()
+
+			eventsStorage.EXPECT().PersistSchedulerEvent(
+				&testing.SchedulerEventMatcher{
+					ExpectedName: models.StartWorkerUpdateEventName,
+					ExpectedMetadata: map[string]interface{}{
+						models.SchedulerVersionMetadataName:     "v1.0",
+						models.InvalidVersionAmountMetadataName: 2,
+						models.UnregisteredAmountMetadataName:   2,
+					},
+				},
+			).Return(nil)
+			eventsStorage.EXPECT().PersistSchedulerEvent(&testing.SchedulerEventMatcher{ExpectedName: models.FailedWorkerUpdateEventName}).Return(nil)
 
 			err := w.EnsureCorrectRooms()
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
* `WORKER_UPDATE_STARTED`: sent when the ensure correct rooms start to replace pods. It has the metadata to indicate the scheduler version and the number of rooms that will be replaced;
* `WORKER_UPDATE_FINISHED`: sent when the ensure correct rooms finishes with success;
* `WORKER_UPDATE_FAILED`: when the ensure correct rooms fails, there is error metadata with the error itself;
* `ROLLBACK_TRIGGERED`: when the worker triggers a rollback;