### PR TITLE
Add scheduler config update events

### DIFF
--- a/api/api_suite_test.go
+++ b/api/api_suite_test.go
@@ -109,13 +109,13 @@ var _ = BeforeEach(func() {
 	lockKey = config.GetString("watcher.lockKey")
 
 	mockRedisClient.EXPECT().Ping().Return(redis.NewStatusResult("PONG", nil)).AnyTimes()
-	app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+	app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 
 	Expect(err).NotTo(HaveOccurred())
 
 	mockLogin = loginMocks.NewMockLogin(mockCtrl)
 	app.Login = mockLogin
-	
+
 	mockSchedulerEventStorage = storageMock.NewMockSchedulerEventStorage(mockCtrl)
 	app.SchedulerEventStorage = mockSchedulerEventStorage
 })

--- a/api/app.go
+++ b/api/app.go
@@ -95,6 +95,7 @@ func NewApp(
 	redisTraceWrapperOrNil redisinterfaces.TraceWrapper,
 	kubernetesClientOrNil kubernetes.Interface,
 	metricsClientsetOrNil metricsClient.Interface,
+	schedulerEventStorageOrNil storage.SchedulerEventStorage,
 ) (*App, error) {
 	a := &App{
 		Config:         config,
@@ -117,6 +118,7 @@ func NewApp(
 		redisClientOrNil, redisTraceWrapperOrNil,
 		kubernetesClientOrNil,
 		metricsClientsetOrNil,
+		schedulerEventStorageOrNil,
 	)
 	if err != nil {
 		return nil, err
@@ -433,6 +435,7 @@ func (a *App) configureApp(
 	redisTraceWrapperOrNil redisinterfaces.TraceWrapper,
 	kubernetesClientOrNil kubernetes.Interface,
 	metricsClientsetOrNil metricsClient.Interface,
+	schedulerEventStorageOrNil storage.SchedulerEventStorage,
 ) error {
 	a.loadConfigurationDefaults()
 	a.configureLogger()
@@ -456,7 +459,7 @@ func (a *App) configureApp(
 	a.configureWilliam()
 	a.configureServer()
 	a.configureEnvironment()
-	a.configureEventStorage()
+	a.configureEventStorage(schedulerEventStorageOrNil)
 	return nil
 }
 
@@ -507,7 +510,12 @@ func (a *App) configureCache() {
 	a.SchedulerCache = models.NewSchedulerCache(expirationTime, cleanupInterval, a.Logger)
 }
 
-func (a *App) configureEventStorage() {
+func (a *App) configureEventStorage(schedulerEventStorageOrNil storage.SchedulerEventStorage) {
+	if schedulerEventStorageOrNil != nil {
+		a.SchedulerEventStorage = schedulerEventStorageOrNil
+		return
+	}
+
 	a.SchedulerEventStorage = storageredis.NewRedisSchedulerEventStorage(a.RedisClient.Client)
 }
 

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("App", func() {
 	Describe("NewApp", func() {
 		It("should return new app", func() {
-			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(application).NotTo(BeNil())
 			Expect(application.Address).NotTo(Equal(""))
@@ -36,14 +36,14 @@ var _ = Describe("App", func() {
 
 			// should use development environment
 			config.Set(api.EnvironmentConfig, api.DevEnvironment)
-			application, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+			application, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(application.RoomAddrGetter).To(BeAssignableToTypeOf(&models.RoomAddressesFromNodePort{}))
 		})
 
 		It("should fail if some error occurred", func() {
 			config.Set("newrelic.key", 12345)
-			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("license length is not 40"))
 			Expect(application).To(BeNil())
@@ -51,7 +51,7 @@ var _ = Describe("App", func() {
 
 		It("should not fail if no newrelic key is provided", func() {
 			config.Set("newrelic.key", "")
-			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+			application, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(application).NotTo(BeNil())
 		})

--- a/api/auth_middleware_test.go
+++ b/api/auth_middleware_test.go
@@ -41,7 +41,7 @@ var _ = Describe("AuthMiddleware", func() {
 		config.Set("william.checkTimeout", "1s")
 
 		var err error
-		app, err = NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+		app, err = NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 		Expect(err).NotTo(HaveOccurred())
 
 		authMiddleware = NewAuthMiddleware(app, auth.ActionResolver("SomePermission"))

--- a/api/room_handler_test.go
+++ b/api/room_handler_test.go
@@ -272,7 +272,7 @@ forwarders:
 				createNamespace(namespace, clientset)
 				pod, err = createPod(roomName, namespace, clientset)
 				Expect(err).NotTo(HaveOccurred())
-				app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+				app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 				Expect(err).NotTo(HaveOccurred())
 				app.Forwarders = []*eventforwarder.Info{
 					&eventforwarder.Info{
@@ -572,7 +572,7 @@ forwarders:
 					createNamespace(namespace, clientset)
 					pod, err = createPod(roomName, namespace, clientset)
 					Expect(err).NotTo(HaveOccurred())
-					app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+					app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 					Expect(err).NotTo(HaveOccurred())
 					app.Forwarders = []*eventforwarder.Info{
 						&eventforwarder.Info{
@@ -754,7 +754,7 @@ forwarders:
 		var app *api.App
 		BeforeEach(func() {
 			var err error
-			app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+			app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 			Expect(err).NotTo(HaveOccurred())
 			app.Forwarders = []*eventforwarder.Info{
 				&eventforwarder.Info{
@@ -895,7 +895,7 @@ forwarders:
 			createNamespace(namespace, clientset)
 			pod, err = createPod("roomName", namespace, clientset)
 			Expect(err).NotTo(HaveOccurred())
-			app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+			app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 			Expect(err).NotTo(HaveOccurred())
 			app.Forwarders = []*eventforwarder.Info{
 				&eventforwarder.Info{

--- a/api/scheduler_handler.go
+++ b/api/scheduler_handler.go
@@ -11,10 +11,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/topfreegames/maestro/api/auth"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/topfreegames/maestro/api/auth"
 
 	"github.com/topfreegames/go-extensions-k8s-client-go/kubernetes"
 	maestroErrors "github.com/topfreegames/maestro/errors"
@@ -282,6 +283,7 @@ func updateSchedulerConfigCommon(
 		nil,
 		app.Config,
 		operationManager,
+		app.SchedulerEventStorage,
 	)
 	logger.WithField("time", time.Now()).Info("finished update")
 
@@ -644,7 +646,7 @@ func (g *SchedulerImageHandler) update(
 
 	db := g.App.DBClient.WithContext(r.Context())
 	err = controller.UpdateSchedulerImage(r.Context(), logger, g.App.RoomManager, mr, db, g.App.RedisClient, g.App.KubernetesClient,
-		schedulerName, imageParams, maxSurge, &clock.Clock{}, g.App.Config, operationManager)
+		schedulerName, imageParams, maxSurge, &clock.Clock{}, g.App.Config, operationManager, g.App.SchedulerEventStorage)
 	if err != nil {
 		status = http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not found") {
@@ -749,7 +751,7 @@ func (g *SchedulerUpdateMinHandler) update(
 	logger.Info("starting controllers update min")
 	db := g.App.DBClient.WithContext(r.Context())
 	err = controller.UpdateSchedulerMin(r.Context(), logger, g.App.RoomManager, mr, db, g.App.RedisClient, schedulerName,
-		schedulerMin, &clock.Clock{}, g.App.Config, operationManager)
+		schedulerMin, &clock.Clock{}, g.App.Config, operationManager, g.App.SchedulerEventStorage)
 	if err != nil {
 		status = http.StatusInternalServerError
 		if strings.Contains(err.Error(), "not found") {

--- a/api/scheduler_handler_test.go
+++ b/api/scheduler_handler_test.go
@@ -759,6 +759,8 @@ autoscaling:
 
 					calls.Finish()
 
+					MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
+
 					recorder = httptest.NewRecorder()
 					app.Router.ServeHTTP(recorder, request)
 					Expect(recorder.Body.String()).To(Equal(`{"success": true}`))
@@ -810,6 +812,8 @@ autoscaling:
 						yamlString1,
 					)
 					Expect(err).NotTo(HaveOccurred())
+
+					MockUpdateSchedulerEvents(mockSchedulerEventStorage, "scheduler-name", "v1.1", "")
 
 					app.Router.ServeHTTP(recorder, request)
 					Expect(recorder.Body.String()).To(Equal(`{"success": true}`))
@@ -1108,6 +1112,8 @@ autoscaling:
 						MockReturnRedisLock(mockRedisClient, configLockKey, nil))
 
 					calls.Finish()
+
+					MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
 
 					recorder = httptest.NewRecorder()
 					app.Router.ServeHTTP(recorder, request)
@@ -1525,7 +1531,7 @@ game: game-name
 				err = yaml.Unmarshal([]byte(yamlString), &configYaml1)
 				Expect(err).NotTo(HaveOccurred())
 				config.Set("basicauth.tryOauthIfUnset", true)
-				app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+				app, err = api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 				Expect(err).NotTo(HaveOccurred())
 				app.Login = mockLogin
 			})
@@ -2163,6 +2169,8 @@ game: game-name
 
 				calls.Finish()
 
+				MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
+
 				recorder = httptest.NewRecorder()
 				app.Router.ServeHTTP(recorder, request)
 				Expect(recorder.Body.String()).To(Equal(`{"success": true}`))
@@ -2256,6 +2264,8 @@ game: game-name
 					MockReturnRedisLock(mockRedisClient, configLockKey, nil))
 
 				calls.Finish()
+
+				MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
 
 				recorder = httptest.NewRecorder()
 				app.Router.ServeHTTP(recorder, request)
@@ -2545,7 +2555,7 @@ game: game-name
 				Expect(err).NotTo(HaveOccurred())
 				config.Set("basicauth.tryOauthIfUnset", true)
 
-				app, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+				app, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 				Expect(err).NotTo(HaveOccurred())
 				app.Login = mockLogin
 				newImageName := "new-image"
@@ -2626,6 +2636,8 @@ game: game-name
 
 				calls.Finish()
 
+				MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
+
 				recorder = httptest.NewRecorder()
 				app.Router.ServeHTTP(recorder, request)
 				Expect(recorder.Body.String()).To(Equal(`{"success": true}`))
@@ -2662,7 +2674,7 @@ game: game-name
 				Expect(err).NotTo(HaveOccurred())
 				scheduler1 = models.NewScheduler(configYaml1.Name, configYaml1.Game, jsonString)
 
-				app, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+				app, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 				Expect(err).NotTo(HaveOccurred())
 				app.Login = mockLogin
 
@@ -2747,6 +2759,8 @@ game: game-name
 					MockReturnRedisLock(mockRedisClient, configLockKey, nil))
 
 				calls.Finish()
+
+				MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
 
 				recorder = httptest.NewRecorder()
 				app.Router.ServeHTTP(recorder, request)
@@ -2865,6 +2879,8 @@ game: game-name
 					MockReturnRedisLock(mockRedisClient, configLockKey, nil))
 
 				calls.Finish()
+
+				MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
 
 				recorder = httptest.NewRecorder()
 				app.Router.ServeHTTP(recorder, request)
@@ -3030,6 +3046,8 @@ game: game-name
 
 				calls.Finish()
 
+				MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
+
 				recorder = httptest.NewRecorder()
 
 				app.Router.ServeHTTP(recorder, request)
@@ -3172,6 +3190,8 @@ game: game-name
 
 				calls.Finish()
 
+				MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
+
 				recorder = httptest.NewRecorder()
 				app.Router.ServeHTTP(recorder, request)
 				Expect(recorder.Code).To(Equal(http.StatusOK))
@@ -3241,7 +3261,7 @@ game: game-name
 
 				config, err := GetDefaultConfig()
 				config.Set("basicauth.tryOauthIfUnset", true)
-				app, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+				app, err := api.NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 				Expect(err).NotTo(HaveOccurred())
 				app.Login = mockLogin
 
@@ -3288,6 +3308,8 @@ game: game-name
 				MockUpdateVersionsTable(mockDb, nil)
 
 				calls.Finish()
+
+				MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
 
 				recorder = httptest.NewRecorder()
 				app.Router.ServeHTTP(recorder, request)
@@ -3366,6 +3388,8 @@ game: game-name
 				MockUpdateVersionsTable(mockDb, nil)
 
 				calls.Finish()
+
+				MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, scheduler1.Version, "")
 
 				recorder = httptest.NewRecorder()
 

--- a/api/scheduler_rollback_handler_test.go
+++ b/api/scheduler_rollback_handler_test.go
@@ -112,6 +112,8 @@ autoscaling:
 
 			calls.Finish()
 
+			MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, "v1.1", "")
+
 			app.Router.ServeHTTP(recorder, request)
 			Expect(recorder.Code).To(Equal(http.StatusOK))
 			Expect(recorder.Body.String()).To(Equal(`{"success": true}`))
@@ -239,6 +241,8 @@ autoscaling:
 			MockReturnRedisLock(mockRedisClient, configLockKey, nil)
 
 			MockUpdateVersionsTable(mockDb, nil)
+
+			MockUpdateSchedulerEvents(mockSchedulerEventStorage, scheduler1.Name, "v1.1", "")
 
 			app.Router.ServeHTTP(recorder, request)
 			Expect(recorder.Code).To(Equal(http.StatusOK))

--- a/api/william_handler_test.go
+++ b/api/william_handler_test.go
@@ -31,7 +31,7 @@ var _ = Describe("WilliamHandler", func() {
 		config.Set("william.enabled", true)
 
 		var err error
-		app, err = NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset)
+		app, err = NewApp("0.0.0.0", 9998, config, logger, false, "", mockDb, mockCtxWrapper, mockRedisClient, mockRedisTraceWrapper, clientset, metricsClientset, mockSchedulerEventStorage)
 		Expect(err).NotTo(HaveOccurred())
 
 		request, _ = http.NewRequest("GET", "/am", nil)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -54,7 +54,7 @@ var startCmd = &cobra.Command{
 
 		cmdL.Info("starting maestro")
 
-		app, err := api.NewApp(bind, port, config, log, incluster, kubeconfig, nil, nil, nil, nil, nil, nil)
+		app, err := api.NewApp(bind, port, config, log, incluster, kubeconfig, nil, nil, nil, nil, nil, nil, nil)
 		if err != nil {
 			cmdL.Fatal(err)
 		}

--- a/controller/controller_suite_test.go
+++ b/controller/controller_suite_test.go
@@ -17,6 +17,7 @@ import (
 	clockmocks "github.com/topfreegames/extensions/clock/mocks"
 	pgmocks "github.com/topfreegames/extensions/pg/mocks"
 	redismocks "github.com/topfreegames/extensions/redis/mocks"
+	storagemock "github.com/topfreegames/maestro/storage/mock"
 	mtesting "github.com/topfreegames/maestro/testing"
 
 	"github.com/golang/mock/gomock"
@@ -44,6 +45,7 @@ var (
 	redisClient           *redis.Client
 	mr                    *models.MixedMetricsReporter
 	schedulerCache        *models.SchedulerCache
+	eventsStorage         *storagemock.MockSchedulerEventStorage
 	err                   error
 	allStatus             = []string{
 		models.StatusCreating,
@@ -95,6 +97,7 @@ var _ = BeforeEach(func() {
 	mockClock = clockmocks.NewMockClock(mockCtrl)
 
 	schedulerCache = models.NewSchedulerCache(1*time.Minute, 10*time.Minute, logger)
+	eventsStorage = storagemock.NewMockSchedulerEventStorage(mockCtrl)
 })
 
 var _ = AfterEach(func() {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1684,7 +1684,6 @@ cmd:
 					}
 				}
 
-
 				jsonBytes, err := pod.MarshalToRedis()
 				Expect(err).NotTo(HaveOccurred())
 				pods = append(pods, pod.Name, string(jsonBytes))
@@ -3620,6 +3619,8 @@ cmd:
 
 			calls.Finish()
 
+			mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, scheduler1.Version, "")
+
 			err = controller.UpdateSchedulerConfig(
 				context.Background(),
 				logger,
@@ -3634,6 +3635,7 @@ cmd:
 				nil,
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -3783,9 +3785,11 @@ portRange:
 
 				calls.Finish()
 
+				mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, scheduler1.Version, "")
+
 				err = controller.UpdateSchedulerConfig(context.Background(), logger,
 					roomManager, mr, mockDb, redisClient, clientset, &configYaml2,
-					maxSurge, &clock.Clock{}, nil, config, opManager)
+					maxSurge, &clock.Clock{}, nil, config, opManager, eventsStorage)
 				Expect(err).NotTo(HaveOccurred())
 
 				ns, err := clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
@@ -3979,9 +3983,11 @@ cmd:
 
 				calls.Finish()
 
+				mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, scheduler1.Version, "")
+
 				err = controller.UpdateSchedulerConfig(context.Background(), logger,
 					roomManager, mr, mockDb, redisClient,
-					clientset, &configYaml2, maxSurge, &clock.Clock{}, nil, config, opManager)
+					clientset, &configYaml2, maxSurge, &clock.Clock{}, nil, config, opManager, eventsStorage)
 				Expect(err).NotTo(HaveOccurred())
 
 				pods, err = clientset.CoreV1().Pods(configYaml2.Name).List(metav1.ListOptions{})
@@ -4181,9 +4187,11 @@ portRange:
 
 				calls.Finish()
 
+				mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, scheduler1.Version, "")
+
 				err = controller.UpdateSchedulerConfig(context.Background(), logger,
 					roomManager, mr, mockDb, redisClient,
-					clientset, &configYaml2, maxSurge, &clock.Clock{}, nil, config, opManager)
+					clientset, &configYaml2, maxSurge, &clock.Clock{}, nil, config, opManager, eventsStorage)
 				Expect(err).NotTo(HaveOccurred())
 
 				pods, err = clientset.CoreV1().Pods(configYaml2.Name).List(metav1.ListOptions{})
@@ -4244,6 +4252,7 @@ portRange:
 				nil,
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("scheduler another-name not found, create it first"))
@@ -4324,6 +4333,8 @@ cmd:
 
 			calls.Finish()
 
+			mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, scheduler1.Version, "")
+
 			err = controller.UpdateSchedulerConfig(
 				context.Background(),
 				logger,
@@ -4338,6 +4349,7 @@ cmd:
 				nil,
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -4393,6 +4405,7 @@ cmd:
 				nil,
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("error on select"))
@@ -4419,6 +4432,7 @@ cmd:
 				nil,
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("timeout while wating for redis lock"))
@@ -4456,6 +4470,7 @@ cmd:
 				nil,
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("timeout while wating for redis lock"))
@@ -4487,6 +4502,7 @@ cmd:
 				nil,
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("error getting lock"))
@@ -4533,6 +4549,8 @@ cmd:
 
 			calls.Finish()
 
+			mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, "v2.0", "v1.0")
+
 			err = controller.UpdateSchedulerConfig(
 				context.Background(),
 				logger,
@@ -4547,6 +4565,7 @@ cmd:
 				nil,
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("operation timedout"))
@@ -4593,6 +4612,8 @@ cmd:
 
 			calls.Finish()
 
+			mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, "v2.0", "v1.0")
+
 			err = controller.UpdateSchedulerConfig(
 				context.Background(),
 				logger,
@@ -4607,6 +4628,7 @@ cmd:
 				nil,
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("operation timedout"))
@@ -4684,6 +4706,8 @@ cmd:
 
 			calls.Finish()
 
+			mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, scheduler1.Version, "")
+
 			err = controller.UpdateSchedulerConfig(
 				context.Background(),
 				logger,
@@ -4698,6 +4722,7 @@ cmd:
 				nil,
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -4759,6 +4784,7 @@ cmd:
 					nil,
 					config,
 					opManager,
+					eventsStorage,
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -4877,6 +4903,8 @@ containers:
 
 				calls.Finish()
 
+				mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, "v2.0", "v1.0")
+
 				err = controller.UpdateSchedulerConfig(
 					context.Background(),
 					logger,
@@ -4891,6 +4919,7 @@ containers:
 					nil,
 					config,
 					opManager,
+					eventsStorage,
 				)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("operation canceled"))
@@ -5134,6 +5163,8 @@ containers:
 
 			calls.Finish()
 
+			mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, scheduler1.Version, "")
+
 			err = controller.UpdateSchedulerImage(
 				context.Background(),
 				logger,
@@ -5148,6 +5179,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -5198,6 +5230,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("scheduler new-name not found, create it first"))
@@ -5244,6 +5277,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("some error in db"))
@@ -5270,6 +5304,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("yaml: did not find expected ',' or '}'"))
@@ -5297,6 +5332,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -5399,6 +5435,8 @@ containers:
 
 			calls.Finish()
 
+			mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, scheduler1.Version, "")
+
 			imageParams.Container = "container1"
 			err = controller.UpdateSchedulerImage(
 				context.Background(),
@@ -5414,6 +5452,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -5472,6 +5511,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -5530,6 +5570,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("no container with name invalid-container"))
@@ -5589,6 +5630,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("need to specify container name"))
@@ -5663,6 +5705,8 @@ containers:
 
 			mt.MockReturnRedisLock(mockRedisClient, configLockKey, nil)
 
+			mt.MockUpdateSchedulerEvents(eventsStorage, scheduler1.Name, scheduler1.Version, "")
+
 			err := controller.UpdateSchedulerMin(
 				context.Background(),
 				logger,
@@ -5675,6 +5719,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -5721,6 +5766,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -5745,6 +5791,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("invalid parameter: autoscaling max must be greater than min"))
@@ -5768,6 +5815,7 @@ containers:
 				&clock.Clock{},
 				config,
 				opManager,
+				eventsStorage,
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("some error in db"))

--- a/models/scheduler_event.go
+++ b/models/scheduler_event.go
@@ -22,20 +22,25 @@ const (
 	FinishedRemoveDeadRoomsEventName = "REMOVE_DEAD_ROOMS_FINISHED"
 
 	// Worker update events.
-	StartWorkerUpdateEventName   = "WORKER_UPDATE_STARTED"
+	StartWorkerUpdateEventName    = "WORKER_UPDATE_STARTED"
 	FailedWorkerUpdateEventName   = "WORKER_UPDATE_FAILED"
-	FinishedWorkerUpdateEventName   = "WORKER_UPDATE_FINISHED"
+	FinishedWorkerUpdateEventName = "WORKER_UPDATE_FINISHED"
+
+	// Worker update events.
+	StartUpdateEventName    = "UPDATE_STARTED"
+	FailedUpdateEventName   = "UPDATE_FAILED"
+	FinishedUpdateEventName = "UPDATE_FINISHED"
 
 	// Rollback events.
-	TriggerRollbackEventName   = "ROLLBACK_TRIGGERED"
+	TriggerRollbackEventName = "ROLLBACK_TRIGGERED"
 
 	// Metadata attributes name.
 
 	// ErrorMetadaName metadata containing an error.
-	ErrorMetadataName  = "error"
+	ErrorMetadataName = "error"
 	// TypeMetadataName type of the operation. For example, AutoScale has "up"
 	// and "down" types.
-	TypeMetadataName   = "type"
+	TypeMetadataName = "type"
 	// AmountMetadataName amount of rooms that are going to be manipulated.
 	AmountMetadataName = "amount"
 	// SucessMetadataName indicates if the remove dead rooms finished successfully.


### PR DESCRIPTION
The API update scheduler action now produces the following events:

* `UPDATE_STARTED`: sent when the scheduler update starts. It has the metadata to indicate the scheduler version;
* `UPDATE_FINISHED`: sent when the update finishes with success;
* `UPDATE_FAILED`: when the update fails, there is error metadata with the error itself;
* `ROLLBACK_TRIGGERED`: when the update fails and triggers a rollback;

This PR also changes the `app.NewApp` constructor to receive an instance of the scheduler events storage (for testing purposes).