### PR TITLE
Runtime watcher update game room instance when receive added event

### DIFF
--- a/cmd/runtime_watcher/wire_gen.go
+++ b/cmd/runtime_watcher/wire_gen.go
@@ -57,7 +57,7 @@ func initializeRuntimeWatcher(c config.Config) (*workers_manager.WorkersManager,
 	}
 	roomManager := room_manager.NewRoomManager(clock, portAllocator, roomStorage, gameRoomInstanceStorage, runtime, roomManagerConfig)
 	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager)
-	workerOptions := workers.ProvideWorkerOptions(operationManager, v2)
+	workerOptions := workers.ProvideWorkerOptions(operationManager, v2, roomManager, runtime)
 	workersManager := workers_manager.NewWorkersManager(workerBuilder, c, schedulerStorage, workerOptions)
 	return workersManager, nil
 }

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -55,7 +55,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	}
 	roomManager := room_manager.NewRoomManager(clock, portAllocator, roomStorage, gameRoomInstanceStorage, runtime, roomManagerConfig)
 	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager)
-	workerOptions := workers.ProvideWorkerOptions(operationManager, v2)
+	workerOptions := workers.ProvideWorkerOptions(operationManager, v2, roomManager, runtime)
 	workersManager := workers_manager.NewWorkersManager(builder, c, schedulerStorage, workerOptions)
 	return workersManager, nil
 }

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -157,7 +157,6 @@ func (m *RoomManager) UpdateRoomInstance(ctx context.Context, gameRoomInstance *
 	return nil
 }
 
-
 // ListRoomsWithDeletionPriority returns a specified number of rooms, following
 // the priority of it being deleted (which will be introduced later). This
 // function can return less rooms than the `amount` since it might not have

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -147,6 +147,17 @@ func (m *RoomManager) UpdateRoom(ctx context.Context, gameRoom *game_room.GameRo
 	return nil
 }
 
+// UpdateRoomInstance updates the instance information.
+func (m *RoomManager) UpdateRoomInstance(ctx context.Context, gameRoomInstance *game_room.Instance) error {
+	err := m.instanceStorage.UpsertInstance(ctx, gameRoomInstance)
+	if err != nil {
+		return fmt.Errorf("failed when updating the game room instance on storage: %w", err)
+	}
+
+	return nil
+}
+
+
 // ListRoomsWithDeletionPriority returns a specified number of rooms, following
 // the priority of it being deleted (which will be introduced later). This
 // function can return less rooms than the `amount` since it might not have

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -72,7 +72,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
 
 		operationDefinition.EXPECT().Unmarshal(gomock.Any()).Return(nil)
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
@@ -125,7 +125,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
 
 		operationDefinition.EXPECT().Unmarshal(gomock.Any()).Return(nil)
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
@@ -176,7 +176,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		}
 
 		executors := map[string]operations.Executor{}
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
 
 		operationDefinition.EXPECT().Unmarshal(gomock.Any()).Return(nil)
 
@@ -219,7 +219,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
 
 		operationDefinition.EXPECT().Unmarshal(gomock.Any()).Return(nil)
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(false)

--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
@@ -68,6 +68,8 @@ func (w *runtimeWatcherWorker) Start(ctx context.Context) error {
 	}
 
 	w.ctx, w.cancelFunc = context.WithCancel(ctx)
+	defer w.cancelFunc()
+
 	resultChan := watcher.ResultChan()
 	for {
 		select {

--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
@@ -24,9 +24,14 @@ package runtime_watcher_worker
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/topfreegames/maestro/internal/core/entities"
+	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+	"github.com/topfreegames/maestro/internal/core/ports"
+	"github.com/topfreegames/maestro/internal/core/services/room_manager"
 	"github.com/topfreegames/maestro/internal/core/workers"
+	"go.uber.org/zap"
 )
 
 var _ workers.Worker = (*runtimeWatcherWorker)(nil)
@@ -34,19 +39,69 @@ var _ workers.Worker = (*runtimeWatcherWorker)(nil)
 // runtimeWatcherWorker is a work that will watch for changes on the Runtime
 // and apply to keep the Maestro state up-to-date. It is not expected to perform
 // any action over the game rooms or the scheduler.
-type runtimeWatcherWorker struct{}
+type runtimeWatcherWorker struct {
+	scheduler   *entities.Scheduler
+	roomManager *room_manager.RoomManager
+	// TODO(gabrielcorado): should we access the port directly? do we need to
+	// provide the same `Watcher` interface but on the RoomManager?
+	runtime ports.Runtime
 
-func NewRuntimeWatcherWorker(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
-	return &runtimeWatcherWorker{}
+	logger *zap.Logger
+
+	ctx        context.Context
+	cancelFunc context.CancelFunc
 }
 
-func (w *runtimeWatcherWorker) Start(_ context.Context) error {
-	return nil
+func NewRuntimeWatcherWorker(scheduler *entities.Scheduler, opts *workers.WorkerOptions) workers.Worker {
+	return &runtimeWatcherWorker{
+		scheduler:   scheduler,
+		roomManager: opts.RoomManager,
+		runtime:     opts.Runtime,
+		logger:      zap.L().With(zap.String("service", "runtime_watcher"), zap.String("scheduler_name", scheduler.Name)),
+	}
+}
+
+func (w *runtimeWatcherWorker) Start(ctx context.Context) error {
+	watcher, err := w.runtime.WatchGameRoomInstances(ctx, w.scheduler)
+	if err != nil {
+		return fmt.Errorf("failed to start watcher: %w", err)
+	}
+
+	w.ctx, w.cancelFunc = context.WithCancel(ctx)
+	resultChan := watcher.ResultChan()
+	for {
+		select {
+		case <-w.ctx.Done():
+			watcher.Stop()
+			return nil
+		case event := <-resultChan:
+			err := w.processEvent(w.ctx, event)
+			if err != nil {
+				w.logger.Warn("failed to process event", zap.Error(err))
+			}
+		}
+	}
 }
 
 func (w *runtimeWatcherWorker) Stop(_ context.Context) {
+	if w.cancelFunc != nil {
+		w.cancelFunc()
+	}
 }
 
 func (w *runtimeWatcherWorker) IsRunning() bool {
-	return true
+	return w.ctx != nil && w.ctx.Err() == nil
+}
+
+func (w *runtimeWatcherWorker) processEvent(ctx context.Context, event game_room.InstanceEvent) error {
+	switch event.Type {
+	case game_room.InstanceEventTypeAdded:
+		err := w.roomManager.UpdateRoomInstance(ctx, event.Instance)
+		if err != nil {
+			return fmt.Errorf("failed to update room instance %s: %w", event.Instance.ID, err)
+		}
+	default:
+		return fmt.Errorf("not implemented")
+	}
+	return nil
 }

--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker_test.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker_test.go
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 // +build unit
 
 package runtime_watcher_worker

--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker_test.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker_test.go
@@ -1,0 +1,119 @@
+// +build unit
+
+package runtime_watcher_worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	clockmock "github.com/topfreegames/maestro/internal/adapters/clock/mock"
+	instancemock "github.com/topfreegames/maestro/internal/adapters/instance_storage/mock"
+	pamock "github.com/topfreegames/maestro/internal/adapters/port_allocator/mock"
+	roomstoragemock "github.com/topfreegames/maestro/internal/adapters/room_storage/mock"
+	runtimemock "github.com/topfreegames/maestro/internal/adapters/runtime/mock"
+	"github.com/topfreegames/maestro/internal/core/entities"
+	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
+	"github.com/topfreegames/maestro/internal/core/services/room_manager"
+	"github.com/topfreegames/maestro/internal/core/workers"
+)
+
+func TestProcessRuntimeEvents(t *testing.T) {
+	workerOptions := func(t *testing.T) (*gomock.Controller, *instancemock.MockGameRoomInstanceStorage, *runtimemock.MockRuntime, *workers.WorkerOptions) {
+		mockCtrl := gomock.NewController(t)
+
+		now := time.Now()
+		portAllocator := pamock.NewMockPortAllocator(mockCtrl)
+		roomStorage := roomstoragemock.NewMockRoomStorage(mockCtrl)
+		runtime := runtimemock.NewMockRuntime(mockCtrl)
+		instanceStorage := instancemock.NewMockGameRoomInstanceStorage(mockCtrl)
+		fakeClock := clockmock.NewFakeClock(now)
+		config := room_manager.RoomManagerConfig{RoomInitializationTimeoutMillis: time.Millisecond * 1000}
+		roomManager := room_manager.NewRoomManager(fakeClock, portAllocator, roomStorage, instanceStorage, runtime, config)
+
+		return mockCtrl, instanceStorage, runtime, &workers.WorkerOptions{
+			Runtime:     runtime,
+			RoomManager: roomManager,
+		}
+	}
+
+	t.Run("fails to start watcher", func(t *testing.T) {
+		mockCtrl, _, runtime, workerOptions := workerOptions(t)
+		defer mockCtrl.Finish()
+
+		scheduler := &entities.Scheduler{Name: "test"}
+		watcher := NewRuntimeWatcherWorker(scheduler, workerOptions)
+
+		runtime.EXPECT().WatchGameRoomInstances(gomock.Any(), scheduler).Return(nil, porterrors.ErrUnexpected)
+
+		watcherDone := make(chan error)
+		go func() {
+			err := watcher.Start(context.Background())
+			watcherDone <- err
+		}()
+
+		require.Eventually(t, func() bool {
+			err := <-watcherDone
+			require.Error(t, err)
+
+			return true
+		}, time.Second, time.Millisecond)
+	})
+
+	t.Run("updates instance on added event", func(t *testing.T) {
+		mockCtrl, instanceStorage, runtime, workerOptions := workerOptions(t)
+		defer mockCtrl.Finish()
+
+		scheduler := &entities.Scheduler{Name: "test"}
+		watcher := NewRuntimeWatcherWorker(scheduler, workerOptions)
+
+		runtimeWatcher := runtimemock.NewMockRuntimeWatcher(mockCtrl)
+		runtime.EXPECT().WatchGameRoomInstances(gomock.Any(), scheduler).Return(runtimeWatcher, nil)
+
+		resultChan := make(chan game_room.InstanceEvent)
+		runtimeWatcher.EXPECT().ResultChan().Return(resultChan)
+		runtimeWatcher.EXPECT().Stop()
+
+		// instance updates
+		newInstance := &game_room.Instance{}
+
+		updateCalled := false
+		instanceStorage.EXPECT().UpsertInstance(gomock.Any(), newInstance).DoAndReturn(func(_ context.Context, _ *game_room.Instance) error {
+			updateCalled = true
+			return nil
+		})
+
+		watcherDone := make(chan error)
+		go func() {
+			err := watcher.Start(context.Background())
+			watcherDone <- err
+		}()
+
+		require.Eventually(t, func() bool {
+			resultChan <- game_room.InstanceEvent{
+				Type:     game_room.InstanceEventTypeAdded,
+				Instance: newInstance,
+			}
+
+			return true
+		}, time.Second, time.Millisecond)
+
+		// wait until the watcher process the event
+		require.Eventually(t, func() bool {
+			return updateCalled
+		}, time.Second, 100*time.Millisecond)
+
+		// stop the watcher
+		watcher.Stop(context.Background())
+
+		require.Eventually(t, func() bool {
+			err := <-watcherDone
+			require.NoError(t, err)
+
+			return true
+		}, time.Second, time.Millisecond)
+	})
+}

--- a/internal/core/workers/worker.go
+++ b/internal/core/workers/worker.go
@@ -27,7 +27,9 @@ import (
 
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/operations"
+	"github.com/topfreegames/maestro/internal/core/ports"
 	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
+	"github.com/topfreegames/maestro/internal/core/services/room_manager"
 )
 
 // This interface aims to map all required functions of a worker
@@ -47,9 +49,16 @@ type Worker interface {
 type WorkerOptions struct {
 	OperationManager   *operation_manager.OperationManager
 	OperationExecutors map[string]operations.Executor
+	RoomManager        *room_manager.RoomManager
+	Runtime            ports.Runtime
 }
 
-func ProvideWorkerOptions(operationManager *operation_manager.OperationManager, operationExecutors map[string]operations.Executor) *WorkerOptions {
+func ProvideWorkerOptions(
+	operationManager *operation_manager.OperationManager,
+	operationExecutors map[string]operations.Executor,
+	roomManager *room_manager.RoomManager,
+	runtime ports.Runtime,
+) *WorkerOptions {
 	return &WorkerOptions{
 		OperationManager:   operationManager,
 		OperationExecutors: operationExecutors,


### PR DESCRIPTION
Implementing the `Start`, `Stop`, and `IsRunning` of the runtime watcher. Implementing processing of `InstanceEventTypeAdded` event.

This PR also adds a new function to the `RoomManager` used to update the game room instance (`UpdateRoomInstance`).