### PR TITLE
Feature: worker operation cancelation watcher

### DIFF
--- a/cmd/worker/wire.go
+++ b/cmd/worker/wire.go
@@ -57,6 +57,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 		operation_manager.New,
 		workers.ProvideWorkerOptions,
 		workers_manager.NewWorkersManager,
+
 	)
 
 	return &workers_manager.WorkersManager{}, nil

--- a/cmd/worker/wire.go
+++ b/cmd/worker/wire.go
@@ -57,7 +57,6 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 		operation_manager.New,
 		workers.ProvideWorkerOptions,
 		workers_manager.NewWorkersManager,
-
 	)
 
 	return &workers_manager.WorkersManager{}, nil

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -76,7 +76,7 @@ func main() {
 	go func() {
 		zap.L().Info("starting operation cancelation request watcher")
 		err := operationExecutionWorkerManager.WorkerOptions.OperationManager.WatchOperationCancelationRequests(ctx)
-		if err != nil && !errors.Is(err, context.Canceled)  {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			zap.L().With(zap.Error(err)).Info("operation cancelation watcher stopped with error")
 			// enforce the cancelation
 			cancelFn()

--- a/internal/adapters/operation_flow/mock/mock.go
+++ b/internal/adapters/operation_flow/mock/mock.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	ports "github.com/topfreegames/maestro/internal/core/ports"
 )
 
 // MockOperationFlow is a mock of OperationFlow interface.
@@ -76,4 +77,18 @@ func (m *MockOperationFlow) NextOperationID(ctx context.Context, schedulerName s
 func (mr *MockOperationFlowMockRecorder) NextOperationID(ctx, schedulerName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextOperationID", reflect.TypeOf((*MockOperationFlow)(nil).NextOperationID), ctx, schedulerName)
+}
+
+// WatchOperationCancelationRequests mocks base method.
+func (m *MockOperationFlow) WatchOperationCancelationRequests(ctx context.Context) chan ports.OperationCancelationRequest {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchOperationCancelationRequests", ctx)
+	ret0, _ := ret[0].(chan ports.OperationCancelationRequest)
+	return ret0
+}
+
+// WatchOperationCancelationRequests indicates an expected call of WatchOperationCancelationRequests.
+func (mr *MockOperationFlowMockRecorder) WatchOperationCancelationRequests(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchOperationCancelationRequests", reflect.TypeOf((*MockOperationFlow)(nil).WatchOperationCancelationRequests), ctx)
 }

--- a/internal/adapters/operation_flow/redis/redis.go
+++ b/internal/adapters/operation_flow/redis/redis.go
@@ -87,7 +87,7 @@ func (r *redisOperationFlow) ListSchedulerPendingOperationIDs(ctx context.Contex
 func (r *redisOperationFlow) WatchOperationCancelationRequests(ctx context.Context) chan ports.OperationCancelationRequest {
 	sub := r.client.Subscribe(ctx, watchOperationCancelationRequestKey)
 
-	resultChan := make(chan ports.OperationCancelationRequest, 10000)
+	resultChan := make(chan ports.OperationCancelationRequest, 100)
 
 	go func() {
 		defer sub.Close()

--- a/internal/adapters/operation_flow/redis/redis.go
+++ b/internal/adapters/operation_flow/redis/redis.go
@@ -24,14 +24,17 @@ package redis
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/topfreegames/maestro/internal/core/ports"
 	"github.com/topfreegames/maestro/internal/core/ports/errors"
+	"go.uber.org/zap"
 )
 
 var _ ports.OperationFlow = (*redisOperationFlow)(nil)
+var watchOperationCancelationRequestKey = "scheduler:operation_cancelation_requests"
 
 // redisOperationFlow adapter of the OperationStorage port. It store store
 // the operations in lists to keep their creation/update order.
@@ -79,6 +82,40 @@ func (r *redisOperationFlow) ListSchedulerPendingOperationIDs(ctx context.Contex
 	}
 
 	return operationsIDs, nil
+}
+
+func (r *redisOperationFlow) WatchOperationCancelationRequests(ctx context.Context) chan ports.OperationCancelationRequest {
+	sub := r.client.Subscribe(ctx, watchOperationCancelationRequestKey)
+
+	resultChan := make(chan ports.OperationCancelationRequest, 10000)
+
+	go func() {
+		defer sub.Close()
+
+		for {
+			select {
+			case msg, ok := <-sub.Channel():
+				if !ok {
+					close(resultChan)
+					return
+				}
+
+				var request ports.OperationCancelationRequest
+				err := json.Unmarshal([]byte(msg.Payload), &request)
+				if err != nil {
+					zap.L().With(zap.Error(err)).Error("failed to parse operation cancelation request")
+					continue
+				}
+
+				resultChan <- request
+			case <-ctx.Done():
+				close(resultChan)
+				return
+			}
+		}
+	}()
+
+	return resultChan
 }
 
 func (r *redisOperationFlow) buildSchedulerPendingOperationsKey(schedulerName string) string {

--- a/internal/core/ports/operation_flow.go
+++ b/internal/core/ports/operation_flow.go
@@ -26,6 +26,11 @@ import (
 	"context"
 )
 
+type OperationCancelationRequest struct {
+	SchedulerName string `json:"schedulerName"`
+	OperationID   string `json:"operationID"`
+}
+
 type OperationFlow interface {
 	InsertOperationID(ctx context.Context, schedulerName, operationID string) error
 	// NextOperationID fetches the next scheduler operation to be
@@ -33,4 +38,6 @@ type OperationFlow interface {
 	NextOperationID(ctx context.Context, schedulerName string) (string, error)
 	// ListSchedulerPendingOperationIDs list scheduler pending operation IDs.
 	ListSchedulerPendingOperationIDs(ctx context.Context, schedulerName string) ([]string, error)
+	// WatchOperationCancelationRequests watches for operation cancelation requests
+	WatchOperationCancelationRequests(ctx context.Context) chan OperationCancelationRequest
 }

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -37,12 +37,12 @@ import (
 )
 
 type OperationCancelFunctions struct {
-	mutex		*sync.RWMutex
-	functions	map[string]map[string]context.CancelFunc
+	mutex     *sync.RWMutex
+	functions map[string]map[string]context.CancelFunc
 }
 
 func NewOperationCancelFunctions() OperationCancelFunctions {
-	return OperationCancelFunctions {
+	return OperationCancelFunctions{
 		functions: map[string]map[string]context.CancelFunc{},
 	}
 }
@@ -203,7 +203,7 @@ func (o *OperationManager) FinishOperation(ctx context.Context, op *operation.Op
 	}
 
 	o.operationCancelFunctions.removeFunction(op.SchedulerName, op.ID)
-	
+
 	return nil
 }
 

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
@@ -37,6 +38,7 @@ import (
 	opstorage "github.com/topfreegames/maestro/internal/adapters/operation_storage/mock"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/operations"
+	"github.com/topfreegames/maestro/internal/core/ports"
 	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 )
 
@@ -309,7 +311,7 @@ func TestNextSchedulerOperation(t *testing.T) {
 }
 
 func TestStartOperation(t *testing.T) {
-	t.Run("starts operation with succeess", func(t *testing.T) {
+	t.Run("starts operation with success", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -322,7 +324,7 @@ func TestStartOperation(t *testing.T) {
 		op := &operation.Operation{ID: uuid.NewString(), DefinitionName: (&testOperationDefinition{}).Name()}
 
 		operationStorage.EXPECT().UpdateOperationStatus(ctx, op.SchedulerName, op.ID, operation.StatusInProgress).Return(nil)
-		err := opManager.StartOperation(ctx, op)
+		err := opManager.StartOperation(ctx, op, func() {})
 		require.NoError(t, err)
 	})
 }
@@ -369,5 +371,63 @@ func TestListActiveOperations(t *testing.T) {
 		operations, err := opManager.ListSchedulerActiveOperations(ctx, schedulerName)
 		require.NoError(t, err)
 		require.ElementsMatch(t, operationsResult, operations)
+	})
+}
+
+func TestWatchOperationCancelationRequests(t *testing.T) {
+	schedulerName := uuid.New().String()
+	operationID := uuid.New().String()
+
+	t.Run("cancels a operation successfully", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
+		opManager := New(operationFlow, nil, nil)
+
+		cancelableContext, cancelFunction := context.WithCancel(context.Background())
+		opManager.operationCancelFunctions[schedulerName] = map[string]context.CancelFunc{
+			operationID: cancelFunction,
+		}
+
+		requestChannel := make(chan ports.OperationCancelationRequest, 1000)
+		operationFlow.EXPECT().WatchOperationCancelationRequests(gomock.Any()).Return(requestChannel)
+
+		opManager.WatchOperationCancelationRequests(context.Background())
+
+		requestChannel <- ports.OperationCancelationRequest{
+			SchedulerName: schedulerName,
+			OperationID:   operationID,
+		}
+
+		require.Eventually(t, func() bool {
+			if cancelableContext.Err() != nil {
+				require.ErrorIs(t, cancelableContext.Err(), context.Canceled)
+				return true
+			}
+
+			return false
+		}, time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("fails fast to cancel when no cancel function found", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
+		opManager := New(operationFlow, nil, nil)
+
+		requestChannel := make(chan ports.OperationCancelationRequest, 1000)
+		operationFlow.EXPECT().WatchOperationCancelationRequests(gomock.Any()).Return(requestChannel)
+
+		opManager.WatchOperationCancelationRequests(context.Background())
+		require.Empty(t, opManager.operationCancelFunctions)
+
+		requestChannel <- ports.OperationCancelationRequest{
+			SchedulerName: schedulerName,
+			OperationID:   operationID,
+		}
+
+		require.Empty(t, opManager.operationCancelFunctions[schedulerName])
 	})
 }

--- a/internal/core/services/workers_manager/workers_manager.go
+++ b/internal/core/services/workers_manager/workers_manager.go
@@ -53,7 +53,7 @@ type WorkersManager struct {
 	schedulerStorage           ports.SchedulerStorage
 	CurrentWorkers             map[string]workers.Worker
 	syncWorkersInterval        time.Duration
-	workerOptions              *workers.WorkerOptions
+	WorkerOptions              *workers.WorkerOptions
 	workersStopTimeoutDuration time.Duration
 	workersWaitGroup           sync.WaitGroup
 }
@@ -67,7 +67,7 @@ func NewWorkersManager(builder workers.WorkerBuilder, configs config.Config, sch
 		schedulerStorage:           schedulerStorage,
 		CurrentWorkers:             map[string]workers.Worker{},
 		syncWorkersInterval:        configs.GetDuration(syncWorkersIntervalPath),
-		workerOptions:              workerOptions,
+		WorkerOptions:              workerOptions,
 		workersStopTimeoutDuration: configs.GetDuration(workersStopTimeoutDurationPath),
 	}
 }
@@ -167,7 +167,7 @@ func (w *WorkersManager) getDesirableWorkers(ctx context.Context, schedulers []*
 
 	desirableWorkers := map[string]workers.Worker{}
 	for _, scheduler := range schedulers {
-		desirableWorkers[scheduler.Name] = w.builder(scheduler, w.workerOptions)
+		desirableWorkers[scheduler.Name] = w.builder(scheduler, w.WorkerOptions)
 	}
 
 	for k := range w.CurrentWorkers {

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -100,8 +100,6 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 
 		loopLogger.Info("Starting operation")
 
-		// TODO(gabrielcorado): when we introduce operation cancelation this is
-		// the one to be cancelled. Right now it is only a placeholder.
 		operationContext, operationCancelationFunction := context.WithCancel(ctx)
 
 		err = w.operationManager.StartOperation(operationContext, op, operationCancelationFunction)

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -98,7 +98,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 			continue
 		}
 
-		loopLogger.Info("Starting to process operation")
+		loopLogger.Info("Starting operation")
 
 		// TODO(gabrielcorado): when we introduce operation cancelation this is
 		// the one to be cancelled. Right now it is only a placeholder.
@@ -141,9 +141,11 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 
 		// TODO(gabrielcorado): we need to propagate the error reason.
 		// TODO(gabrielcorado): consider handling the finish operation error.
-		_ = w.operationManager.FinishOperation(operationContext, op)
+		err = w.operationManager.FinishOperation(ctx, op)
+		if err != nil {
+			loopLogger.Error("failed to finish operation", zap.Error(err))
+		}
 	}
-
 }
 
 func (w *OperationExecutionWorker) Stop(_ context.Context) {


### PR DESCRIPTION
## Description

This PR aims to create the operation cancelation watcher, it is composed by:

* A Redis pub/sub subscriber that receives the cancelation events;
* A map of context cancelation function per scheduler name and operation ID;
* Once the event is consumed, the operation manager fetches the context cancelation function and calls it in order to cancel the operation;