### PR TITLE
Runtime watcher instance deleted event

### DIFF
--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
@@ -102,6 +102,11 @@ func (w *runtimeWatcherWorker) processEvent(ctx context.Context, event game_room
 		if err != nil {
 			return fmt.Errorf("failed to update room instance %s: %w", event.Instance.ID, err)
 		}
+	case game_room.InstanceEventTypeDeleted:
+		err := w.roomManager.CleanRoomState(ctx, event.Instance.SchedulerID, event.Instance.ID)
+		if err != nil {
+			return fmt.Errorf("failed to clean room %s state: %w", event.Instance.ID, err)
+		}
 	default:
 		return fmt.Errorf("not implemented")
 	}

--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker_test.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker_test.go
@@ -44,7 +44,7 @@ import (
 )
 
 func TestProcessRuntimeEvents(t *testing.T) {
-	workerOptions := func(t *testing.T) (*gomock.Controller, *instancemock.MockGameRoomInstanceStorage, *runtimemock.MockRuntime, *workers.WorkerOptions) {
+	workerOptions := func(t *testing.T) (*gomock.Controller, *instancemock.MockGameRoomInstanceStorage, *roomstoragemock.MockRoomStorage, *runtimemock.MockRuntime, *workers.WorkerOptions) {
 		mockCtrl := gomock.NewController(t)
 
 		now := time.Now()
@@ -56,14 +56,14 @@ func TestProcessRuntimeEvents(t *testing.T) {
 		config := room_manager.RoomManagerConfig{RoomInitializationTimeoutMillis: time.Millisecond * 1000}
 		roomManager := room_manager.NewRoomManager(fakeClock, portAllocator, roomStorage, instanceStorage, runtime, config)
 
-		return mockCtrl, instanceStorage, runtime, &workers.WorkerOptions{
+		return mockCtrl, instanceStorage, roomStorage, runtime, &workers.WorkerOptions{
 			Runtime:     runtime,
 			RoomManager: roomManager,
 		}
 	}
 
 	t.Run("fails to start watcher", func(t *testing.T) {
-		mockCtrl, _, runtime, workerOptions := workerOptions(t)
+		mockCtrl, _, _, runtime, workerOptions := workerOptions(t)
 		defer mockCtrl.Finish()
 
 		scheduler := &entities.Scheduler{Name: "test"}
@@ -87,7 +87,7 @@ func TestProcessRuntimeEvents(t *testing.T) {
 	})
 
 	t.Run("updates instance on added event", func(t *testing.T) {
-		mockCtrl, instanceStorage, runtime, workerOptions := workerOptions(t)
+		mockCtrl, instanceStorage, _, runtime, workerOptions := workerOptions(t)
 		defer mockCtrl.Finish()
 
 		scheduler := &entities.Scheduler{Name: "test"}
@@ -193,6 +193,65 @@ func TestProcessRuntimeEvents(t *testing.T) {
 			err := <-watcherDone
 			require.NoError(t, err)
 			require.False(t, watcher.IsRunning())
+
+			return true
+		}, time.Second, time.Millisecond)
+	})
+
+	t.Run("updates clean room state on delete event", func(t *testing.T) {
+		mockCtrl, instanceStorage, roomStorage, runtime, workerOptions := workerOptions(t)
+		defer mockCtrl.Finish()
+
+		scheduler := &entities.Scheduler{Name: "test"}
+		watcher := NewRuntimeWatcherWorker(scheduler, workerOptions)
+
+		runtimeWatcher := runtimemock.NewMockRuntimeWatcher(mockCtrl)
+		runtime.EXPECT().WatchGameRoomInstances(gomock.Any(), scheduler).Return(runtimeWatcher, nil)
+
+		resultChan := make(chan game_room.InstanceEvent)
+		runtimeWatcher.EXPECT().ResultChan().Return(resultChan)
+		runtimeWatcher.EXPECT().Stop()
+
+		// instance updates
+		instance := &game_room.Instance{ID: "room-id", SchedulerID: "room-scheduler"}
+
+		removeRoom := false
+		removeInstance := false
+		roomStorage.EXPECT().DeleteRoom(gomock.Any(), instance.SchedulerID, instance.ID).DoAndReturn(func(_ context.Context, _ string, _ string) error {
+			removeRoom = true
+			return nil
+		})
+		instanceStorage.EXPECT().DeleteInstance(gomock.Any(), instance.SchedulerID, instance.ID).DoAndReturn(func(_ context.Context, _ string, _ string) error {
+			removeInstance = true
+			return nil
+		})
+
+		watcherDone := make(chan error)
+		go func() {
+			err := watcher.Start(context.Background())
+			watcherDone <- err
+		}()
+
+		require.Eventually(t, func() bool {
+			resultChan <- game_room.InstanceEvent{
+				Type:     game_room.InstanceEventTypeDeleted,
+				Instance: instance,
+			}
+
+			return true
+		}, time.Second, time.Millisecond)
+
+		// wait until the watcher process the event
+		require.Eventually(t, func() bool {
+			return removeRoom && removeInstance
+		}, time.Second, 100*time.Millisecond)
+
+		// stop the watcher
+		watcher.Stop(context.Background())
+
+		require.Eventually(t, func() bool {
+			err := <-watcherDone
+			require.NoError(t, err)
 
 			return true
 		}, time.Second, time.Millisecond)

--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker_test.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker_test.go
@@ -143,7 +143,7 @@ func TestProcessRuntimeEvents(t *testing.T) {
 	})
 
 	t.Run("when update instance fails, does nothing", func(t *testing.T) {
-		mockCtrl, instanceStorage, runtime, workerOptions := workerOptions(t)
+		mockCtrl, instanceStorage, _, runtime, workerOptions := workerOptions(t)
 		defer mockCtrl.Finish()
 
 		scheduler := &entities.Scheduler{Name: "test"}
@@ -244,6 +244,60 @@ func TestProcessRuntimeEvents(t *testing.T) {
 		// wait until the watcher process the event
 		require.Eventually(t, func() bool {
 			return removeRoom && removeInstance
+		}, time.Second, 100*time.Millisecond)
+
+		// stop the watcher
+		watcher.Stop(context.Background())
+
+		require.Eventually(t, func() bool {
+			err := <-watcherDone
+			require.NoError(t, err)
+
+			return true
+		}, time.Second, time.Millisecond)
+	})
+
+	t.Run("when clean room state fails, does nothing", func(t *testing.T) {
+		mockCtrl, _, roomStorage, runtime, workerOptions := workerOptions(t)
+		defer mockCtrl.Finish()
+
+		scheduler := &entities.Scheduler{Name: "test"}
+		watcher := NewRuntimeWatcherWorker(scheduler, workerOptions)
+
+		runtimeWatcher := runtimemock.NewMockRuntimeWatcher(mockCtrl)
+		runtime.EXPECT().WatchGameRoomInstances(gomock.Any(), scheduler).Return(runtimeWatcher, nil)
+
+		resultChan := make(chan game_room.InstanceEvent)
+		runtimeWatcher.EXPECT().ResultChan().Return(resultChan)
+		runtimeWatcher.EXPECT().Stop()
+
+		// instance updates
+		instance := &game_room.Instance{ID: "room-id", SchedulerID: "room-scheduler"}
+
+		removeRoom := false
+		roomStorage.EXPECT().DeleteRoom(gomock.Any(), instance.SchedulerID, instance.ID).DoAndReturn(func(_ context.Context, _ string, _ string) error {
+			removeRoom = true
+			return porterrors.ErrUnexpected
+		})
+
+		watcherDone := make(chan error)
+		go func() {
+			err := watcher.Start(context.Background())
+			watcherDone <- err
+		}()
+
+		require.Eventually(t, func() bool {
+			resultChan <- game_room.InstanceEvent{
+				Type:     game_room.InstanceEventTypeDeleted,
+				Instance: instance,
+			}
+
+			return true
+		}, time.Second, time.Millisecond)
+
+		// wait until the watcher process the event
+		require.Eventually(t, func() bool {
+			return removeRoom
 		}, time.Second, 100*time.Millisecond)
 
 		// stop the watcher


### PR DESCRIPTION
Implements the process of instance deleted events. It consists of cleaning the room state, which is done by a newly introduced `CleanRoomState` function from `RoomManager`.

NOTE: Right now, this PR is pointing to the branch `feature/runtime-pod-created` (which is the #203 PR). After the #203 is closed, this one should be rebased and the target changed to `next`.