### PR TITLE
Create list game rooms endpoint

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -349,7 +349,7 @@ func (a *App) getRouter() *mux.Router {
 		NewParamMiddleware(func() interface{} { return &models.SchedulerParams{} }),
 	).ServeHTTP).Methods("GET").Name("roomsByMetric")
 
-	r.HandleFunc("/scheduler/{schedulerName}/rooms/{status}", Chain(
+	r.HandleFunc("/scheduler/{schedulerName}/rooms/status/{status}", Chain(
 		NewRoomListBySchedulerAndStatusHandler(a),
 		NewResponseTimeMiddleware(a),
 		NewMetricsReporterMiddleware(a),

--- a/api/app.go
+++ b/api/app.go
@@ -349,6 +349,16 @@ func (a *App) getRouter() *mux.Router {
 		NewParamMiddleware(func() interface{} { return &models.SchedulerParams{} }),
 	).ServeHTTP).Methods("GET").Name("roomsByMetric")
 
+	r.HandleFunc("/scheduler/{schedulerName}/rooms/{status}", Chain(
+		NewRoomListBySchedulerAndStatusHandler(a),
+		NewResponseTimeMiddleware(a),
+		NewMetricsReporterMiddleware(a),
+		NewSentryMiddleware(),
+		NewNewRelicMiddleware(a),
+		NewDogStatsdMiddleware(a),
+		NewParamMiddleware(func() interface{} { return &models.SchedulerRoomsParams{} }),
+	).ServeHTTP).Methods("GET").Name("roomsByStatus")
+
 	r.HandleFunc("/scheduler/{schedulerName}/locks", Chain(
 		NewSchedulerLocksListHandler(a),
 		NewResponseTimeMiddleware(a),

--- a/api/param_middleware.go
+++ b/api/param_middleware.go
@@ -45,6 +45,14 @@ func schedulerParamsFromContext(ctx context.Context) *models.SchedulerParams {
 	return param.(*models.SchedulerParams)
 }
 
+func schedulerRoomsParamsFromContext(ctx context.Context) *models.SchedulerRoomsParams {
+	param := ctx.Value(paramKey)
+	if param == nil {
+		return nil
+	}
+	return param.(*models.SchedulerRoomsParams)
+}
+
 func schedulerLockParamsFromContext(ctx context.Context) *models.SchedulerLockParams {
 	param := ctx.Value(paramKey)
 	if param == nil {

--- a/api/room_handler_test.go
+++ b/api/room_handler_test.go
@@ -1267,7 +1267,7 @@ forwarders:
 		})
 	})
 
-	Describe("GET /scheduler/{schedulerName}/rooms/{status}", func() {
+	Describe("GET /scheduler/{schedulerName}/rooms/status/{status}", func() {
 		namespace := "scheduler-name"
 
 		Describe("when valid parameters are provided", func() {
@@ -1303,7 +1303,7 @@ forwarders:
 				mockRedisClient.EXPECT().HGet("scheduler:scheduler-name:podMap", "test-ready-1").
 					Return(redis.NewStringResult(`{"status":{"startTime": "2021-01-02T15:04:05Z"}, "version": "13"}`, nil))
 
-				url := fmt.Sprintf("/scheduler/%s/rooms/%s?limit=%d&offset=%d", namespace, models.StatusReady, 10, 1)
+				url := fmt.Sprintf("/scheduler/%s/rooms/status/%s?limit=%d&offset=%d", namespace, models.StatusReady, 10, 1)
 				request, err := http.NewRequest("GET", url, nil)
 				Expect(err).NotTo(HaveOccurred())
 				app.Router.ServeHTTP(recorder, request)
@@ -1368,7 +1368,7 @@ forwarders:
 				mockRedisClient.EXPECT().HGet("scheduler:scheduler-name:podMap", "test-ready-1").
 					Return(redis.NewStringResult(`{"status":{"startTime": "2021-01-02T15:04:05Z"}, "version": "13"}`, nil))
 
-				url := fmt.Sprintf("/scheduler/%s/rooms/%s", namespace, models.StatusReady)
+				url := fmt.Sprintf("/scheduler/%s/rooms/status/%s", namespace, models.StatusReady)
 				request, err := http.NewRequest("GET", url, nil)
 				Expect(err).NotTo(HaveOccurred())
 				app.Router.ServeHTTP(recorder, request)
@@ -1406,7 +1406,7 @@ forwarders:
 
 				mockRedisClient.EXPECT().SMembers(gomock.Any()).Return(goredis.NewStringSliceResult(nil, errors.New("some error")))
 
-				url := fmt.Sprintf("/scheduler/%s/rooms/%s", namespace, models.StatusReady)
+				url := fmt.Sprintf("/scheduler/%s/rooms/status/%s", namespace, models.StatusReady)
 				request, err := http.NewRequest("GET", url, nil)
 				Expect(err).NotTo(HaveOccurred())
 				app.Router.ServeHTTP(recorder, request)
@@ -1434,7 +1434,7 @@ forwarders:
 				mockRedisClient.EXPECT().HGet("scheduler:scheduler-name:podMap", "test-ready-1").
 					Return(redis.NewStringResult("", errors.New("some error")))
 
-				url := fmt.Sprintf("/scheduler/%s/rooms/%s", namespace, models.StatusReady)
+				url := fmt.Sprintf("/scheduler/%s/rooms/status/%s", namespace, models.StatusReady)
 				request, err := http.NewRequest("GET", url, nil)
 				Expect(err).NotTo(HaveOccurred())
 				app.Router.ServeHTTP(recorder, request)
@@ -1452,7 +1452,7 @@ forwarders:
 			It("should return with error for negative offset", func() {
 				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 
-				url := fmt.Sprintf("/scheduler/%s/rooms/%s?limit=%d&offset=%d", "bla", models.StatusReady, 10, -1)
+				url := fmt.Sprintf("/scheduler/%s/rooms/status/%s?limit=%d&offset=%d", "bla", models.StatusReady, 10, -1)
 				request, err := http.NewRequest("GET", url, nil)
 				Expect(err).NotTo(HaveOccurred())
 				app.Router.ServeHTTP(recorder, request)
@@ -1467,7 +1467,7 @@ forwarders:
 			It("should return with error for negative limit", func() {
 				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
 
-				url := fmt.Sprintf("/scheduler/%s/rooms/%s?limit=%d&offset=%d", "bla", models.StatusReady, -10, 1)
+				url := fmt.Sprintf("/scheduler/%s/rooms/status/%s?limit=%d&offset=%d", "bla", models.StatusReady, -10, 1)
 				request, err := http.NewRequest("GET", url, nil)
 				Expect(err).NotTo(HaveOccurred())
 				app.Router.ServeHTTP(recorder, request)

--- a/api/room_handler_test.go
+++ b/api/room_handler_test.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"time"
 
+	goredis "github.com/go-redis/redis"
+
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/go-redis/redis"
@@ -1262,6 +1264,221 @@ forwarders:
 			Expect(obj).To(HaveKeyWithValue("description", "something went wrong"))
 			Expect(obj).To(HaveKeyWithValue("error", "list by metrics handler error"))
 			Expect(obj).To(HaveKeyWithValue("success", false))
+		})
+	})
+
+	Describe("GET /scheduler/{schedulerName}/rooms/{status}", func() {
+		namespace := "scheduler-name"
+
+		Describe("when valid parameters are provided", func() {
+			It("should return rooms with success with provided valid offset and limit", func() {
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
+				expectedRooms := []string{
+					"scheduler:scheduler-name:rooms:test-ready-1",
+					"scheduler:scheduler-name:rooms:test-ready-2",
+					"scheduler:scheduler-name:rooms:test-ready-3",
+				}
+
+				mockRedisClient.EXPECT().SMembers(gomock.Any()).Return(goredis.NewStringSliceResult(expectedRooms, nil))
+				mockRedisClient.EXPECT().HGetAll("scheduler:scheduler-name:rooms:test-ready-1").
+					Return(redis.NewStringStringMapResult(map[string]string{
+						"status":   "ready",
+						"lastPing": "1632405900",
+					}, nil))
+				mockRedisClient.EXPECT().HGetAll("scheduler:scheduler-name:rooms:test-ready-2").
+					Return(redis.NewStringStringMapResult(map[string]string{
+						"status":   "ready",
+						"lastPing": "1632405900",
+					}, nil))
+				mockRedisClient.EXPECT().HGetAll("scheduler:scheduler-name:rooms:test-ready-3").
+					Return(redis.NewStringStringMapResult(map[string]string{
+						"status":   "ready",
+						"lastPing": "1632405900",
+					}, nil))
+
+				mockRedisClient.EXPECT().HGet("scheduler:scheduler-name:podMap", "test-ready-3").
+					Return(redis.NewStringResult(`{"status":{"startTime": "2021-01-02T15:04:05Z"}, "version": "13"}`, nil))
+				mockRedisClient.EXPECT().HGet("scheduler:scheduler-name:podMap", "test-ready-2").
+					Return(redis.NewStringResult(`{"status":{"startTime": "2021-01-02T15:04:05Z"}, "version": "13"}`, nil))
+				mockRedisClient.EXPECT().HGet("scheduler:scheduler-name:podMap", "test-ready-1").
+					Return(redis.NewStringResult(`{"status":{"startTime": "2021-01-02T15:04:05Z"}, "version": "13"}`, nil))
+
+				url := fmt.Sprintf("/scheduler/%s/rooms/%s?limit=%d&offset=%d", namespace, models.StatusReady, 10, 1)
+				request, err := http.NewRequest("GET", url, nil)
+				Expect(err).NotTo(HaveOccurred())
+				app.Router.ServeHTTP(recorder, request)
+
+				Expect(recorder.Code).To(Equal(http.StatusOK))
+
+				var roomsResponse []map[string]interface{}
+				err = json.Unmarshal([]byte(recorder.Body.String()), &roomsResponse)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(roomsResponse).To(HaveLen(3))
+				Expect(roomsResponse[0]).To(Equal(map[string]interface{}{
+					"room_id":           "test-ready-1",
+					"created_at":        "2021-01-02T15:04:05Z",
+					"scheduler_name":    "scheduler-name",
+					"scheduler_version": "13",
+					"status":            "ready",
+				}))
+				Expect(roomsResponse[1]).To(Equal(map[string]interface{}{
+					"room_id":           "test-ready-2",
+					"created_at":        "2021-01-02T15:04:05Z",
+					"scheduler_name":    "scheduler-name",
+					"scheduler_version": "13",
+					"status":            "ready",
+				}))
+				Expect(roomsResponse[2]).To(Equal(map[string]interface{}{
+					"room_id":           "test-ready-3",
+					"created_at":        "2021-01-02T15:04:05Z",
+					"scheduler_name":    "scheduler-name",
+					"scheduler_version": "13",
+					"status":            "ready",
+				}))
+			})
+			It("should return rooms with success for absent offset and limit", func() {
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
+				expectedRooms := []string{
+					"scheduler:scheduler-name:rooms:test-ready-1",
+					"scheduler:scheduler-name:rooms:test-ready-2",
+					"scheduler:scheduler-name:rooms:test-ready-3",
+				}
+
+				mockRedisClient.EXPECT().SMembers(gomock.Any()).Return(goredis.NewStringSliceResult(expectedRooms, nil))
+				mockRedisClient.EXPECT().HGetAll("scheduler:scheduler-name:rooms:test-ready-1").
+					Return(redis.NewStringStringMapResult(map[string]string{
+						"status":   "ready",
+						"lastPing": "1632405900",
+					}, nil))
+				mockRedisClient.EXPECT().HGetAll("scheduler:scheduler-name:rooms:test-ready-2").
+					Return(redis.NewStringStringMapResult(map[string]string{
+						"status":   "ready",
+						"lastPing": "1632405900",
+					}, nil))
+				mockRedisClient.EXPECT().HGetAll("scheduler:scheduler-name:rooms:test-ready-3").
+					Return(redis.NewStringStringMapResult(map[string]string{
+						"status":   "ready",
+						"lastPing": "1632405900",
+					}, nil))
+
+				mockRedisClient.EXPECT().HGet("scheduler:scheduler-name:podMap", "test-ready-3").
+					Return(redis.NewStringResult(`{"status":{"startTime": "2021-01-02T15:04:05Z"}, "version": "13"}`, nil))
+				mockRedisClient.EXPECT().HGet("scheduler:scheduler-name:podMap", "test-ready-2").
+					Return(redis.NewStringResult(`{"status":{"startTime": "2021-01-02T15:04:05Z"}, "version": "13"}`, nil))
+				mockRedisClient.EXPECT().HGet("scheduler:scheduler-name:podMap", "test-ready-1").
+					Return(redis.NewStringResult(`{"status":{"startTime": "2021-01-02T15:04:05Z"}, "version": "13"}`, nil))
+
+				url := fmt.Sprintf("/scheduler/%s/rooms/%s", namespace, models.StatusReady)
+				request, err := http.NewRequest("GET", url, nil)
+				Expect(err).NotTo(HaveOccurred())
+				app.Router.ServeHTTP(recorder, request)
+
+				Expect(recorder.Code).To(Equal(http.StatusOK))
+
+				var roomsResponse []map[string]interface{}
+				err = json.Unmarshal([]byte(recorder.Body.String()), &roomsResponse)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(roomsResponse).To(HaveLen(3))
+				Expect(roomsResponse[0]).To(Equal(map[string]interface{}{
+					"room_id":           "test-ready-1",
+					"created_at":        "2021-01-02T15:04:05Z",
+					"scheduler_name":    "scheduler-name",
+					"scheduler_version": "13",
+					"status":            "ready",
+				}))
+				Expect(roomsResponse[1]).To(Equal(map[string]interface{}{
+					"room_id":           "test-ready-2",
+					"created_at":        "2021-01-02T15:04:05Z",
+					"scheduler_name":    "scheduler-name",
+					"scheduler_version": "13",
+					"status":            "ready",
+				}))
+				Expect(roomsResponse[2]).To(Equal(map[string]interface{}{
+					"room_id":           "test-ready-3",
+					"created_at":        "2021-01-02T15:04:05Z",
+					"scheduler_name":    "scheduler-name",
+					"scheduler_version": "13",
+					"status":            "ready",
+				}))
+			})
+			It("should return with error if some error occur on getting rooms", func() {
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
+
+				mockRedisClient.EXPECT().SMembers(gomock.Any()).Return(goredis.NewStringSliceResult(nil, errors.New("some error")))
+
+				url := fmt.Sprintf("/scheduler/%s/rooms/%s", namespace, models.StatusReady)
+				request, err := http.NewRequest("GET", url, nil)
+				Expect(err).NotTo(HaveOccurred())
+				app.Router.ServeHTTP(recorder, request)
+
+				Expect(recorder.Code).To(Equal(http.StatusInternalServerError))
+
+				var response map[string]interface{}
+				err = json.Unmarshal([]byte(recorder.Body.String()), &response)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response["description"]).To(Equal("some error"))
+			})
+			It("should return with error if some error occur on getting pods", func() {
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
+				expectedRooms := []string{
+					"scheduler:scheduler-name:rooms:test-ready-1",
+				}
+
+				mockRedisClient.EXPECT().SMembers(gomock.Any()).Return(goredis.NewStringSliceResult(expectedRooms, nil))
+				mockRedisClient.EXPECT().HGetAll("scheduler:scheduler-name:rooms:test-ready-1").
+					Return(redis.NewStringStringMapResult(map[string]string{
+						"status":   "ready",
+						"lastPing": "1632405900",
+					}, nil))
+
+				mockRedisClient.EXPECT().HGet("scheduler:scheduler-name:podMap", "test-ready-1").
+					Return(redis.NewStringResult("", errors.New("some error")))
+
+				url := fmt.Sprintf("/scheduler/%s/rooms/%s", namespace, models.StatusReady)
+				request, err := http.NewRequest("GET", url, nil)
+				Expect(err).NotTo(HaveOccurred())
+				app.Router.ServeHTTP(recorder, request)
+
+				Expect(recorder.Code).To(Equal(http.StatusInternalServerError))
+
+				var response map[string]interface{}
+				err = json.Unmarshal([]byte(recorder.Body.String()), &response)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response["description"]).To(Equal("some error"))
+			})
+		})
+
+		Context("when invalid parameters are provided", func() {
+			It("should return with error for negative offset", func() {
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
+
+				url := fmt.Sprintf("/scheduler/%s/rooms/%s?limit=%d&offset=%d", "bla", models.StatusReady, 10, -1)
+				request, err := http.NewRequest("GET", url, nil)
+				Expect(err).NotTo(HaveOccurred())
+				app.Router.ServeHTTP(recorder, request)
+
+				Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+
+				var response map[string]interface{}
+				err = json.Unmarshal([]byte(recorder.Body.String()), &response)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response["description"]).To(Equal("offset value should be greater than 0"))
+			})
+			It("should return with error for negative limit", func() {
+				mockRedisTraceWrapper.EXPECT().WithContext(gomock.Any(), mockRedisClient).Return(mockRedisClient)
+
+				url := fmt.Sprintf("/scheduler/%s/rooms/%s?limit=%d&offset=%d", "bla", models.StatusReady, -10, 1)
+				request, err := http.NewRequest("GET", url, nil)
+				Expect(err).NotTo(HaveOccurred())
+				app.Router.ServeHTTP(recorder, request)
+
+				Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+
+				var response map[string]interface{}
+				err = json.Unmarshal([]byte(recorder.Body.String()), &response)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response["description"]).To(Equal("limit value should be greater than 0"))
+			})
 		})
 	})
 })

--- a/models/params.go
+++ b/models/params.go
@@ -25,6 +25,12 @@ type SchedulerEventsParams struct {
 	SchedulerName string `json:"schedulerName" valid:"required"`
 }
 
+// SchedulerRoomsParams is the struct that defines the params for scheduler events routes
+type SchedulerRoomsParams struct {
+	SchedulerName string `json:"schedulerName" valid:"required"`
+	Status        string `json:"status" valid:"required"`
+}
+
 // SchedulerLockParams is the struct that defines the params for scheduler locks routes
 type SchedulerLockParams struct {
 	SchedulerName string `json:"schedulerName" valid:"required"`


### PR DESCRIPTION
## What ❓ 
This PR add a new endpoint to maestro for listing game rooms details based on a scheduler name and a specific status, parametrized by an optional limit and offset values for enabling pagination.

Added a new handler, including tests and parameters definition, alongside a new method o rooms model `GetRoomsByStatus` for retrieving rooms of a specific status and scheduler name. 

The new endpoint contract:

```
GET /schedulers/:name/rooms/status/:status?limit=<int>&offset=<int>

Response body:
{
  [
    {
        "scheduler_name": string,
	"scheduler_version": string,
	"room_id": string,
	"status": string,
	"created_at": string
    }
    ...
  ]
}
```