### PR TITLE
Feature: operation cancelation e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ run/e2e-tests: deps/stop build/worker build/management-api build/rooms-api build
 
 .PHONY: build/worker
 build/worker:
-	@rm -f ./bin/worker-*
+	@rm -f ./bin/worker-* || true
 	@go build -o ./bin/worker ./cmd/worker
 	@env GOOS=linux GOARCH=amd64 go build -o ./bin/worker-linux-x86_64 ./cmd/worker
 
@@ -58,7 +58,7 @@ run/worker: build/worker
 
 .PHONY: build/management-api
 build/management-api:
-	@rm -f ./bin/management-api-*
+	@rm -f ./bin/management-api-* || true
 	@go build -o ./bin/management-api ./cmd/management_api
 	@env GOOS=linux GOARCH=amd64 go build -o ./bin/management-api-linux-x86_64 ./cmd/management_api
 
@@ -68,7 +68,7 @@ run/management-api: build/management-api
 
 .PHONY: build/rooms-api
 build/rooms-api:
-	@rm -f ./bin/rooms-api-*
+	@rm -f ./bin/rooms-api-* || true
 	@go build -o ./bin/rooms-api ./cmd/rooms_api
 	@env GOOS=linux GOARCH=amd64 go build -o ./bin/rooms-api-linux-x86_64 ./cmd/rooms_api
 
@@ -78,7 +78,7 @@ run/rooms-api: build/rooms-api
 
 .PHONY: build/runtime-watcher
 build/runtime-watcher:
-	@rm -f ./bin/runtime-watcher-*
+	@rm -f ./bin/runtime-watcher-* || true
 	@go build -o ./bin/runtime-watcher ./cmd/runtime_watcher
 	@env GOOS=linux GOARCH=amd64 go build -o ./bin/runtime-watcher-linux-x86_64 ./cmd/runtime_watcher
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ license-check:
 	@go run github.com/google/addlicense -skip yaml -skip yml -skip proto -check .
 
 .PHONY: run/e2e-tests
-run/e2e-tests: deps/stop
+run/e2e-tests: deps/stop build/worker build/management-api build/rooms-api build/runtime-watcher
 	cd e2e; go mod download; go test -count=1 ./suites/...
 
 ################################################################################
@@ -48,8 +48,9 @@ run/e2e-tests: deps/stop
 
 .PHONY: build/worker
 build/worker:
-	@rm -f ./bin/worker
+	@rm -f ./bin/worker-*
 	@go build -o ./bin/worker ./cmd/worker
+	@env GOOS=linux GOARCH=amd64 go build -o ./bin/worker-linux-x86_64 ./cmd/worker
 
 .PHONY: run/worker
 run/worker: build/worker
@@ -57,8 +58,9 @@ run/worker: build/worker
 
 .PHONY: build/management-api
 build/management-api:
-	@rm -f ./bin/management-api
+	@rm -f ./bin/management-api-*
 	@go build -o ./bin/management-api ./cmd/management_api
+	@env GOOS=linux GOARCH=amd64 go build -o ./bin/management-api-linux-x86_64 ./cmd/management_api
 
 .PHONY: run/management-api
 run/management-api: build/management-api
@@ -66,8 +68,9 @@ run/management-api: build/management-api
 
 .PHONY: build/rooms-api
 build/rooms-api:
-	@rm -f ./bin/rooms-api
+	@rm -f ./bin/rooms-api-*
 	@go build -o ./bin/rooms-api ./cmd/rooms_api
+	@env GOOS=linux GOARCH=amd64 go build -o ./bin/rooms-api-linux-x86_64 ./cmd/rooms_api
 
 .PHONY: run/rooms-api
 run/rooms-api: build/rooms-api
@@ -75,8 +78,9 @@ run/rooms-api: build/rooms-api
 
 .PHONY: build/runtime-watcher
 build/runtime-watcher:
-	@rm -f ./bin/runtime-watcher
+	@rm -f ./bin/runtime-watcher-*
 	@go build -o ./bin/runtime-watcher ./cmd/runtime_watcher
+	@env GOOS=linux GOARCH=amd64 go build -o ./bin/runtime-watcher-linux-x86_64 ./cmd/runtime_watcher
 
 .PHONY: run/runtime-watcher
 run/runtime-watcher: build/runtime-watcher

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ migrate:
 deps/start:
 	@echo "Starting dependencies "
 	@docker-compose --project-name maestro up -d
-	@sleep 10
 	@echo "Dependencies started successfully."
 
 .PHONY: deps/stop

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -24,7 +24,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"os"
 	"os/signal"
@@ -75,12 +74,13 @@ func main() {
 
 	go func() {
 		zap.L().Info("starting operation cancelation request watcher")
-		err := operationExecutionWorkerManager.WorkerOptions.OperationManager.WatchOperationCancelationRequests(ctx)
-		if err != nil && !errors.Is(err, context.Canceled) {
+		err = operationExecutionWorkerManager.WorkerOptions.OperationManager.WatchOperationCancelationRequests(ctx)
+		if err != nil {
 			zap.L().With(zap.Error(err)).Info("operation cancelation watcher stopped with error")
 			// enforce the cancelation
 			cancelFn()
 		}
+		zap.L().Info("operation cancelation request watcher stoped")
 	}()
 
 	go func() {
@@ -91,6 +91,7 @@ func main() {
 			// enforce the cancelation
 			cancelFn()
 		}
+		zap.L().Info("operation execution worker manager stoped")
 	}()
 
 	<-ctx.Done()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,33 +62,6 @@ services:
     ports:
     - "6379:6379"
 
-  worker:
-    build:
-      context: .
-      dockerfile: ./docker/worker/Dockerfile
-      args:
-        CONFIG_FILE_PATH: "config/worker_container.local.yaml"
-    ports:
-      - "8082:8082"
-
-  rooms-api:
-    build:
-      context: .
-      dockerfile: ./docker/rooms-api/Dockerfile
-      args:
-        CONFIG_FILE_PATH: "config/rooms-api_container.local.yaml"
-    ports:
-      - "8090:8090"
-
-  management-api:
-    build:
-      context: .
-      dockerfile: ./docker/management-api/Dockerfile
-      args:
-        CONFIG_FILE_PATH: "config/management-api_container.local.yaml"
-    ports:
-      - "8080:8080"
-
 volumes:
   k3s-server: {}
   postgres: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,11 +56,21 @@ services:
     - POSTGRES_DB=maestro
     - POSTGRES_USER=maestro
     - POSTGRES_PASSWORD=maestro
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 
   redis:
     image: redis:5.0.10-alpine
     ports:
     - "6379:6379"
+    healthcheck:
+      test:  [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 
 volumes:
   k3s-server: {}

--- a/docker/management-api/Dockerfile
+++ b/docker/management-api/Dockerfile
@@ -18,25 +18,11 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-
-FROM golang:1.16.3-buster AS build-env
+FROM alpine:3
 
 MAINTAINER TFG Co <backend@tfgco.com>
 
-RUN mkdir -p /app
-
-RUN apt update && apt install --no-install-recommends -y git make
-RUN go install github.com/jteeuwen/go-bindata/...
-COPY . /go/src/github.com/topfreegames/maestro
-
-RUN cd /go/src/github.com/topfreegames/maestro && \
-  make build/management-api && \
-  mv bin/management-api /app/management-api && \
-  mv config /app/config
-
-FROM debian:buster-slim
-
-RUN apt update && apt install -y ca-certificates openssl
+RUN apk add ca-certificates openssl
 
 ARG MAESTRO_ADAPTERS_SCHEDULERSTORAGE_POSTGRES_URL
 ENV MAESTRO_ADAPTERS_SCHEDULERSTORAGE_POSTGRES_URL=$MAESTRO_ADAPTERS_SCHEDULERSTORAGE_POSTGRES_URL
@@ -47,8 +33,8 @@ ENV MAESTRO_ADAPTERS_OPERATIONSTORAGE_REDIS_URL=$MAESTRO_ADAPTERS_OPERATIONSTORA
 
 WORKDIR /app
 
-COPY --from=build-env /app/management-api /app/management-api
-COPY --from=build-env /app/config /app/config
+COPY ./bin/management-api-linux-x86_64 /app/management-api
+COPY ./config /app/config
 
 EXPOSE 8080
 

--- a/docker/rooms-api/Dockerfile
+++ b/docker/rooms-api/Dockerfile
@@ -19,25 +19,11 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-FROM golang:1.16.3-buster AS build-env
+FROM alpine:3
 
 MAINTAINER TFG Co <backend@tfgco.com>
 
-RUN mkdir -p /app
-
-RUN apt update && apt install --no-install-recommends -y git make
-RUN go install github.com/jteeuwen/go-bindata/...
-COPY . /go/src/github.com/topfreegames/maestro
-
-RUN cd /go/src/github.com/topfreegames/maestro && \
-  make build/rooms-api && \
-  mv bin/rooms-api /app/rooms-api && \
-  mv config /app/config
-
-
-FROM debian:buster-slim
-
-RUN apt update && apt install -y ca-certificates openssl
+RUN apk add ca-certificates openssl
 
 ARG MAESTRO_ADAPTERS_ROOMSTORAGE_REDIS_URL
 ENV MAESTRO_ADAPTERS_ROOMSTORAGE_REDIS_URL=$MAESTRO_ADAPTERS_ROOMSTORAGE_REDIS_URL
@@ -50,8 +36,8 @@ ENV MAESTRO_ADAPTERS_RUNTIME_KUBERNETES_MASTERURL=$MAESTRO_ADAPTERS_RUNTIME_KUBE
 
 WORKDIR /app
 
-COPY --from=build-env /app/rooms-api /app/rooms-api
-COPY --from=build-env /app/config /app/config
+COPY ./bin/rooms-api-linux-x86_64 /app/rooms-api
+COPY ./config /app/config
 
 EXPOSE 8090
 

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -19,26 +19,11 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-FROM golang:1.16.3-buster AS build-env
+FROM alpine:3
 
 MAINTAINER TFG Co <backend@tfgco.com>
 
-RUN mkdir -p /app
-
-RUN apt update && apt install --no-install-recommends -y git make
-RUN go install github.com/jteeuwen/go-bindata/...
-COPY . /go/src/github.com/topfreegames/maestro
-
-RUN cd /go/src/github.com/topfreegames/maestro && \
-  make build/worker && \
-  mv bin/worker /app/worker && \
-  mv config /app/config
-
-
-FROM debian:buster-slim
-
-RUN apt update && apt install -y ca-certificates openssl
-
+RUN apk add ca-certificates openssl
 
 ARG MAESTRO_ADAPTERS_SCHEDULERSTORAGE_POSTGRES_URL
 ENV MAESTRO_ADAPTERS_SCHEDULERSTORAGE_POSTGRES_URL=$MAESTRO_ADAPTERS_SCHEDULERSTORAGE_POSTGRES_URL
@@ -58,8 +43,8 @@ ENV MAESTRO_ADAPTERS_RUNTIME_KUBERNETES_MASTERURL=$MAESTRO_ADAPTERS_RUNTIME_KUBE
 
 WORKDIR /app
 
-COPY --from=build-env /app/worker /app/worker
-COPY --from=build-env /app/config /app/config
+COPY ./bin/worker-linux-x86_64 /app/worker
+COPY ./config /app/config
 
 EXPOSE 8082
 

--- a/e2e/framework/maestro/docker-compose.yml
+++ b/e2e/framework/maestro/docker-compose.yml
@@ -110,6 +110,11 @@ services:
     image: redis:5.0.10-alpine
     ports:
     - "6379:6379"
+    healthcheck:
+      test:  [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 
 volumes:
   kubeconfig: {}

--- a/e2e/framework/redis.go
+++ b/e2e/framework/redis.go
@@ -24,6 +24,7 @@ package framework
 
 import (
 	"github.com/go-redis/redis"
+	redisV8 "github.com/go-redis/redis/v8"
 )
 
 func getRedisConnection(address string) (*redis.Client, error) {
@@ -32,4 +33,12 @@ func getRedisConnection(address string) (*redis.Client, error) {
 		return nil, err
 	}
 	return redis.NewClient(opts), nil
+}
+
+func getRedisConnectionV8(address string) (*redisV8.Client, error) {
+	opts, err := redisV8.ParseURL(address)
+	if err != nil {
+		return nil, err
+	}
+	return redisV8.NewClient(opts), nil
 }

--- a/e2e/framework/wrappers.go
+++ b/e2e/framework/wrappers.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// TODO: remove the old redis client version
 func WithClients(t *testing.T, testCase func(apiClient *APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, redisClientV8 *redisV8.Client, maestro *maestro.MaestroInstance)) {
 	client := NewAPIClient(defaultMaestro.ManagementApiServer.Address)
 

--- a/e2e/framework/wrappers.go
+++ b/e2e/framework/wrappers.go
@@ -26,13 +26,14 @@ import (
 	"testing"
 
 	"github.com/go-redis/redis"
+	redisV8 "github.com/go-redis/redis/v8"
 
 	"github.com/topfreegames/maestro/e2e/framework/maestro"
 
 	"k8s.io/client-go/kubernetes"
 )
 
-func WithClients(t *testing.T, testCase func(apiClient *APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance)) {
+func WithClients(t *testing.T, testCase func(apiClient *APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, redisClientV8 *redisV8.Client, maestro *maestro.MaestroInstance)) {
 	client := NewAPIClient(defaultMaestro.ManagementApiServer.Address)
 
 	kubeClient, err := getKubeClient()
@@ -43,6 +44,10 @@ func WithClients(t *testing.T, testCase func(apiClient *APIClient, kubeClient ku
 	if err != nil {
 		t.Fatal(err)
 	}
+	redisClientV8, err := getRedisConnectionV8(defaultMaestro.Deps.RedisAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	testCase(client, kubeClient, redisClient, defaultMaestro)
+	testCase(client, kubeClient, redisClient, redisClientV8, defaultMaestro)
 }

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -3,11 +3,13 @@ module github.com/topfreegames/maestro/e2e
 go 1.16
 
 require (
+	github.com/go-redis/redis v6.15.9+incompatible
+	github.com/go-redis/redis/v8 v8.10.0 // indirect
 	github.com/golang/protobuf v1.5.2
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/testcontainers/testcontainers-go v0.11.1
 	github.com/topfreegames/maestro v0.0.0-00010101000000-000000000000
-	github.com/go-redis/redis v6.15.9+incompatible
 	k8s.io/apimachinery v0.22.1
 	k8s.io/apiserver v0.22.1
 	k8s.io/client-go v0.22.1

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -852,6 +852,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.5.0 h1:I7ELFeVBr3yfPIcc8+MWvrjk+3VjbcSzoXm3JVa+jD8=
 github.com/google/wire v0.5.0/go.mod h1:ngWDr9Qvq3yZA10YrxfyGELY/AFWGVpy9c1LTRi1EoU=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=

--- a/e2e/suites/management/add_rooms_test.go
+++ b/e2e/suites/management/add_rooms_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/go-redis/redis"
+	redisV8 "github.com/go-redis/redis/v8"
 	roomStorageRedis "github.com/topfreegames/maestro/internal/adapters/room_storage/redis"
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 
@@ -43,7 +44,7 @@ import (
 )
 
 func TestAddRooms(t *testing.T) {
-	framework.WithClients(t, func(apiClient *framework.APIClient, kubeclient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
+	framework.WithClients(t, func(apiClient *framework.APIClient, kubeclient kubernetes.Interface, redisClient *redis.Client, redisClientV8 *redisV8.Client, maestro *maestro.MaestroInstance) {
 
 		roomsStorage := roomStorageRedis.NewRedisStateStorage(redisClient)
 

--- a/e2e/suites/management/cancel_operation_test.go
+++ b/e2e/suites/management/cancel_operation_test.go
@@ -1,0 +1,116 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package management
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis"
+	redisV8 "github.com/go-redis/redis/v8"
+	"github.com/google/uuid"
+	timeClock "github.com/topfreegames/maestro/internal/adapters/clock/time"
+	operationFlowRedis "github.com/topfreegames/maestro/internal/adapters/operation_flow/redis"
+	operationStorageRedis "github.com/topfreegames/maestro/internal/adapters/operation_storage/redis"
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/operations/test_operation"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/topfreegames/maestro/e2e/framework/maestro"
+
+	"github.com/topfreegames/maestro/e2e/framework"
+	maestroApiV1 "github.com/topfreegames/maestro/pkg/api/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func TestCancelOperation(t *testing.T) {
+	framework.WithClients(t, func(apiClient *framework.APIClient, kubeclient kubernetes.Interface, redisClient *redis.Client, redisClientV8 *redisV8.Client, maestro *maestro.MaestroInstance) {
+
+		operationStorage := operationStorageRedis.NewRedisOperationStorage(redisClientV8, timeClock.NewClock())
+		operationFlow := operationFlowRedis.NewRedisOperationFlow(redisClientV8)
+
+		t.Run("cancel slow operation successfully", func(t *testing.T) {
+			ctx := context.Background()
+			schedulerName, err := createSchedulerAndWaitForIt(
+				t,
+				maestro,
+				apiClient,
+				kubeclient,
+				[]string{"sh", "-c", "tail -f /dev/null"},
+			)
+
+			definition := test_operation.TestOperationDefinition{
+				SleepSeconds: 100000,
+			}
+
+			op := &operation.Operation{
+				ID:             uuid.NewString(),
+				Status:         operation.StatusPending,
+				DefinitionName: definition.Name(),
+				SchedulerName:  schedulerName,
+				CreatedAt:      time.Now(),
+			}
+		
+			err = operationStorage.CreateOperation(ctx, op, definition.Marshal())
+			require.NoError(t, err)
+			err = operationFlow.InsertOperationID(ctx, op.SchedulerName, op.ID)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				listOperationsRequest := &maestroApiV1.ListOperationsRequest{}
+				listOperationsResponse := &maestroApiV1.ListOperationsResponse{}
+				err = apiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", schedulerName), listOperationsRequest, listOperationsResponse)
+				require.NoError(t, err)
+
+				if len(listOperationsResponse.ActiveOperations) < 1 {
+					return false
+				}
+
+				require.Equal(t, "test_operation", listOperationsResponse.ActiveOperations[0].DefinitionName)
+				return true
+			}, 240*time.Second, time.Second)
+
+
+			cancelOperationRequest := &maestroApiV1.CancelOperationRequest{SchedulerName: schedulerName, OperationId: op.ID}
+			cancelOperationResponse := &maestroApiV1.CancelOperationResponse{}
+			err = apiClient.Do("POST", fmt.Sprintf("/schedulers/%s/operations/%s/cancel", schedulerName, op.ID), cancelOperationRequest, cancelOperationResponse)
+
+			require.Eventually(t, func() bool {
+				listOperationsRequest := &maestroApiV1.ListOperationsRequest{}
+				listOperationsResponse := &maestroApiV1.ListOperationsResponse{}
+				err = apiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", schedulerName), listOperationsRequest, listOperationsResponse)
+				require.NoError(t, err)
+
+				if len(listOperationsResponse.FinishedOperations) < 3 {
+					return false
+				}
+
+				require.Equal(t, "test_operation", listOperationsResponse.FinishedOperations[2].DefinitionName)
+				return true
+			}, 240*time.Second, time.Second)
+		})
+	})
+}

--- a/e2e/suites/management/cancel_operation_test.go
+++ b/e2e/suites/management/cancel_operation_test.go
@@ -97,6 +97,7 @@ func TestCancelOperation(t *testing.T) {
 			cancelOperationRequest := &maestroApiV1.CancelOperationRequest{SchedulerName: schedulerName, OperationId: op.ID}
 			cancelOperationResponse := &maestroApiV1.CancelOperationResponse{}
 			err = apiClient.Do("POST", fmt.Sprintf("/schedulers/%s/operations/%s/cancel", schedulerName, op.ID), cancelOperationRequest, cancelOperationResponse)
+			require.NoError(t, err)
 
 			require.Eventually(t, func() bool {
 				listOperationsRequest := &maestroApiV1.ListOperationsRequest{}
@@ -104,11 +105,11 @@ func TestCancelOperation(t *testing.T) {
 				err = apiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", schedulerName), listOperationsRequest, listOperationsResponse)
 				require.NoError(t, err)
 
-				if len(listOperationsResponse.FinishedOperations) < 3 {
+				if len(listOperationsResponse.FinishedOperations) < 2 {
 					return false
 				}
 
-				require.Equal(t, "test_operation", listOperationsResponse.FinishedOperations[2].DefinitionName)
+				require.Equal(t, "test_operation", listOperationsResponse.FinishedOperations[1].DefinitionName)
 				return true
 			}, 240*time.Second, time.Second)
 		})

--- a/e2e/suites/management/cancel_operation_test.go
+++ b/e2e/suites/management/cancel_operation_test.go
@@ -73,7 +73,7 @@ func TestCancelOperation(t *testing.T) {
 				SchedulerName:  schedulerName,
 				CreatedAt:      time.Now(),
 			}
-		
+
 			err = operationStorage.CreateOperation(ctx, op, definition.Marshal())
 			require.NoError(t, err)
 			err = operationFlow.InsertOperationID(ctx, op.SchedulerName, op.ID)
@@ -92,7 +92,6 @@ func TestCancelOperation(t *testing.T) {
 				require.Equal(t, "test_operation", listOperationsResponse.ActiveOperations[0].DefinitionName)
 				return true
 			}, 240*time.Second, time.Second)
-
 
 			cancelOperationRequest := &maestroApiV1.CancelOperationRequest{SchedulerName: schedulerName, OperationId: op.ID}
 			cancelOperationResponse := &maestroApiV1.CancelOperationResponse{}

--- a/e2e/suites/management/create_scheduler_test.go
+++ b/e2e/suites/management/create_scheduler_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/go-redis/redis"
+	redisV8 "github.com/go-redis/redis/v8"
 
 	"github.com/topfreegames/maestro/e2e/framework/maestro"
 
@@ -40,7 +41,7 @@ import (
 )
 
 func TestCreateScheduler(t *testing.T) {
-	framework.WithClients(t, func(apiClient *framework.APIClient, kubeclient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
+	framework.WithClients(t, func(apiClient *framework.APIClient, kubeclient kubernetes.Interface, redisClient *redis.Client, redisClientV8 *redisV8.Client, maestro *maestro.MaestroInstance) {
 		schedulerName := framework.GenerateSchedulerName()
 		createRequest := &maestrov1.CreateSchedulerRequest{
 			Name:                   schedulerName,

--- a/internal/adapters/operation_flow/redis/redis.go
+++ b/internal/adapters/operation_flow/redis/redis.go
@@ -106,12 +106,12 @@ func (r *redisOperationFlow) WatchOperationCancelationRequests(ctx context.Conte
 
 	go func() {
 		defer sub.Close()
+		defer close(resultChan)
 
 		for {
 			select {
 			case msg, ok := <-sub.Channel():
 				if !ok {
-					close(resultChan)
 					return
 				}
 
@@ -124,7 +124,6 @@ func (r *redisOperationFlow) WatchOperationCancelationRequests(ctx context.Conte
 
 				resultChan <- request
 			case <-ctx.Done():
-				close(resultChan)
 				return
 			}
 		}

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/topfreegames/maestro/internal/core/operations/add_rooms"
 	"github.com/topfreegames/maestro/internal/core/operations/create_scheduler"
 	"github.com/topfreegames/maestro/internal/core/operations/remove_rooms"
+	"github.com/topfreegames/maestro/internal/core/operations/test_operation"
 	"github.com/topfreegames/maestro/internal/core/ports"
 	"github.com/topfreegames/maestro/internal/core/services/room_manager"
 )
@@ -43,6 +44,9 @@ func ProvideDefinitionConstructors() map[string]operations.DefinitionConstructor
 	definitionConstructors[remove_rooms.OperationName] = func() operations.Definition {
 		return &remove_rooms.RemoveRoomsDefinition{}
 	}
+	definitionConstructors[test_operation.OperationName] = func() operations.Definition {
+		return &test_operation.TestOperationDefinition{}
+	}
 
 	return definitionConstructors
 
@@ -57,6 +61,8 @@ func ProvideExecutors(
 	executors := map[string]operations.Executor{}
 	executors[create_scheduler.OperationName] = create_scheduler.NewExecutor(runtime, schedulerStorage)
 	executors[add_rooms.OperationName] = add_rooms.NewExecutor(roomManager, schedulerStorage)
+	executors[remove_rooms.OperationName] = remove_rooms.NewExecutor(roomManager)
+	executors[test_operation.OperationName] = test_operation.NewExecutor()
 
 	return executors
 

--- a/internal/core/operations/test_operation/test_operation_definition.go
+++ b/internal/core/operations/test_operation/test_operation_definition.go
@@ -1,0 +1,65 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package test_operation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"go.uber.org/zap"
+)
+
+const OperationName = "test_operation"
+
+type TestOperationDefinition struct {
+	SleepSeconds int `json:"sleepSeconds"`
+}
+
+func (d *TestOperationDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
+	return true
+}
+
+func (d *TestOperationDefinition) Name() string {
+	return OperationName
+}
+
+func (d *TestOperationDefinition) Marshal() []byte {
+	bytes, err := json.Marshal(d)
+	if err != nil {
+		zap.L().With(zap.Error(err)).Error("error marshalling test operation definition")
+		return nil
+	}
+
+	return bytes
+}
+
+func (d *TestOperationDefinition) Unmarshal(raw []byte) error {
+	err := json.Unmarshal(raw, d)
+	if err != nil {
+		return fmt.Errorf("error marshalling test operation definition: %w", err)
+	}
+
+	return nil
+}

--- a/internal/core/operations/test_operation/test_operation_executor.go
+++ b/internal/core/operations/test_operation/test_operation_executor.go
@@ -37,12 +37,21 @@ func NewExecutor() *TestOperationExecutor {
 	return &TestOperationExecutor{}
 }
 
-func (e *TestOperationExecutor) Execute(_ctx context.Context, _op *operation.Operation, definition operations.Definition) error {
+func (e *TestOperationExecutor) Execute(ctx context.Context, _op *operation.Operation, definition operations.Definition) error {
 	testOperationDefinition := definition.(*TestOperationDefinition)
 
 	zap.L().Sugar().Infof("sleeping routine for %d seconds", testOperationDefinition.SleepSeconds)
 
-	time.Sleep(time.Duration(testOperationDefinition.SleepSeconds) * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
+	for i := 1; i < testOperationDefinition.SleepSeconds; i += 1 {
+		select {
+		case <-ticker.C:
+			continue
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 
 	zap.L().Sugar().Infof("routine slept for %d seconds", testOperationDefinition.SleepSeconds)
 

--- a/internal/core/operations/test_operation/test_operation_executor.go
+++ b/internal/core/operations/test_operation/test_operation_executor.go
@@ -1,0 +1,59 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package test_operation
+
+import (
+	"context"
+	"time"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/operations"
+	"go.uber.org/zap"
+)
+
+type TestOperationExecutor struct{}
+
+func NewExecutor() *TestOperationExecutor {
+	return &TestOperationExecutor{}
+}
+
+func (e *TestOperationExecutor) Execute(_ctx context.Context, _op *operation.Operation, definition operations.Definition) error {
+	testOperationDefinition := definition.(*TestOperationDefinition)
+
+	zap.L().Sugar().Infof("sleeping routine for %d seconds", testOperationDefinition.SleepSeconds)
+
+	time.Sleep(time.Duration(testOperationDefinition.SleepSeconds) * time.Second)
+
+	zap.L().Sugar().Infof("routine slept for %d seconds", testOperationDefinition.SleepSeconds)
+
+	return nil
+}
+
+// OnError will do nothing.
+func (e *TestOperationExecutor) OnError(_ context.Context, _ *operation.Operation, _ operations.Definition, _ error) error {
+	return nil
+}
+
+func (e *TestOperationExecutor) Name() string {
+	return OperationName
+}

--- a/internal/core/operations/test_operation/test_operation_executor.go
+++ b/internal/core/operations/test_operation/test_operation_executor.go
@@ -42,15 +42,12 @@ func (e *TestOperationExecutor) Execute(ctx context.Context, _op *operation.Oper
 
 	zap.L().Sugar().Infof("sleeping routine for %d seconds", testOperationDefinition.SleepSeconds)
 
-	ticker := time.NewTicker(1 * time.Second)
-	for i := 1; i < testOperationDefinition.SleepSeconds; i += 1 {
-		select {
-		case <-ticker.C:
-			continue
+	ticker := time.NewTicker(time.Duration(testOperationDefinition.SleepSeconds) * time.Second)
+	select {
+	case <-ticker.C:
 
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
 	zap.L().Sugar().Infof("routine slept for %d seconds", testOperationDefinition.SleepSeconds)

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -403,7 +403,7 @@ func TestWatchOperationCancelationRequests(t *testing.T) {
 		ctx, ctxCancelFunction := context.WithCancel(context.Background())
 		go func() {
 			err := opManager.WatchOperationCancelationRequests(ctx)
-			require.ErrorIs(t, err, context.Canceled)
+			require.NoError(t, err)
 		}()
 
 		requestChannel <- ports.OperationCancelationRequest{

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -84,6 +84,11 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 			zap.String("operation_definition", def.Name()),
 		)
 
+		if op.Status != operation.StatusPending {
+			loopLogger.Warn("operation is at an invalid status to proceed")
+			continue
+		}
+
 		executor, hasExecutor := w.executorsByName[def.Name()]
 		if !hasExecutor {
 			loopLogger.Warn("operation definition has no executor")


### PR DESCRIPTION
## Description

This PR aims to add an E2E test over the cancel operation feature. Basically, it follows the script:

1. Creates a scheduler;
2. Evaluates the scheduler is "online";
3. Enqueues a test operation; when executing it, it sleeps during the given time (in seconds);
4. Ensures the test operation is running;
5. Calls the Management API to cancel the test operation;
6. Evaluates the operation is finished;