### PR TITLE
Create get room details endpoint

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -349,6 +349,16 @@ func (a *App) getRouter() *mux.Router {
 		NewParamMiddleware(func() interface{} { return &models.SchedulerParams{} }),
 	).ServeHTTP).Methods("GET").Name("roomsByMetric")
 
+	r.HandleFunc("/scheduler/{schedulerName}/rooms/{roomId}", Chain(
+		NewRoomDetailsHandler(a),
+		NewResponseTimeMiddleware(a),
+		NewMetricsReporterMiddleware(a),
+		NewSentryMiddleware(),
+		NewNewRelicMiddleware(a),
+		NewDogStatsdMiddleware(a),
+		NewParamMiddleware(func() interface{} { return &models.SchedulerRoomDetailsParams{} }),
+	).ServeHTTP).Methods("GET").Name("roomDetails")
+
 	r.HandleFunc("/scheduler/{schedulerName}/rooms/status/{status}", Chain(
 		NewRoomListBySchedulerAndStatusHandler(a),
 		NewResponseTimeMiddleware(a),

--- a/api/param_middleware.go
+++ b/api/param_middleware.go
@@ -53,6 +53,14 @@ func schedulerRoomsParamsFromContext(ctx context.Context) *models.SchedulerRooms
 	return param.(*models.SchedulerRoomsParams)
 }
 
+func schedulerRoomDetailsParamsFromContext(ctx context.Context) *models.SchedulerRoomDetailsParams {
+	param := ctx.Value(paramKey)
+	if param == nil {
+		return nil
+	}
+	return param.(*models.SchedulerRoomDetailsParams)
+}
+
 func schedulerLockParamsFromContext(ctx context.Context) *models.SchedulerLockParams {
 	param := ctx.Value(paramKey)
 	if param == nil {

--- a/api/room_handler.go
+++ b/api/room_handler.go
@@ -564,6 +564,10 @@ func (h *RoomDetailsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	room, err := models.GetRoomDetails(trace, params.SchedulerName, params.RoomId, mr)
 
 	if err != nil {
+		if err.Error() == "room not found" {
+			triggerApiError(w, logger, err, http.StatusNotFound, h.App)
+			return
+		}
 		triggerApiError(w, logger, err, http.StatusInternalServerError, h.App)
 		return
 	}
@@ -571,6 +575,10 @@ func (h *RoomDetailsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	pod, err := models.GetPodFromRedis(trace, mr, room.ID, params.SchedulerName)
 	if err != nil {
 		triggerApiError(w, logger, err, http.StatusInternalServerError, h.App)
+		return
+	}
+	if pod == nil {
+		triggerApiError(w, logger, err, http.StatusNotFound, h.App)
 		return
 	}
 	roomDetail := map[string]interface{}{

--- a/api/room_handler.go
+++ b/api/room_handler.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/topfreegames/extensions/middleware"
@@ -494,11 +495,12 @@ func (h *RoomListBySchedulerAndStatusHandler) ServeHTTP(w http.ResponseWriter, r
 			return
 		}
 		roomDetail := map[string]interface{}{
-			"scheduler_name":    params.SchedulerName,
-			"scheduler_version": pod.Version,
-			"room_id":           room.ID,
-			"status":            room.Status,
-			"created_at":        pod.Status.StartTime,
+			"schedulerName":    params.SchedulerName,
+			"schedulerVersion": pod.Version,
+			"roomId":           room.ID,
+			"status":           room.Status,
+			"createdAt":        pod.Status.StartTime,
+			"lastPingAt":       time.Unix(room.LastPingAt, 0).UTC().Format(time.RFC3339),
 		}
 		roomsDetails = append(roomsDetails, roomDetail)
 	}
@@ -582,11 +584,12 @@ func (h *RoomDetailsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	roomDetail := map[string]interface{}{
-		"scheduler_name":    params.SchedulerName,
-		"scheduler_version": pod.Version,
-		"room_id":           room.ID,
-		"status":            room.Status,
-		"created_at":        pod.Status.StartTime,
+		"schedulerName":    params.SchedulerName,
+		"schedulerVersion": pod.Version,
+		"roomId":           room.ID,
+		"status":           room.Status,
+		"createdAt":        pod.Status.StartTime,
+		"lastPingAt":       time.Unix(room.LastPingAt, 0).UTC().Format(time.RFC3339),
 	}
 
 	bytes, err := json.Marshal(roomDetail)

--- a/api/room_handler_test.go
+++ b/api/room_handler_test.go
@@ -1315,25 +1315,28 @@ forwarders:
 				Expect(err).NotTo(HaveOccurred())
 				Expect(roomsResponse).To(HaveLen(3))
 				Expect(roomsResponse[0]).To(Equal(map[string]interface{}{
-					"room_id":           "test-ready-1",
-					"created_at":        "2021-01-02T15:04:05Z",
-					"scheduler_name":    "scheduler-name",
-					"scheduler_version": "13",
-					"status":            "ready",
+					"roomId":           "test-ready-1",
+					"createdAt":        "2021-01-02T15:04:05Z",
+					"schedulerName":    "scheduler-name",
+					"schedulerVersion": "13",
+					"status":           "ready",
+					"lastPingAt":       "2021-09-23T14:05:00Z",
 				}))
 				Expect(roomsResponse[1]).To(Equal(map[string]interface{}{
-					"room_id":           "test-ready-2",
-					"created_at":        "2021-01-02T15:04:05Z",
-					"scheduler_name":    "scheduler-name",
-					"scheduler_version": "13",
-					"status":            "ready",
+					"roomId":           "test-ready-2",
+					"createdAt":        "2021-01-02T15:04:05Z",
+					"schedulerName":    "scheduler-name",
+					"schedulerVersion": "13",
+					"status":           "ready",
+					"lastPingAt":       "2021-09-23T14:05:00Z",
 				}))
 				Expect(roomsResponse[2]).To(Equal(map[string]interface{}{
-					"room_id":           "test-ready-3",
-					"created_at":        "2021-01-02T15:04:05Z",
-					"scheduler_name":    "scheduler-name",
-					"scheduler_version": "13",
-					"status":            "ready",
+					"roomId":           "test-ready-3",
+					"createdAt":        "2021-01-02T15:04:05Z",
+					"schedulerName":    "scheduler-name",
+					"schedulerVersion": "13",
+					"status":           "ready",
+					"lastPingAt":       "2021-09-23T14:05:00Z",
 				}))
 			})
 			It("should return rooms with success for absent offset and limit", func() {
@@ -1380,25 +1383,28 @@ forwarders:
 				Expect(err).NotTo(HaveOccurred())
 				Expect(roomsResponse).To(HaveLen(3))
 				Expect(roomsResponse[0]).To(Equal(map[string]interface{}{
-					"room_id":           "test-ready-1",
-					"created_at":        "2021-01-02T15:04:05Z",
-					"scheduler_name":    "scheduler-name",
-					"scheduler_version": "13",
-					"status":            "ready",
+					"roomId":           "test-ready-1",
+					"createdAt":        "2021-01-02T15:04:05Z",
+					"schedulerName":    "scheduler-name",
+					"schedulerVersion": "13",
+					"status":           "ready",
+					"lastPingAt":       "2021-09-23T14:05:00Z",
 				}))
 				Expect(roomsResponse[1]).To(Equal(map[string]interface{}{
-					"room_id":           "test-ready-2",
-					"created_at":        "2021-01-02T15:04:05Z",
-					"scheduler_name":    "scheduler-name",
-					"scheduler_version": "13",
-					"status":            "ready",
+					"roomId":           "test-ready-2",
+					"createdAt":        "2021-01-02T15:04:05Z",
+					"schedulerName":    "scheduler-name",
+					"schedulerVersion": "13",
+					"status":           "ready",
+					"lastPingAt":       "2021-09-23T14:05:00Z",
 				}))
 				Expect(roomsResponse[2]).To(Equal(map[string]interface{}{
-					"room_id":           "test-ready-3",
-					"created_at":        "2021-01-02T15:04:05Z",
-					"scheduler_name":    "scheduler-name",
-					"scheduler_version": "13",
-					"status":            "ready",
+					"roomId":           "test-ready-3",
+					"createdAt":        "2021-01-02T15:04:05Z",
+					"schedulerName":    "scheduler-name",
+					"schedulerVersion": "13",
+					"status":           "ready",
+					"lastPingAt":       "2021-09-23T14:05:00Z",
 				}))
 			})
 			It("should return with error if some error occur on getting rooms", func() {
@@ -1508,11 +1514,12 @@ forwarders:
 			err = json.Unmarshal([]byte(recorder.Body.String()), &roomsResponse)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(roomsResponse).To(Equal(map[string]interface{}{
-				"room_id":           roomId,
-				"created_at":        "2021-01-02T15:04:05Z",
-				"scheduler_name":    schedulerName,
-				"scheduler_version": "13",
-				"status":            "ready",
+				"roomId":           roomId,
+				"createdAt":        "2021-01-02T15:04:05Z",
+				"schedulerName":    schedulerName,
+				"schedulerVersion": "13",
+				"status":           "ready",
+				"lastPingAt":       "2021-09-23T14:05:00Z",
 			}))
 
 		})

--- a/models/params.go
+++ b/models/params.go
@@ -31,6 +31,12 @@ type SchedulerRoomsParams struct {
 	Status        string `json:"status" valid:"required"`
 }
 
+// SchedulerRoomDetailsParams is the struct that defines the params for room details routes
+type SchedulerRoomDetailsParams struct {
+	SchedulerName string `json:"schedulerName" valid:"required"`
+	RoomId        string `json:"roomId" valid:"required"`
+}
+
 // SchedulerLockParams is the struct that defines the params for scheduler locks routes
 type SchedulerLockParams struct {
 	SchedulerName string `json:"schedulerName" valid:"required"`

--- a/models/room.go
+++ b/models/room.go
@@ -523,21 +523,13 @@ func GetRoomsByStatus(redisClient interfaces.RedisClient, schedulerName string, 
 	paginatedRedisKeys := paginateKeys(redisKeys, limit, offset)
 
 	for _, redisKey := range paginatedRedisKeys {
-		roomData, err := redisClient.HGetAll(redisKey).Result()
+		id := RoomFromRedisKey(redisKey)
+		room, err := GetRoomDetails(redisClient, schedulerName, id, mr)
 		if err != nil {
 			return nil, err
 		}
 
-		lastPingAt, _ := strconv.ParseInt(roomData["lastPing"], 10, 64)
-		status := roomData["status"]
-		id := RoomFromRedisKey(redisKey)
-
-		rooms = append(rooms, &Room{
-			ID:            id,
-			SchedulerName: schedulerName,
-			Status:        status,
-			LastPingAt:    lastPingAt,
-		})
+		rooms = append(rooms, room)
 	}
 
 	return rooms, nil

--- a/models/room.go
+++ b/models/room.go
@@ -9,6 +9,7 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -549,6 +550,9 @@ func GetRoomDetails(redisClient interfaces.RedisClient, schedulerName string, ro
 
 	if err != nil {
 		return nil, err
+	}
+	if len(roomData) == 0 {
+		return nil, errors.New("room not found")
 	}
 
 	lastPingAt, _ := strconv.ParseInt(roomData["lastPing"], 10, 64)

--- a/models/room_test.go
+++ b/models/room_test.go
@@ -538,7 +538,7 @@ var _ = Describe("Room", func() {
 	Describe("GetRoomsByStatus", func() {
 		Context("when limit is greater than the number of rooms", func() {
 			It("should return all rooms for offset equal 1", func() {
-				scheduler := "pong-free-for-all"
+				scheduler := "scheduler-name"
 
 				expectedRooms := []string{
 					"scheduler:scheduler-name:rooms:test-ready-1",
@@ -574,7 +574,7 @@ var _ = Describe("Room", func() {
 				Expect(len(rooms)).To(Equal(len(expectedRooms)))
 			})
 			It("should return an empty list for offset greater than 1", func() {
-				scheduler := "pong-free-for-all"
+				scheduler := "scheduler-name"
 
 				expectedRooms := []string{
 					"scheduler:scheduler-name:rooms:test-ready-1",
@@ -592,7 +592,7 @@ var _ = Describe("Room", func() {
 		})
 		Context("when limit is less than the number of rooms", func() {
 			It("should return paginated rooms for even number of rooms", func() {
-				scheduler := "pong-free-for-all"
+				scheduler := "scheduler-name"
 
 				expectedRooms := []string{
 					"scheduler:scheduler-name:rooms:test-ready-1",
@@ -619,7 +619,7 @@ var _ = Describe("Room", func() {
 			})
 
 			It("should return paginated rooms for odd number of rooms", func() {
-				scheduler := "pong-free-for-all"
+				scheduler := "scheduler-name"
 
 				expectedRooms := []string{
 					"scheduler:scheduler-name:rooms:test-ready-1",
@@ -651,7 +651,7 @@ var _ = Describe("Room", func() {
 				Expect(err.Error()).To(Equal("some error"))
 			})
 			It("should return an error if redis returns an error on HGetAll", func() {
-				scheduler := "pong-free-for-all"
+				scheduler := "scheduler-name"
 				expectedRooms := []string{
 					"scheduler:scheduler-name:rooms:test-ready-1",
 					"scheduler:scheduler-name:rooms:test-ready-2",

--- a/models/room_test.go
+++ b/models/room_test.go
@@ -692,7 +692,7 @@ var _ = Describe("Room", func() {
 				Expect(room.SchedulerName).To(Equal(scheduler))
 			})
 		})
-		Context("when no redis returns with error", func() {
+		Context("when redis returns with error", func() {
 			It("should return with error", func() {
 				scheduler := "scheduler-name-1"
 				roomId := "room-id-1"
@@ -703,6 +703,19 @@ var _ = Describe("Room", func() {
 				_, err := models.GetRoomDetails(mockRedisClient, scheduler, roomId, mmr)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("some error"))
+			})
+		})
+		Context("when no room is found", func() {
+			It("should return with error", func() {
+				scheduler := "scheduler-name-1"
+				roomId := "room-id-1"
+
+				mockRedisClient.EXPECT().HGetAll("scheduler:scheduler-name-1:rooms:room-id-1").
+					Return(redis.NewStringStringMapResult(map[string]string{}, nil))
+
+				_, err := models.GetRoomDetails(mockRedisClient, scheduler, roomId, mmr)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("room not found"))
 			})
 		})
 	})


### PR DESCRIPTION
## What ❓ 
This PR add a new endpoint to maestro for getting game room details based on a scheduler name and the room id.

Added a new handler, including tests and parameters definition, alongside a new method o rooms model `GetRoomDetails` for retrieving room details given a roomId. 

The new endpoint contract:

```
GET /schedulers/:name/rooms/:roomId

Response body:

 {
    "scheduler_name": string,
    "scheduler_version": string,
    "room_id": string,
    "status": string,
    "created_at": string
  }

```