### PR TITLE
Populate game room instance address (Kubernetes runtime)

### DIFF
--- a/internal/adapters/runtime/kubernetes/game_room.go
+++ b/internal/adapters/runtime/kubernetes/game_room.go
@@ -46,7 +46,14 @@ func (k *kubernetes) CreateGameRoomInstance(ctx context.Context, schedulerID str
 		return nil, errors.NewErrUnexpected("error create game room instance: %s", err)
 	}
 
-	return convertPod(pod), nil
+	// when pod is created, we cannot have its node, so we're "forcing" node to
+	// be nil here.
+	instance, err := convertPod(pod, nil)
+	if err != nil {
+		return nil, errors.NewErrUnexpected("failed to convert game room instance: %s", err)
+	}
+
+	return instance, nil
 }
 
 func (k *kubernetes) DeleteGameRoomInstance(ctx context.Context, gameRoomInstance *game_room.Instance) error {

--- a/internal/adapters/runtime/kubernetes/game_room_watcher.go
+++ b/internal/adapters/runtime/kubernetes/game_room_watcher.go
@@ -52,7 +52,6 @@ type kubernetesWatcher struct {
 
 	stopped  bool
 	stopChan chan struct{}
-	stopOnce sync.Once
 }
 
 func (kw *kubernetesWatcher) ResultChan() chan game_room.InstanceEvent {

--- a/internal/adapters/runtime/mock/mock.go
+++ b/internal/adapters/runtime/mock/mock.go
@@ -132,6 +132,20 @@ func (m *MockRuntimeWatcher) EXPECT() *MockRuntimeWatcherMockRecorder {
 	return m.recorder
 }
 
+// Err mocks base method.
+func (m *MockRuntimeWatcher) Err() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Err")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Err indicates an expected call of Err.
+func (mr *MockRuntimeWatcherMockRecorder) Err() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockRuntimeWatcher)(nil).Err))
+}
+
 // ResultChan mocks base method.
 func (m *MockRuntimeWatcher) ResultChan() chan game_room.InstanceEvent {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/runtime.go
+++ b/internal/core/ports/runtime.go
@@ -52,4 +52,7 @@ type RuntimeWatcher interface {
 	ResultChan() chan game_room.InstanceEvent
 	// Stop stops the watcher.
 	Stop()
+	// Err returns the error of the watcher. It is possible that the watcher
+	// doesn't have any error (returning nil).
+	Err() error
 }


### PR DESCRIPTION
Kubernetes runtime now gets the pod address and IPs and fills the `Instance` `Address` field.

This PR also improves how the Kubernetes watcher deals with `Stop`. It now closes the `ResultChan`, making it easier for consumers to notice that the watcher is gone. Also, there was a change in the `RuntimeWatcher` interface. It now has an `Err()` function, which will be used to retrieve watcher errors.