### PR TITLE
Add github action matrix test for different k3s versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,26 @@ jobs:
   integration:
     name: Integration tests
     runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.16.3'
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+    - name: Run tests
+      run: |
+        make run/integration-tests
+    - name: Upload coverage to Codecov
+      run: bash <(curl -s https://codecov.io/bash)
+  runtime-integration:
+    name: Runtime Integration tests
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +64,4 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
     - name: Run tests
       run: |
-        make run/integration-tests
-    - name: Upload coverage to Codecov
-      run: bash <(curl -s https://codecov.io/bash)
+        make run/runtime-integration-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,12 @@ jobs:
   integration:
     name: Integration tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k3s-version: [v1.19.11, v1.20.7, v1.21.1]
+    env:
+      K3S_VERSION:  ${{ matrix.k3s-version }}
     steps:
     - name: Set up Go
       uses: actions/setup-go@v1

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ run/unit-tests:
 run/integration-tests:
 	@go test -tags=integration -count=1 -timeout 20m -coverprofile=coverage.out -covermode=atomic ./...
 
+.PHONY: run/runtime-integration-tests
+run/runtime-integration-tests:
+	@go test -tags=integration -count=1 -timeout 20m ./internal/adapters/runtime/kubernetes/...
+
 .PHONY: license-check
 license-check:
 	@go run github.com/google/addlicense -skip yaml -skip yml -skip proto -check .

--- a/internal/adapters/runtime/kubernetes/game_room_test.go
+++ b/internal/adapters/runtime/kubernetes/game_room_test.go
@@ -33,13 +33,14 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 	"github.com/topfreegames/maestro/internal/core/ports/errors"
+	"github.com/topfreegames/maestro/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGameRoomCreation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	client := getKubernetesClientset(t)
+	client := test.GetKubernetesClientset(t, kubernetesContainer)
 	kubernetesRuntime := New(client)
 
 	t.Run("successfully create a room", func(t *testing.T) {
@@ -92,7 +93,7 @@ func TestGameRoomCreation(t *testing.T) {
 func TestGameRoomDeletion(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	client := getKubernetesClientset(t)
+	client := test.GetKubernetesClientset(t, kubernetesContainer)
 	kubernetesRuntime := New(client)
 
 	t.Run("successfully delete a room", func(t *testing.T) {

--- a/internal/adapters/runtime/kubernetes/game_room_watcher_test.go
+++ b/internal/adapters/runtime/kubernetes/game_room_watcher_test.go
@@ -29,15 +29,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+	"github.com/topfreegames/maestro/test"
+
 	"github.com/stretchr/testify/require"
 	"github.com/topfreegames/maestro/internal/core/entities"
-	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 )
 
 func TestGameRoomsWatch(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	client := getKubernetesClientset(t)
+	client := test.GetKubernetesClientset(t, kubernetesContainer)
 	kubernetesRuntime := New(client)
 
 	t.Run("watch pod addition", func(t *testing.T) {

--- a/internal/adapters/runtime/kubernetes/scheduler_test.go
+++ b/internal/adapters/runtime/kubernetes/scheduler_test.go
@@ -31,13 +31,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/ports/errors"
+	"github.com/topfreegames/maestro/test"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSchedulerCreation(t *testing.T) {
 	ctx := context.Background()
-	client := getKubernetesClientset(t)
+	client := test.GetKubernetesClientset(t, kubernetesContainer)
 	kubernetesRuntime := New(client)
 
 	t.Run("create single scheduler", func(t *testing.T) {
@@ -62,7 +63,7 @@ func TestSchedulerCreation(t *testing.T) {
 
 func TestSchedulerDeletion(t *testing.T) {
 	ctx := context.Background()
-	client := getKubernetesClientset(t)
+	client := test.GetKubernetesClientset(t, kubernetesContainer)
 	kubernetesRuntime := New(client)
 
 	t.Run("delete scheduler", func(t *testing.T) {

--- a/test/kubernetes.go
+++ b/test/kubernetes.go
@@ -20,25 +20,44 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-//+build integration
-
-package kubernetes
+package test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
-	"github.com/topfreegames/maestro/test"
+	"github.com/stretchr/testify/require"
+
+	prek3s "github.com/orlangure/gnomock/preset/k3s"
+	"k8s.io/client-go/kubernetes"
 )
 
-var kubernetesContainer *gnomock.Container
+func WithK3sContainer(exec func(container *gnomock.Container)) {
 
-func TestMain(m *testing.M) {
-	var code int
-	test.WithK3sContainer(func(c *gnomock.Container) {
-		kubernetesContainer = c
-		code = m.Run()
-	})
-	os.Exit(code)
+	k3sVersion, ok := os.LookupEnv("K3S_VERSION")
+	if !ok {
+		k3sVersion = "v1.19.11"
+	}
+
+	var err error
+	k3sContainer, err := gnomock.Start(prek3s.Preset(prek3s.WithVersion(k3sVersion)))
+	if err != nil {
+		panic(fmt.Sprintf("error creating k3s docker instance: %s\n", err))
+	}
+
+	exec(k3sContainer)
+
+	_ = gnomock.Stop(k3sContainer)
+}
+
+func GetKubernetesClientset(t *testing.T, container *gnomock.Container) kubernetes.Interface {
+	kubeconfig, err := prek3s.Config(container)
+	require.NoError(t, err)
+
+	client, err := kubernetes.NewForConfig(kubeconfig)
+	require.NoError(t, err)
+
+	return client
 }


### PR DESCRIPTION
## Description

This PR aims to add to the current step of integration tests on GitHub actions, the ability to use multiple k3s versions to run Kubernetes related tests.