### PR TITLE
Compose runtime and ping status

### DIFF
--- a/internal/adapters/room_storage/mock/mock.go
+++ b/internal/adapters/room_storage/mock/mock.go
@@ -154,6 +154,20 @@ func (mr *MockRoomStorageMockRecorder) UpdateRoom(ctx, room interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoom", reflect.TypeOf((*MockRoomStorage)(nil).UpdateRoom), ctx, room)
 }
 
+// UpdateRoomStatus mocks base method.
+func (m *MockRoomStorage) UpdateRoomStatus(ctx context.Context, scheduler, roomId string, status game_room.GameRoomStatus) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRoomStatus", ctx, scheduler, roomId, status)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateRoomStatus indicates an expected call of UpdateRoomStatus.
+func (mr *MockRoomStorageMockRecorder) UpdateRoomStatus(ctx, scheduler, roomId, status interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoomStatus", reflect.TypeOf((*MockRoomStorage)(nil).UpdateRoomStatus), ctx, scheduler, roomId, status)
+}
+
 // WatchRoomStatus mocks base method.
 func (m *MockRoomStorage) WatchRoomStatus(ctx context.Context, room *game_room.GameRoom) (ports.RoomStorageStatusWatcher, error) {
 	m.ctrl.T.Helper()

--- a/internal/api/handlers/fixtures/invalid-state-transition-ping-data.json
+++ b/internal/api/handlers/fixtures/invalid-state-transition-ping-data.json
@@ -4,7 +4,7 @@
     "timestamp": 1629834996
   },
   {
-    "status": "pending",
+    "status": "occupied",
     "timestamp": 1629834996
   }
 ]

--- a/internal/api/handlers/fixtures/valid-ping-data-list.json
+++ b/internal/api/handlers/fixtures/valid-ping-data-list.json
@@ -1,17 +1,6 @@
 [
   {
     "metadata": {
-      "list-test": [
-        "test",
-        "test",
-        "test"
-      ]
-    },
-    "status": "unready",
-    "timestamp": 1629834996
-  },
-  {
-    "metadata": {
       "struct-test": {
         "field1": "field1",
         "field2": "field2",
@@ -41,7 +30,7 @@
       "null": null
 
     },
-    "status": "error",
+    "status": "terminated",
     "timestamp": 1629834996
   }
 ]

--- a/internal/api/handlers/rooms_handler.go
+++ b/internal/api/handlers/rooms_handler.go
@@ -59,13 +59,16 @@ func (h *RoomsHandler) UpdateRoomWithPing(ctx context.Context, message *api.Upda
 		if errors.Is(err, portsErrors.ErrNotFound) {
 			return nil, status.Error(codes.NotFound, err.Error())
 		}
+
+		// TODO(gabrielcorado): should we fail when the status transition fails?
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
+
 	return &api.UpdateRoomWithPingResponse{Success: true}, nil
 }
 
 func (h *RoomsHandler) fromApiUpdateRoomRequestToEntity(request *api.UpdateRoomWithPingRequest) (*game_room.GameRoom, error) {
-	status, err := game_room.FromStringToGameRoomStatus(request.GetStatus())
+	status, err := game_room.FromStringToGameRoomPingStatus(request.GetStatus())
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +76,7 @@ func (h *RoomsHandler) fromApiUpdateRoomRequestToEntity(request *api.UpdateRoomW
 	return &game_room.GameRoom{
 		ID:          request.GetRoomName(),
 		SchedulerID: request.GetSchedulerName(),
-		Status:      status,
+		PingStatus:  status,
 		Metadata:    request.Metadata.AsMap(),
 		LastPingAt:  time.Unix(request.GetTimestamp(), 0),
 	}, nil

--- a/internal/core/entities/game_room/instance.go
+++ b/internal/core/entities/game_room/instance.go
@@ -22,6 +22,8 @@
 
 package game_room
 
+import "fmt"
+
 // InstanceStatusType represents the status that a game room instance has.
 type InstanceStatusType int
 
@@ -38,6 +40,23 @@ const (
 	// Instance has some sort of error.
 	InstanceError
 )
+
+func (statusType InstanceStatusType) String() string {
+	switch statusType {
+	case InstanceUnknown:
+		return "unknown"
+	case InstancePending:
+		return "pending"
+	case InstanceReady:
+		return "ready"
+	case InstanceTerminating:
+		return "terminating"
+	case InstanceError:
+		return "error"
+	default:
+		panic(fmt.Sprintf("invalid value for InstanceStatusType : %d", int(statusType)))
+	}
+}
 
 type InstanceStatus struct {
 	Type InstanceStatusType `json:"type"`

--- a/internal/core/entities/game_room/instance_event.go
+++ b/internal/core/entities/game_room/instance_event.go
@@ -22,6 +22,8 @@
 
 package game_room
 
+import "fmt"
+
 type InstanceEventType int
 
 const (
@@ -36,6 +38,19 @@ const (
 	// deleted from the runtime. Can happen only once per instance.
 	InstanceEventTypeDeleted
 )
+
+func (eventType InstanceEventType) String() string {
+	switch eventType {
+	case InstanceEventTypeAdded:
+		return "added"
+	case InstanceEventTypeUpdated:
+		return "updated"
+	case InstanceEventTypeDeleted:
+		return "deleted"
+	default:
+		panic(fmt.Sprintf("invalid value for InstanceEventType: %d", int(eventType)))
+	}
+}
 
 // InstanceEvent this struct repesents an event that happened on the
 // run time, check InstanceEventType to see which event is avaiable.

--- a/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
@@ -85,7 +85,6 @@ func TestExecute(t *testing.T) {
 
 		instanceStorageMock.EXPECT().GetInstance(ctx, schedulerName, availableRooms[0].ID).Return(gameRoomInstance, nil)
 		runtimeMock.EXPECT().DeleteGameRoomInstance(ctx, gameRoomInstance).Return(nil)
-		roomStorageMock.EXPECT().UpdateRoom(ctx, availableRooms[0]).Return(nil)
 
 		err := executor.Execute(ctx, operation, definition)
 		require.NoError(t, err)
@@ -110,7 +109,6 @@ func TestExecute(t *testing.T) {
 		// first one is successfull
 		instanceStorageMock.EXPECT().GetInstance(ctx, schedulerName, availableRooms[0].ID).Return(gameRoomInstance, nil)
 		runtimeMock.EXPECT().DeleteGameRoomInstance(ctx, gameRoomInstance).Return(nil)
-		roomStorageMock.EXPECT().UpdateRoom(ctx, availableRooms[0]).Return(nil)
 
 		// second one fails on runtime
 		instanceStorageMock.EXPECT().GetInstance(ctx, schedulerName, availableRooms[1].ID).Return(gameRoomInstance, nil)

--- a/internal/core/ports/room_storage.go
+++ b/internal/core/ports/room_storage.go
@@ -49,6 +49,8 @@ type RoomStorage interface {
 	GetRoomCount(ctx context.Context, scheduler string) (int, error)
 	// GetRoomCountByStatus gets the count of rooms with a specific status in a scheduler
 	GetRoomCountByStatus(ctx context.Context, scheduler string, status game_room.GameRoomStatus) (int, error)
+	// UpdateRoomStatus updates the game room status.
+	UpdateRoomStatus(ctx context.Context, scheduler , roomId string, status game_room.GameRoomStatus) error
 
 	// WatchRoomStatus watche for status changes on the storage.
 	WatchRoomStatus(ctx context.Context, room *game_room.GameRoom) (RoomStorageStatusWatcher, error)

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -190,23 +190,20 @@ func TestRoomManager_DeleteRoom(t *testing.T) {
 	)
 
 	t.Run("when the game room status transition is valid then it deletes the game room and update its status", func(t *testing.T) {
-		nextStatus := game_room.GameStatusTerminating
 		gameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusReady}
-		newGameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: nextStatus}
 		instance := &game_room.Instance{ID: "test-instance"}
 		instanceStorage.EXPECT().GetInstance(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(instance, nil)
-		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(nil)
 		runtime.EXPECT().DeleteGameRoomInstance(context.Background(), instance).Return(nil)
 
 		err := roomManager.DeleteRoom(context.Background(), gameRoom)
 		require.NoError(t, err)
 	})
 
-	t.Run("when the game room status transition is invalid then it deletes the game room and returns with proper error", func(t *testing.T) {
+	t.Run("when room deletion has error returns error", func(t *testing.T) {
 		gameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusTerminating}
 		instance := &game_room.Instance{ID: "test-instance"}
 		instanceStorage.EXPECT().GetInstance(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(instance, nil)
-		runtime.EXPECT().DeleteGameRoomInstance(context.Background(), instance).Return(nil)
+		runtime.EXPECT().DeleteGameRoomInstance(context.Background(), instance).Return(porterrors.ErrUnexpected)
 
 		err := roomManager.DeleteRoom(context.Background(), gameRoom)
 		require.Error(t, err)
@@ -230,44 +227,53 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 		runtime,
 		config,
 	)
-	currentGameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusReady}
-	newGameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusOccupied, LastPingAt: clock.Now()}
+	currentInstance := &game_room.Instance{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.InstanceStatus{Type: game_room.InstanceReady}}
+	newGameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusReady, PingStatus: game_room.GameRoomPingStatusOccupied, LastPingAt: clock.Now()}
 
 	t.Run("when the current game room exists then it execute without returning error", func(t *testing.T) {
-		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(nil)
+		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
+		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
+		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(nil)
 
 		err := roomManager.UpdateRoom(context.Background(), newGameRoom)
-
 		require.NoError(t, err)
 	})
 
-	t.Run("when the current game room does not exist then it returns proper error", func(t *testing.T) {
-		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(nil, porterrors.ErrUnexpected)
+	t.Run("when update fails then it returns proper error", func(t *testing.T) {
+		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(porterrors.ErrUnexpected)
 
 		err := roomManager.UpdateRoom(context.Background(), newGameRoom)
-
 		require.Error(t, err)
 	})
 
 	t.Run("when there is some error while updating the room then it returns proper error", func(t *testing.T) {
-		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(porterrors.ErrUnexpected)
 
 		err := roomManager.UpdateRoom(context.Background(), newGameRoom)
-
 		require.Error(t, err)
 	})
 
 	t.Run("when the game room state transition is invalid then it returns proper error", func(t *testing.T) {
-		newGameRoomInvalidState := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusPending}
-		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoomInvalidState.SchedulerID, newGameRoomInvalidState.ID).Return(currentGameRoom, nil)
+		newGameRoomInvalidState := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusTerminating, PingStatus: game_room.GameRoomPingStatusReady}
+		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoomInvalidState).Return(nil)
+		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoomInvalidState.SchedulerID, newGameRoomInvalidState.ID).Return(currentInstance, nil)
+		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoomInvalidState.SchedulerID, newGameRoomInvalidState.ID).Return(newGameRoomInvalidState, nil)
+		// roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(nil)
 
 		err := roomManager.UpdateRoom(context.Background(), newGameRoomInvalidState)
-
 		require.Error(t, err)
 	})
 
+	t.Run("when update status fails then it returns error", func(t *testing.T) {
+		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(nil)
+		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
+		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
+		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(porterrors.ErrUnexpected)
+
+		err := roomManager.UpdateRoom(context.Background(), newGameRoom)
+		require.Error(t, err)
+	})
 }
 
 func TestRoomManager_ListRoomsWithDeletionPriority(t *testing.T) {
@@ -355,10 +361,14 @@ func TestRoomManager_UpdateRoomInstance(t *testing.T) {
 		runtime,
 		config,
 	)
-	newGameRoomInstance := &game_room.Instance{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.InstanceStatus{Type: game_room.InstanceReady}}
+	currentGameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusReady, PingStatus: game_room.GameRoomPingStatusReady, LastPingAt: clock.Now()}
+	newGameRoomInstance := &game_room.Instance{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.InstanceStatus{Type: game_room.InstanceError}}
 
 	t.Run("updates rooms with success", func(t *testing.T) {
 		instanceStorage.EXPECT().UpsertInstance(context.Background(), newGameRoomInstance).Return(nil)
+		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID).Return(newGameRoomInstance, nil)
+		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID).Return(currentGameRoom, nil)
+		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID, game_room.GameStatusError).Return(nil)
 
 		err := roomManager.UpdateRoomInstance(context.Background(), newGameRoomInstance)
 		require.NoError(t, err)

--- a/internal/core/services/room_manager/status.go
+++ b/internal/core/services/room_manager/status.go
@@ -63,8 +63,66 @@ var validStatusTransitions = map[game_room.GameRoomStatus]map[game_room.GameRoom
 	game_room.GameStatusTerminating: {},
 }
 
+// roomStatusComposition define what is the "final" game room status based on
+// the provided ping and instance status.
+var roomStatusComposition = []struct {
+	pingStatus         game_room.GameRoomPingStatus
+	instanceStatusType game_room.InstanceStatusType
+	status             game_room.GameRoomStatus
+}{
+	// Pending
+	{game_room.GameRoomPingStatusUnknown, game_room.InstanceUnknown, game_room.GameStatusPending},
+	{game_room.GameRoomPingStatusUnknown, game_room.InstancePending, game_room.GameStatusPending},
+	{game_room.GameRoomPingStatusReady, game_room.InstancePending, game_room.GameStatusPending},
+	{game_room.GameRoomPingStatusReady, game_room.InstanceUnknown, game_room.GameStatusPending},
+	{game_room.GameRoomPingStatusOccupied, game_room.InstanceUnknown, game_room.GameStatusPending},
+	{game_room.GameRoomPingStatusOccupied, game_room.InstancePending, game_room.GameStatusPending},
+
+	// Ready
+	{game_room.GameRoomPingStatusReady, game_room.InstanceReady, game_room.GameStatusReady},
+
+	// Occupied
+	{game_room.GameRoomPingStatusOccupied, game_room.InstanceReady, game_room.GameStatusOccupied},
+
+	// Unready
+	{game_room.GameRoomPingStatusUnknown, game_room.InstanceReady, game_room.GameStatusUnready},
+
+	// Terminating
+	{game_room.GameRoomPingStatusUnknown, game_room.InstanceTerminating, game_room.GameStatusTerminating},
+	{game_room.GameRoomPingStatusReady, game_room.InstanceTerminating, game_room.GameStatusTerminating},
+	{game_room.GameRoomPingStatusOccupied, game_room.InstanceTerminating, game_room.GameStatusTerminating},
+	{game_room.GameRoomPingStatusTerminating, game_room.InstancePending, game_room.GameStatusTerminating},
+	{game_room.GameRoomPingStatusTerminating, game_room.InstanceReady, game_room.GameStatusTerminating},
+	{game_room.GameRoomPingStatusTerminating, game_room.InstanceTerminating, game_room.GameStatusTerminating},
+	{game_room.GameRoomPingStatusTerminating, game_room.InstanceUnknown, game_room.GameStatusTerminating},
+	{game_room.GameRoomPingStatusTerminated, game_room.InstancePending, game_room.GameStatusTerminating},
+	{game_room.GameRoomPingStatusTerminated, game_room.InstanceReady, game_room.GameStatusTerminating},
+	{game_room.GameRoomPingStatusTerminated, game_room.InstanceTerminating, game_room.GameStatusTerminating},
+	{game_room.GameRoomPingStatusTerminated, game_room.InstanceUnknown, game_room.GameStatusTerminating},
+
+	// Error
+	{game_room.GameRoomPingStatusUnknown, game_room.InstanceError, game_room.GameStatusError},
+	{game_room.GameRoomPingStatusReady, game_room.InstanceError, game_room.GameStatusError},
+	{game_room.GameRoomPingStatusOccupied, game_room.InstanceError, game_room.GameStatusError},
+	{game_room.GameRoomPingStatusTerminating, game_room.InstanceError, game_room.GameStatusError},
+	{game_room.GameRoomPingStatusTerminated, game_room.InstanceError, game_room.GameStatusError},
+}
+
+func roomComposedStatus(pingStatus game_room.GameRoomPingStatus, instanceStatusType game_room.InstanceStatusType) (game_room.GameRoomStatus, error) {
+	for _, composition := range roomStatusComposition {
+		if composition.pingStatus == pingStatus && composition.instanceStatusType == instanceStatusType {
+			return composition.status, nil
+		}
+	}
+
+	return game_room.GameStatusPending, fmt.Errorf(
+		"ping status \"%s\" and instance status \"%s\" doesn't have a match",
+		pingStatus.String(), instanceStatusType.String(),
+	)
+}
+
 // validateRoomStatusTransition validates that a transition from currentStatus to newStatus can happen.
-func (m *RoomManager) validateRoomStatusTransition(currentStatus game_room.GameRoomStatus, newStatus game_room.GameRoomStatus) error {
+func validateRoomStatusTransition(currentStatus game_room.GameRoomStatus, newStatus game_room.GameRoomStatus) error {
 	transitions, ok := validStatusTransitions[currentStatus]
 	if !ok {
 		return fmt.Errorf("game rooms has an invalid status %s", currentStatus.String())
@@ -72,6 +130,40 @@ func (m *RoomManager) validateRoomStatusTransition(currentStatus game_room.GameR
 
 	if _, valid := transitions[newStatus]; !valid {
 		return fmt.Errorf("cannot change game room status from %s to %s", currentStatus.String(), newStatus.String())
+	}
+
+	return nil
+}
+
+// updateGameRoomStatus updates the game based on the ping and runtime status.
+func (m *RoomManager) updateGameRoomStatus(ctx context.Context, schedulerId, gameRoomId string) error {
+	gameRoom, err := m.roomStorage.GetRoom(ctx, schedulerId, gameRoomId)
+	if err != nil {
+		return fmt.Errorf("failed to get game room: %w", err)
+	}
+
+	instance, err := m.instanceStorage.GetInstance(ctx, schedulerId, gameRoomId)
+	if err != nil {
+		return fmt.Errorf("failed to get game room instance: %w", err)
+	}
+
+	newStatus, err := roomComposedStatus(gameRoom.PingStatus, instance.Status.Type)
+	if err != nil {
+		return fmt.Errorf("failed to generate new game room status: %w", err)
+	}
+
+	// nothing changed
+	if newStatus == gameRoom.Status {
+		return nil
+	}
+
+	if err := validateRoomStatusTransition(gameRoom.Status, newStatus); err != nil {
+		return fmt.Errorf("state transition is invalid: %w", err)
+	}
+
+	err = m.roomStorage.UpdateRoomStatus(ctx, schedulerId, gameRoomId, newStatus)
+	if err != nil {
+		return fmt.Errorf("failed to update game room status: %w", err)
 	}
 
 	return nil

--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
@@ -97,7 +97,7 @@ func (w *runtimeWatcherWorker) IsRunning() bool {
 
 func (w *runtimeWatcherWorker) processEvent(ctx context.Context, event game_room.InstanceEvent) error {
 	switch event.Type {
-	case game_room.InstanceEventTypeAdded:
+	case game_room.InstanceEventTypeAdded, game_room.InstanceEventTypeUpdated:
 		err := w.roomManager.UpdateRoomInstance(ctx, event.Instance)
 		if err != nil {
 			return fmt.Errorf("failed to update room instance %s: %w", event.Instance.ID, err)

--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker_test.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker_test.go
@@ -26,6 +26,7 @@ package runtime_watcher_worker
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -43,25 +44,25 @@ import (
 	"github.com/topfreegames/maestro/internal/core/workers"
 )
 
-func TestProcessRuntimeEvents(t *testing.T) {
-	workerOptions := func(t *testing.T) (*gomock.Controller, *instancemock.MockGameRoomInstanceStorage, *roomstoragemock.MockRoomStorage, *runtimemock.MockRuntime, *workers.WorkerOptions) {
-		mockCtrl := gomock.NewController(t)
+func workerOptions(t *testing.T) (*gomock.Controller, *instancemock.MockGameRoomInstanceStorage, *roomstoragemock.MockRoomStorage, *runtimemock.MockRuntime, *workers.WorkerOptions) {
+	mockCtrl := gomock.NewController(t)
 
-		now := time.Now()
-		portAllocator := pamock.NewMockPortAllocator(mockCtrl)
-		roomStorage := roomstoragemock.NewMockRoomStorage(mockCtrl)
-		runtime := runtimemock.NewMockRuntime(mockCtrl)
-		instanceStorage := instancemock.NewMockGameRoomInstanceStorage(mockCtrl)
-		fakeClock := clockmock.NewFakeClock(now)
-		config := room_manager.RoomManagerConfig{RoomInitializationTimeoutMillis: time.Millisecond * 1000}
-		roomManager := room_manager.NewRoomManager(fakeClock, portAllocator, roomStorage, instanceStorage, runtime, config)
+	now := time.Now()
+	portAllocator := pamock.NewMockPortAllocator(mockCtrl)
+	roomStorage := roomstoragemock.NewMockRoomStorage(mockCtrl)
+	runtime := runtimemock.NewMockRuntime(mockCtrl)
+	instanceStorage := instancemock.NewMockGameRoomInstanceStorage(mockCtrl)
+	fakeClock := clockmock.NewFakeClock(now)
+	config := room_manager.RoomManagerConfig{RoomInitializationTimeoutMillis: time.Millisecond * 1000}
+	roomManager := room_manager.NewRoomManager(fakeClock, portAllocator, roomStorage, instanceStorage, runtime, config)
 
-		return mockCtrl, instanceStorage, roomStorage, runtime, &workers.WorkerOptions{
-			Runtime:     runtime,
-			RoomManager: roomManager,
-		}
+	return mockCtrl, instanceStorage, roomStorage, runtime, &workers.WorkerOptions{
+		Runtime:     runtime,
+		RoomManager: roomManager,
 	}
+}
 
+func TestRuntimeWatcher_Start(t *testing.T) {
 	t.Run("fails to start watcher", func(t *testing.T) {
 		mockCtrl, _, _, runtime, workerOptions := workerOptions(t)
 		defer mockCtrl.Finish()
@@ -85,124 +86,135 @@ func TestProcessRuntimeEvents(t *testing.T) {
 			return true
 		}, time.Second, time.Millisecond)
 	})
+}
 
-	t.Run("updates instance on added event", func(t *testing.T) {
-		mockCtrl, instanceStorage, roomStorage, runtime, workerOptions := workerOptions(t)
-		defer mockCtrl.Finish()
+func TestRuntimeWatcher_UpdateInstance(t *testing.T) {
+	events := []game_room.InstanceEventType{
+		game_room.InstanceEventTypeAdded,
+		game_room.InstanceEventTypeUpdated,
+	}
 
-		scheduler := &entities.Scheduler{Name: "test"}
-		watcher := NewRuntimeWatcherWorker(scheduler, workerOptions)
+	for _, event := range events {
+		t.Run(fmt.Sprintf("when %s happens, updates instance", event.String()), func(t *testing.T) {
+			mockCtrl, instanceStorage, roomStorage, runtime, workerOptions := workerOptions(t)
+			defer mockCtrl.Finish()
 
-		runtimeWatcher := runtimemock.NewMockRuntimeWatcher(mockCtrl)
-		runtime.EXPECT().WatchGameRoomInstances(gomock.Any(), scheduler).Return(runtimeWatcher, nil)
+			scheduler := &entities.Scheduler{Name: "test"}
+			watcher := NewRuntimeWatcherWorker(scheduler, workerOptions)
 
-		resultChan := make(chan game_room.InstanceEvent)
-		runtimeWatcher.EXPECT().ResultChan().Return(resultChan)
-		runtimeWatcher.EXPECT().Stop()
+			runtimeWatcher := runtimemock.NewMockRuntimeWatcher(mockCtrl)
+			runtime.EXPECT().WatchGameRoomInstances(gomock.Any(), scheduler).Return(runtimeWatcher, nil)
 
-		// instance updates
-		newInstance := &game_room.Instance{Status: game_room.InstanceStatus{Type: game_room.InstanceReady}}
-		gameRoom := &game_room.GameRoom{Status: game_room.GameStatusPending, PingStatus: game_room.GameRoomPingStatusReady}
+			resultChan := make(chan game_room.InstanceEvent)
+			runtimeWatcher.EXPECT().ResultChan().Return(resultChan)
+			runtimeWatcher.EXPECT().Stop()
 
-		updateCalled := false
-		instanceStorage.EXPECT().UpsertInstance(gomock.Any(), newInstance).DoAndReturn(func(_ context.Context, _ *game_room.Instance) error {
-			updateCalled = true
-			return nil
-		})
-		roomStorage.EXPECT().GetRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoom, nil)
-		instanceStorage.EXPECT().GetInstance(gomock.Any(), gomock.Any(), gomock.Any()).Return(newInstance, nil)
-		roomStorage.EXPECT().UpdateRoomStatus(gomock.Any(), gomock.Any(), gomock.Any(), game_room.GameStatusReady).Return(nil)
+			// instance updates
+			newInstance := &game_room.Instance{Status: game_room.InstanceStatus{Type: game_room.InstanceReady}}
+			gameRoom := &game_room.GameRoom{Status: game_room.GameStatusPending, PingStatus: game_room.GameRoomPingStatusReady}
 
-		watcherDone := make(chan error)
-		go func() {
-			err := watcher.Start(context.Background())
-			watcherDone <- err
-		}()
+			updateCalled := false
+			instanceStorage.EXPECT().UpsertInstance(gomock.Any(), newInstance).DoAndReturn(func(_ context.Context, _ *game_room.Instance) error {
+				updateCalled = true
+				return nil
+			})
+			roomStorage.EXPECT().GetRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoom, nil)
+			instanceStorage.EXPECT().GetInstance(gomock.Any(), gomock.Any(), gomock.Any()).Return(newInstance, nil)
+			roomStorage.EXPECT().UpdateRoomStatus(gomock.Any(), gomock.Any(), gomock.Any(), game_room.GameStatusReady).Return(nil)
 
-		require.Eventually(t, func() bool {
-			resultChan <- game_room.InstanceEvent{
-				Type:     game_room.InstanceEventTypeAdded,
-				Instance: newInstance,
-			}
+			watcherDone := make(chan error)
+			go func() {
+				err := watcher.Start(context.Background())
+				watcherDone <- err
+			}()
 
-			return true
-		}, time.Second, time.Millisecond)
+			require.Eventually(t, func() bool {
+				resultChan <- game_room.InstanceEvent{
+					Type:     event,
+					Instance: newInstance,
+				}
 
-		// wait until the watcher process the event
-		require.Eventually(t, func() bool {
-			return updateCalled
-		}, time.Second, 100*time.Millisecond)
+				return true
+			}, time.Second, time.Millisecond)
 
-		// stop the watcher
-		require.True(t, watcher.IsRunning())
-		watcher.Stop(context.Background())
+			// wait until the watcher process the event
+			require.Eventually(t, func() bool {
+				return updateCalled
+			}, time.Second, 100*time.Millisecond)
 
-		require.Eventually(t, func() bool {
-			err := <-watcherDone
-			require.NoError(t, err)
-			require.False(t, watcher.IsRunning())
+			// stop the watcher
+			require.True(t, watcher.IsRunning())
+			watcher.Stop(context.Background())
 
-			return true
-		}, time.Second, time.Millisecond)
-	})
+			require.Eventually(t, func() bool {
+				err := <-watcherDone
+				require.NoError(t, err)
+				require.False(t, watcher.IsRunning())
 
-	t.Run("when update instance fails, does nothing", func(t *testing.T) {
-		mockCtrl, instanceStorage, _, runtime, workerOptions := workerOptions(t)
-		defer mockCtrl.Finish()
-
-		scheduler := &entities.Scheduler{Name: "test"}
-		watcher := NewRuntimeWatcherWorker(scheduler, workerOptions)
-
-		runtimeWatcher := runtimemock.NewMockRuntimeWatcher(mockCtrl)
-		runtime.EXPECT().WatchGameRoomInstances(gomock.Any(), scheduler).Return(runtimeWatcher, nil)
-
-		resultChan := make(chan game_room.InstanceEvent)
-		runtimeWatcher.EXPECT().ResultChan().Return(resultChan)
-		runtimeWatcher.EXPECT().Stop()
-
-		// instance updates
-		newInstance := &game_room.Instance{}
-
-		updateCalled := false
-		instanceStorage.EXPECT().UpsertInstance(gomock.Any(), newInstance).DoAndReturn(func(_ context.Context, _ *game_room.Instance) error {
-			updateCalled = true
-			return porterrors.ErrUnexpected
+				return true
+			}, time.Second, time.Millisecond)
 		})
 
-		watcherDone := make(chan error)
-		go func() {
-			err := watcher.Start(context.Background())
-			watcherDone <- err
-		}()
+		t.Run(fmt.Sprintf("when %s happens, and update instance fails, does nothgin", event.String()), func(t *testing.T) {
+			mockCtrl, instanceStorage, _, runtime, workerOptions := workerOptions(t)
+			defer mockCtrl.Finish()
 
-		require.Eventually(t, func() bool {
-			resultChan <- game_room.InstanceEvent{
-				Type:     game_room.InstanceEventTypeAdded,
-				Instance: newInstance,
-			}
+			scheduler := &entities.Scheduler{Name: "test"}
+			watcher := NewRuntimeWatcherWorker(scheduler, workerOptions)
 
-			return true
-		}, time.Second, time.Millisecond)
+			runtimeWatcher := runtimemock.NewMockRuntimeWatcher(mockCtrl)
+			runtime.EXPECT().WatchGameRoomInstances(gomock.Any(), scheduler).Return(runtimeWatcher, nil)
 
-		// wait until the watcher process the event
-		require.Eventually(t, func() bool {
-			return updateCalled
-		}, time.Second, 100*time.Millisecond)
+			resultChan := make(chan game_room.InstanceEvent)
+			runtimeWatcher.EXPECT().ResultChan().Return(resultChan)
+			runtimeWatcher.EXPECT().Stop()
 
-		// stop the watcher
-		require.True(t, watcher.IsRunning())
-		watcher.Stop(context.Background())
+			// instance updates
+			newInstance := &game_room.Instance{}
 
-		require.Eventually(t, func() bool {
-			err := <-watcherDone
-			require.NoError(t, err)
-			require.False(t, watcher.IsRunning())
+			updateCalled := false
+			instanceStorage.EXPECT().UpsertInstance(gomock.Any(), newInstance).DoAndReturn(func(_ context.Context, _ *game_room.Instance) error {
+				updateCalled = true
+				return porterrors.ErrUnexpected
+			})
 
-			return true
-		}, time.Second, time.Millisecond)
-	})
+			watcherDone := make(chan error)
+			go func() {
+				err := watcher.Start(context.Background())
+				watcherDone <- err
+			}()
 
-	t.Run("updates clean room state on delete event", func(t *testing.T) {
+			require.Eventually(t, func() bool {
+				resultChan <- game_room.InstanceEvent{
+					Type:     event,
+					Instance: newInstance,
+				}
+
+				return true
+			}, time.Second, time.Millisecond)
+
+			// wait until the watcher process the event
+			require.Eventually(t, func() bool {
+				return updateCalled
+			}, time.Second, 100*time.Millisecond)
+
+			// stop the watcher
+			require.True(t, watcher.IsRunning())
+			watcher.Stop(context.Background())
+
+			require.Eventually(t, func() bool {
+				err := <-watcherDone
+				require.NoError(t, err)
+				require.False(t, watcher.IsRunning())
+
+				return true
+			}, time.Second, time.Millisecond)
+		})
+	}
+}
+
+func TestRuntimeWatcher_CleanRoomState(t *testing.T) {
+	t.Run("clean room state on delete event", func(t *testing.T) {
 		mockCtrl, instanceStorage, roomStorage, runtime, workerOptions := workerOptions(t)
 		defer mockCtrl.Finish()
 


### PR DESCRIPTION
This PR changes how we defined the Game Room status. It is now composed of both: Ping status and Runtime status.

A few other changes were necessary due to this core change:
- `RoomStorage` changes;
    - Base room key is now Hash, which contains the room metadata and the ping status;
    - `UpdateRoom` now only updates ping status;
    - New `UpdateRoomStatus` function that updates only the room status;
- `RoomManager` changes;
    - `UpdateInstance` and `UpdateRoom` now calls internal `updateGameRoomStatus` which is going to update the final room status if necessary;
- Rooms ping API now updates the ping status instead of the game room status;

NOTE: This PR is not going to change the e2e (although it might break it). The change is going to be done in future PR.