### PR TITLE
using original value for new generated version to ensure that format …

### DIFF
--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -144,7 +144,7 @@ func (s *SchedulerManager) UpdateSchedulerConfig(ctx context.Context, scheduler 
 		newVersion = currentVersion.IncMajor()
 	}
 
-	scheduler.Spec.Version = newVersion.String()
+	scheduler.Spec.Version = newVersion.Original()
 	scheduler.RollbackVersion = currentScheduler.Spec.Version
 
 	err = s.schedulerStorage.UpdateScheduler(ctx, scheduler)


### PR DESCRIPTION
This merge request is only to ensure that value version continue in original format that it was when scheduler was created.