### PR TITLE
Fix concurrency problem in update scheduler executor

### DIFF
--- a/config/runtime-watcher.local.yaml
+++ b/config/runtime-watcher.local.yaml
@@ -35,3 +35,4 @@ services:
   roomManager:
     roomPingTimeoutMillis: 90000
     roomInitializationTimeoutMillis: 120000
+    roomDeletionTimeoutMillis: 120000

--- a/config/worker.local.yaml
+++ b/config/worker.local.yaml
@@ -35,3 +35,4 @@ services:
   roomManager:
     roomPingTimeoutMillis: 90000
     roomInitializationTimeoutMillis: 120000
+    roomDeletionTimeoutMillis: 120000

--- a/e2e/suites/management/get_scheduler_test.go
+++ b/e2e/suites/management/get_scheduler_test.go
@@ -75,7 +75,7 @@ func TestGetScheduler(t *testing.T) {
 
 			err = apiClient.Do("GET", fmt.Sprintf("/schedulers/%s?version=non-existent", schedulerName), getSchedulerRequest, getSchedulerResponse)
 
-			require.Error(t, err, "failed with status 404, response body: {\"code\":5, \"message\":\"scheduler " + schedulerName + " not found\", \"details\":[]}")
+			require.Error(t, err, "failed with status 404, response body: {\"code\":5, \"message\":\"scheduler "+schedulerName+" not found\", \"details\":[]}")
 		})
 
 		t.Run("Should Fail - non-existent scheduler", func(t *testing.T) {

--- a/internal/core/entities/game_room/instance_event.go
+++ b/internal/core/entities/game_room/instance_event.go
@@ -34,7 +34,7 @@ const (
 	// change on the runtime, for example, if its status change. Can happen
 	// multiple times for an instance.
 	InstanceEventTypeUpdated
-	// InstanceEventTypeDelete will happen when the instance is
+	// InstanceEventTypeDeleted will happen when the instance is
 	// deleted from the runtime. Can happen only once per instance.
 	InstanceEventTypeDeleted
 )

--- a/internal/core/operations/remove_rooms/remove_rooms_executor.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor.go
@@ -25,6 +25,7 @@ package remove_rooms
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/operations"
@@ -42,7 +43,7 @@ func NewExecutor(roomManager *room_manager.RoomManager) *RemoveRoomsExecutor {
 
 func (e *RemoveRoomsExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
 	removeDefinition := definition.(*RemoveRoomsDefinition)
-	rooms, err := e.roomManager.ListRoomsWithDeletionPriority(ctx, op.SchedulerName, removeDefinition.Version, removeDefinition.Amount)
+	rooms, err := e.roomManager.ListRoomsWithDeletionPriority(ctx, op.SchedulerName, removeDefinition.Version, removeDefinition.Amount, &sync.Map{})
 	if err != nil {
 		return fmt.Errorf("failed to list rooms to delete: %w", err)
 	}

--- a/internal/core/ports/room_storage.go
+++ b/internal/core/ports/room_storage.go
@@ -53,7 +53,6 @@ type RoomStorage interface {
 	GetRoomCountByStatus(ctx context.Context, scheduler string, status game_room.GameRoomStatus) (int, error)
 	// UpdateRoomStatus updates the game room status.
 	UpdateRoomStatus(ctx context.Context, scheduler, roomId string, status game_room.GameRoomStatus) error
-
 	// WatchRoomStatus watch for status changes on the storage.
 	WatchRoomStatus(ctx context.Context, room *game_room.GameRoom) (RoomStorageStatusWatcher, error)
 }

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -132,11 +132,11 @@ func (m *RoomManager) DeleteRoom(ctx context.Context, gameRoom *game_room.GameRo
 
 	duration := m.config.RoomDeletionTimeout
 	timeoutContext, cancelFunc := context.WithTimeout(ctx, duration)
+	defer cancelFunc()
 	err = m.WaitRoomStatus(timeoutContext, gameRoom, game_room.GameStatusTerminating)
 	if err != nil {
 		return fmt.Errorf("got timeout while waiting game room status to be terminating: %w", err)
 	}
-	defer cancelFunc()
 
 	return nil
 }

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -29,6 +29,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -211,7 +212,7 @@ func (m *RoomManager) CleanRoomState(ctx context.Context, schedulerName, roomId 
 //
 // This function can return less rooms than the `amount` since it might not have
 // enough rooms on the scheduler.
-func (m *RoomManager) ListRoomsWithDeletionPriority(ctx context.Context, schedulerName, ignoredVersion string, amount int) ([]*game_room.GameRoom, error) {
+func (m *RoomManager) ListRoomsWithDeletionPriority(ctx context.Context, schedulerName, ignoredVersion string, amount int, roomsBeingReplaced *sync.Map) ([]*game_room.GameRoom, error) {
 
 	var schedulerRoomsIDs []string
 	onErrorRoomIDs, err := m.roomStorage.GetRoomIDsByStatus(ctx, schedulerName, game_room.GameStatusError)
@@ -251,6 +252,12 @@ func (m *RoomManager) ListRoomsWithDeletionPriority(ctx context.Context, schedul
 		room, err := m.roomStorage.GetRoom(ctx, schedulerName, roomID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch room information: %w", err)
+		}
+
+		_, roomIsBeingReplaced := roomsBeingReplaced.Load(room.ID)
+
+		if roomIsBeingReplaced {
+			continue
 		}
 
 		if room.Status == game_room.GameStatusTerminating || (ignoredVersion != "" && ignoredVersion == room.Version) {

--- a/internal/core/services/room_manager/room_manager_config.go
+++ b/internal/core/services/room_manager/room_manager_config.go
@@ -27,4 +27,5 @@ import "time"
 type RoomManagerConfig struct {
 	RoomPingTimeout           time.Duration
 	RoomInitializationTimeout time.Duration
+	RoomDeletionTimeout       time.Duration
 }

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -32,9 +32,12 @@ import (
 func NewRoomManagerConfig(c config.Config) (room_manager.RoomManagerConfig, error) {
 	pingTimeout := time.Duration(c.GetInt("services.roomManager.roomPingTimeoutMillis")) * time.Millisecond
 	initializationTimeout := time.Duration(c.GetInt("services.roomManager.roomInitializationTimeoutMillis")) * time.Millisecond
+	deletionTimeout := time.Duration(c.GetInt("services.roomManager.roomDeletionTimeoutMillis")) * time.Millisecond
+
 	roomManagerConfig := room_manager.RoomManagerConfig{
 		RoomPingTimeout:           pingTimeout,
 		RoomInitializationTimeout: initializationTimeout,
+		RoomDeletionTimeout:       deletionTimeout,
 	}
 
 	return roomManagerConfig, nil


### PR DESCRIPTION
## What 👀 
Adds a mechanism in update rooms executor to prevent rooms that ate already being replaced to be replaced more than one time. Also implements a TODO that existed in DeleteRoom method in RoonManager.

## Why ❓ 
Upon implementing the e2e test for the update scheduler, we found that the update scheduler executor is trying to replace the same room more than one time, which leads to a higher number of game rooms created after the operation finishes. This is not the behavior that we expect for the update, we expect each room to be replaced one time only, that means, if we have a current scheduler with 4 rooms, after a major version update, we expect the scheduler to have 4 rooms (with the new version) after the operation finishes.

## How 0️⃣ 1️⃣  
- Using a sync map to manage rooms that are being replaced and prevent them from being replaced again.
- Update DeleteRoom method to wait for the status of the room to be Terminating.
- Updated tests and add some new test cases.