### PR TITLE
implements RevokeLease method on OperationLeaseStorage adapter

### DIFF
--- a/internal/adapters/operation_lease/redis/redis.go
+++ b/internal/adapters/operation_lease/redis/redis.go
@@ -78,10 +78,10 @@ func (r *redisOperationLeaseStorage) RevokeLease(ctx context.Context, schedulerN
 	}
 
 	if !existsLease {
-		return errors.NewErrNotFound("Lease of scheduler \"%s\" and operationId \"%s\" trying to be revoked does not exist", schedulerName, operationID)
+		return errors.NewErrNotFound("Lease of scheduler \"%s\" and operationId \"%s\" does not exist", schedulerName, operationID)
 	}
 
-	_, err = r.client.ZRem(context.Background(), r.buildSchedulerOperationLeaseKey(schedulerName), operationID).Result()
+	_, err = r.client.ZRem(ctx, r.buildSchedulerOperationLeaseKey(schedulerName), operationID).Result()
 	if err != nil {
 		return errors.NewErrUnexpected("Unexpected error on ZRem function")
 	}


### PR DESCRIPTION
### What?
- Implements RevokeLease method on OperationLeaseStorage adapter.
### Why?
- After a lease is granted to an operation of a scheduler, we need a method to revoke it (we won't be updating it forever, neither letting it expired, since expired means that the operation might be stuck)
### How?
- The method verifies if the operationLease exists, and if so, removes it from the redis zset.