### PR TITLE
implements RenewLease method of operationLeaseStorage Adapter

### DIFF
--- a/internal/adapters/operation_lease/redis/redis.go
+++ b/internal/adapters/operation_lease/redis/redis.go
@@ -76,6 +76,20 @@ func (r *redisOperationLeaseStorage) RevokeLease(ctx context.Context, schedulerN
 }
 
 func (r *redisOperationLeaseStorage) RenewLease(ctx context.Context, schedulerName, operationID string, ttl time.Duration) error {
+	existsLease, err := r.existsOperationLease(ctx, schedulerName, operationID)
+	if err != nil {
+		return err
+	}
+
+	if !existsLease {
+		return errors.NewErrNotFound("Lease of scheduler \"%s\" and operationId \"%s\" does not exist", schedulerName, operationID)
+	}
+
+	err = r.client.ZIncrBy(ctx, r.buildSchedulerOperationLeaseKey(schedulerName), ttl.Seconds(), operationID).Err()
+	if err != nil {
+		return errors.NewErrUnexpected("Unexpected error on incrementing sorted set member score")
+	}
+
 	return nil
 }
 

--- a/internal/adapters/operation_lease/redis/redis_test.go
+++ b/internal/adapters/operation_lease/redis/redis_test.go
@@ -27,6 +27,7 @@ package redis
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -97,8 +98,46 @@ func TestRevokeLease(t *testing.T) {
 }
 
 func TestRenewLease(t *testing.T) {
+	schedulerName := "schedulerName"
+	operationId := "operationID"
+
 	t.Run("with success", func(t *testing.T) {
-		require.Equal(t, 1, 1)
+		client := test.GetRedisConnection(t, redisAddress)
+		clock := clockmock.NewFakeClock(time.Now())
+		storage := NewRedisOperationLeaseStorage(client, clock)
+
+		err := storage.GrantLease(context.Background(), schedulerName, operationId, time.Minute)
+		require.NoError(t, err)
+
+		score_initial, err := client.ZScore(context.Background(), buildOperationLeaseKey(schedulerName), operationId).Result()
+		require.NotEqual(t, err, redis.Nil)
+
+		err = storage.RenewLease(context.Background(), schedulerName, operationId, time.Minute)
+		require.Equal(t, err, nil)
+
+		score_after_renew, err := client.ZScore(context.Background(), buildOperationLeaseKey(schedulerName), operationId).Result()
+		require.NoError(t, err)
+		require.Greater(t, score_after_renew, score_initial)
+	})
+
+	t.Run("with error - not exists", func(t *testing.T) {
+		client := test.GetRedisConnection(t, redisAddress)
+		clock := clockmock.NewFakeClock(time.Now())
+		storage := NewRedisOperationLeaseStorage(client, clock)
+
+		err := storage.RenewLease(context.Background(), schedulerName, operationId, time.Minute)
+		require.Equal(t, err, errors.NewErrNotFound("Lease of scheduler \"%s\" and operationId \"%s\" does not exist", schedulerName, operationId))
+	})
+
+	t.Run("with error - redis fails", func(t *testing.T) {
+		client := test.GetRedisConnection(t, redisAddress)
+		clock := clockmock.NewFakeClock(time.Now())
+		storage := NewRedisOperationLeaseStorage(client, clock)
+
+		client.Close()
+
+		err := storage.RenewLease(context.Background(), schedulerName, operationId, time.Minute)
+		require.Error(t, err)
 	})
 }
 
@@ -112,4 +151,8 @@ func TestListExpiredLeases(t *testing.T) {
 	t.Run("with success", func(t *testing.T) {
 		require.Equal(t, 1, 1)
 	})
+}
+
+func buildOperationLeaseKey(schedulerName string) string {
+	return fmt.Sprintf("operations:%s:operationsLease", schedulerName)
 }


### PR DESCRIPTION
### What was done?
- Implementation of RenewLease method of OperationLeaseStorage adapter.
### Why was done?
- So an operation lease can be renewed from time to time, so we can keep track of operations that are still running.
### How was done?
- Using a method ZIncrBy of the redis go package. This method updates the score of a sorted set member.