### PR TITLE
Always build maestro components images while running e2e tests

### DIFF
--- a/e2e/framework/maestro/components/management_api.go
+++ b/e2e/framework/maestro/components/management_api.go
@@ -46,7 +46,7 @@ func ProvideManagementApi(maestroPath string) (*ManagementApiServer, error) {
 	identifier := strings.ToLower("test-something")
 
 	compose := tc.NewLocalDockerCompose(composeFilePaths, identifier)
-	composeErr := compose.WithCommand([]string{"up", "-d", "management-api"}).Invoke()
+	composeErr := compose.WithCommand([]string{"up", "-d", "--build", "management-api"}).Invoke()
 
 	if composeErr.Error != nil {
 		return nil, fmt.Errorf("failed to start management API: %s", composeErr.Error)

--- a/e2e/framework/maestro/components/rooms_api.go
+++ b/e2e/framework/maestro/components/rooms_api.go
@@ -49,7 +49,7 @@ func ProvideRoomsApi(maestroPath string) (*RoomsApiServer, error) {
 	identifier := strings.ToLower("test-something")
 
 	compose := tc.NewLocalDockerCompose(composeFilePaths, identifier)
-	composeErr := compose.WithCommand([]string{"up", "-d", "rooms-api"}).Invoke()
+	composeErr := compose.WithCommand([]string{"up", "-d", "--build", "rooms-api"}).Invoke()
 
 	if composeErr.Error != nil {
 		return nil, fmt.Errorf("failed to start rooms API: %s", composeErr.Error)

--- a/e2e/framework/maestro/components/runtime_watcher.go
+++ b/e2e/framework/maestro/components/runtime_watcher.go
@@ -44,7 +44,7 @@ func ProvideRuntimeWatcher(maestroPath string) (*RuntimeWatcherServer, error) {
 	identifier := strings.ToLower("test-something")
 
 	compose := tc.NewLocalDockerCompose(composeFilePaths, identifier)
-	composeErr := compose.WithCommand([]string{"up", "-d", "runtime-watcher"}).Invoke()
+	composeErr := compose.WithCommand([]string{"up", "-d", "--build", "runtime-watcher"}).Invoke()
 
 	if composeErr.Error != nil {
 		return nil, fmt.Errorf("failed to start runtime watcher API: %s", composeErr.Error)

--- a/e2e/framework/maestro/components/worker.go
+++ b/e2e/framework/maestro/components/worker.go
@@ -44,7 +44,7 @@ func ProvideWorker(maestroPath string) (*WorkerServer, error) {
 	identifier := strings.ToLower("test-something")
 
 	compose := tc.NewLocalDockerCompose(composeFilePaths, identifier)
-	composeErr := compose.WithCommand([]string{"up", "-d", "worker"}).Invoke()
+	composeErr := compose.WithCommand([]string{"up", "-d", "--build", "worker"}).Invoke()
 
 	if composeErr.Error != nil {
 		return nil, fmt.Errorf("failed to start worker API: %s", composeErr.Error)

--- a/e2e/framework/maestro/maestro.go
+++ b/e2e/framework/maestro/maestro.go
@@ -50,9 +50,9 @@ func ProvideMaestro() (*MaestroInstance, error) {
 		return nil, fmt.Errorf("failed to start dependencies: %s", err)
 	}
 
-	workerInstance, err := components.ProvideWorker(path)
+	roomsApiInstance, err := components.ProvideRoomsApi(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start worker: %s", err)
+		return nil, fmt.Errorf("failed to start rooms api: %s", err)
 	}
 
 	managementApiInstance, err := components.ProvideManagementApi(path)
@@ -60,9 +60,9 @@ func ProvideMaestro() (*MaestroInstance, error) {
 		return nil, fmt.Errorf("failed to start worker: %s", err)
 	}
 
-	roomsApiInstance, err := components.ProvideRoomsApi(path)
+	workerInstance, err := components.ProvideWorker(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start rooms api: %s", err)
+		return nil, fmt.Errorf("failed to start worker: %s", err)
 	}
 
 	runtimeWatcherInstance, err := components.ProvideRuntimeWatcher(path)


### PR DESCRIPTION
What ❓
Configure e2e tests execution to always build maestro components images.

Why 🤔
Currently, when executing e2e tests via makefile, images built previously (rooms API, worker, etc) aren't built again. This can lead up to problems when changing the code since the changes will not be "loaded" because the image already exists and it will not build again. Currently, we have to delete images manually so it builds it again with new changes. We need to guarantee that the image used in e2e tests will be built while running it, preventing these problems to happen.

How 👀
Running docker commands with --build flag for maestro components.