### PR TITLE
Implement ListExpiredLeases method including unitary tests

### DIFF
--- a/internal/adapters/operation_lease/redis/redis.go
+++ b/internal/adapters/operation_lease/redis/redis.go
@@ -117,7 +117,8 @@ func (r *redisOperationLeaseStorage) ListExpiredLeases(ctx context.Context, sche
 	}).Result()
 
 	if err != nil {
-		return nil, err
+		return nil, errors.NewErrUnexpected("failed on listing expired lease for \"%s\"", schedulerName).WithError(err)
+
 	}
 
 	expiredOperations := r.convertToOperationLeaseList(ops)


### PR DESCRIPTION
## What❓
Implement ListExpiredLeases method logic to retrieve leases that have expired. 

## Why 🤔 
Following the Operations lease feature plan, we need to provide some method in the repository that can retrieve operations lease that have expired (using a maxTtl argument as reference)

## How 👀 
Using [ZRANGEBYSCORE](https://redis.io/commands/zrangebyscore) to retrieve the list of leases whose ttl (score) resides in the range [-inf,  maxTtl]