### PR TITLE
Adds Operation Manager lease methods

### DIFF
--- a/cmd/management_api/wire.go
+++ b/cmd/management_api/wire.go
@@ -45,6 +45,7 @@ func initializeManagementMux(ctx context.Context, conf config.Config) (*runtime.
 		service.NewClockTime,
 		service.NewOperationFlowRedis,
 		service.NewOperationStorageRedis,
+		service.NewOperationLeaseStorageRedis,
 		service.NewSchedulerStoragePg,
 
 		// scheduler operations

--- a/cmd/management_api/wire_gen.go
+++ b/cmd/management_api/wire_gen.go
@@ -36,7 +36,11 @@ func initializeManagementMux(ctx context.Context, conf config.Config) (*runtime.
 		return nil, err
 	}
 	v := providers.ProvideDefinitionConstructors()
-	operationManager := operation_manager.New(operationFlow, operationStorage, v)
+	operationLeaseStorage, err := service.NewOperationLeaseStorageRedis(clock, conf)
+	if err != nil {
+		return nil, err
+	}
+	operationManager := operation_manager.New(operationFlow, operationStorage, v, operationLeaseStorage)
 	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 	schedulersHandler := handlers.ProvideSchedulersHandler(schedulerManager)
 	operationsHandler := handlers.ProvideOperationsHandler(operationManager)

--- a/cmd/worker/wire.go
+++ b/cmd/worker/wire.go
@@ -45,6 +45,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 		service.NewOperationFlowRedis,
 		service.NewClockTime,
 		service.NewOperationStorageRedis,
+		service.NewOperationLeaseStorageRedis,
 		service.NewPortAllocatorRandom,
 		service.NewRoomStorageRedis,
 		service.NewGameRoomInstanceStorageRedis,

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -34,7 +34,11 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 		return nil, err
 	}
 	v := providers.ProvideDefinitionConstructors()
-	operationManager := operation_manager.New(operationFlow, operationStorage, v)
+	operationLeaseStorage, err := service.NewOperationLeaseStorageRedis(clock, c)
+	if err != nil {
+		return nil, err
+	}
+	operationManager := operation_manager.New(operationFlow, operationStorage, v, operationLeaseStorage)
 	runtime, err := service.NewRuntimeKubernetes(c)
 	if err != nil {
 		return nil, err

--- a/config/management-api.local.yaml
+++ b/config/management-api.local.yaml
@@ -18,3 +18,6 @@ adapters:
   operationStorage:
     redis:
       url: "redis://localhost:6379/0"
+  operationLeaseStorage:
+    redis:
+      url: "redis://localhost:6379/0"

--- a/config/runtime-watcher.local.yaml
+++ b/config/runtime-watcher.local.yaml
@@ -15,6 +15,9 @@ adapters:
   operationStorage:
     redis:
       url: "redis://localhost:6379/0"
+  operationLeaseStorage:
+    redis:
+      url: "redis://localhost:6379/0"
   runtime:
     kubernetes:
       masterUrl: "https://127.0.0.1:6443"

--- a/config/worker.local.yaml
+++ b/config/worker.local.yaml
@@ -15,6 +15,9 @@ adapters:
   operationStorage:
     redis:
       url: "redis://localhost:6379/0"
+  operationLeaseStorage:
+    redis:
+      url: "redis://localhost:6379/0"
   runtime:
     kubernetes:
       masterUrl: "https://127.0.0.1:6443"

--- a/internal/api/handlers/operations_handler_test.go
+++ b/internal/api/handlers/operations_handler_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/stretchr/testify/require"
 	opflow "github.com/topfreegames/maestro/internal/adapters/operation_flow/mock"
+	oplstorage "github.com/topfreegames/maestro/internal/adapters/operation_lease/mock"
 	opstorage "github.com/topfreegames/maestro/internal/adapters/operation_storage/mock"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/operations"
@@ -132,7 +133,8 @@ func TestListOperations(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 
 		operationFlow.EXPECT().ListSchedulerPendingOperationIDs(gomock.Any(), schedulerName).Return([]string{"1", "2", "3"}, nil)
 		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, "1").Return(pendingOperations[0], []byte{}, nil)
@@ -245,7 +247,8 @@ func TestListOperations(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 
 		operationFlow.EXPECT().ListSchedulerPendingOperationIDs(gomock.Any(), schedulerName).Return([]string{"1", "2", "3"}, nil)
 		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, "1").Return(pendingOperations[0], []byte{}, nil)
@@ -358,7 +361,8 @@ func TestListOperations(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 
 		operationFlow.EXPECT().ListSchedulerPendingOperationIDs(gomock.Any(), schedulerName).Return([]string{"1", "2", "3"}, nil)
 		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, "1").Return(pendingOperations[0], []byte{}, nil)
@@ -472,7 +476,8 @@ func TestListOperations(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterOperationsServiceHandlerServer(context.Background(), mux, ProvideOperationsHandler(operationManager))
@@ -501,7 +506,8 @@ func TestListOperations(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterOperationsServiceHandlerServer(context.Background(), mux, ProvideOperationsHandler(operationManager))
@@ -530,7 +536,8 @@ func TestListOperations(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 
 		operationID := "operation-1"
 		schedulerName := "zooba"
@@ -571,7 +578,7 @@ func TestCancelOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, nil, nil)
+		operationManager := operation_manager.New(operationFlow, nil, nil, nil)
 
 		operationFlow.EXPECT().EnqueueOperationCancellationRequest(gomock.Any(), gomock.Eq(ports.OperationCancellationRequest{
 			SchedulerName: schedulerName,
@@ -598,7 +605,7 @@ func TestCancelOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, nil, nil)
+		operationManager := operation_manager.New(operationFlow, nil, nil, nil)
 
 		operationFlow.EXPECT().EnqueueOperationCancellationRequest(gomock.Any(), gomock.Eq(ports.OperationCancellationRequest{
 			SchedulerName: schedulerName,

--- a/internal/api/handlers/schedulers_handler_test.go
+++ b/internal/api/handlers/schedulers_handler_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/stretchr/testify/require"
 	opflow "github.com/topfreegames/maestro/internal/adapters/operation_flow/mock"
+	oplstorage "github.com/topfreegames/maestro/internal/adapters/operation_lease/mock"
 	opstorage "github.com/topfreegames/maestro/internal/adapters/operation_storage/mock"
 	schedulerStorageMock "github.com/topfreegames/maestro/internal/adapters/scheduler_storage/mock"
 	"github.com/topfreegames/maestro/internal/core/entities"
@@ -415,7 +416,8 @@ func TestCreateScheduler(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		scheduler := &entities.Scheduler{
@@ -581,7 +583,8 @@ func TestAddRooms(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -634,7 +637,8 @@ func TestAddRooms(t *testing.T) {
 		defer mockCtrl.Finish()
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, nil)
@@ -663,7 +667,8 @@ func TestRemoveRooms(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -716,7 +721,8 @@ func TestRemoveRooms(t *testing.T) {
 		defer mockCtrl.Finish()
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, nil)
@@ -750,7 +756,8 @@ func TestUpdateScheduler(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -815,7 +822,8 @@ func TestUpdateScheduler(t *testing.T) {
 		defer mockCtrl.Finish()
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("storage offline"))

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	opflow "github.com/topfreegames/maestro/internal/adapters/operation_flow/mock"
+	oplstorage "github.com/topfreegames/maestro/internal/adapters/operation_lease/mock"
 	opstorage "github.com/topfreegames/maestro/internal/adapters/operation_storage/mock"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/operations"
@@ -98,7 +99,8 @@ func TestCreateOperation(t *testing.T) {
 			operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 			operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 			definitionConstructors := operations.NewDefinitionConstructors()
-			opManager := New(operationFlow, operationStorage, definitionConstructors)
+			operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+			opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 			ctx := context.Background()
 			testDefinition, _ := test.definition.(*testOperationDefinition)
@@ -138,8 +140,9 @@ func TestGetOperation(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -167,7 +170,8 @@ func TestGetOperation(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -191,7 +195,8 @@ func TestGetOperation(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -215,7 +220,8 @@ func TestGetOperation(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -242,7 +248,8 @@ func TestNextSchedulerOperation(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -273,7 +280,8 @@ func TestNextSchedulerOperation(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -293,7 +301,8 @@ func TestNextSchedulerOperation(t *testing.T) {
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -319,7 +328,8 @@ func TestStartOperation(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		op := &operation.Operation{ID: uuid.NewString(), DefinitionName: (&testOperationDefinition{}).Name()}
@@ -338,7 +348,8 @@ func TestFinishOperation(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		op := &operation.Operation{
@@ -367,7 +378,8 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{
@@ -392,7 +404,8 @@ func TestListSchedulerFinishedOperations(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{
@@ -417,7 +430,8 @@ func TestListSchedulerPendingOperations(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
-		opManager := New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{
@@ -448,7 +462,8 @@ func TestWatchOperationCancellationRequests(t *testing.T) {
 
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
-		opManager := New(operationFlow, operationStorage, nil)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, nil, operationLeaseStorage)
 
 		cancelableContext, cancelFunction := context.WithCancel(context.Background())
 		opManager.operationCancelFunctions.putFunction(schedulerName, operationID, cancelFunction)

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	opflow "github.com/topfreegames/maestro/internal/adapters/operation_flow/mock"
+	oplstorage "github.com/topfreegames/maestro/internal/adapters/operation_lease/mock"
 	opstorage "github.com/topfreegames/maestro/internal/adapters/operation_storage/mock"
 	schedulerStorageMock "github.com/topfreegames/maestro/internal/adapters/scheduler_storage/mock"
 	"github.com/topfreegames/maestro/internal/core/entities"
@@ -55,7 +56,8 @@ func TestAddRooms(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(ctx, gomock.Any(), gomock.Any()).Return(nil)
@@ -89,7 +91,8 @@ func TestAddRooms(t *testing.T) {
 		defer mockCtrl.Finish()
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, schedulerName).Return(nil, nil)
@@ -113,7 +116,8 @@ func TestRemoveRooms(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 		//operationDefinition := remove_rooms.RemoveRoomsDefinition{Amount: 10}
 
@@ -148,7 +152,8 @@ func TestRemoveRooms(t *testing.T) {
 		defer mockCtrl.Finish()
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, schedulerName).Return(nil, nil)
@@ -335,7 +340,8 @@ func TestCreateSchedulerOperation(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(ctx, gomock.Any(), gomock.Any()).Return(nil)
@@ -378,7 +384,8 @@ func TestCreateSchedulerOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, scheduler.Name).Return(currentScheduler, nil)
@@ -404,7 +411,8 @@ func TestGetSchedulerVersions(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
@@ -425,7 +433,8 @@ func TestGetSchedulerVersions(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
@@ -448,7 +457,8 @@ func TestGetScheduler(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
@@ -473,7 +483,8 @@ func TestGetScheduler(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors())
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
 
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	opflow "github.com/topfreegames/maestro/internal/adapters/operation_flow/mock"
+	oplstorage "github.com/topfreegames/maestro/internal/adapters/operation_lease/mock"
 	opstorage "github.com/topfreegames/maestro/internal/adapters/operation_storage/mock"
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
@@ -62,7 +63,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		definitionConstructors[operationName] = defFunc
 
-		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",
@@ -115,7 +117,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		definitionConstructors[operationName] = defFunc
 
-		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",
@@ -167,7 +170,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		definitionConstructors[operationName] = defFunc
 
-		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",
@@ -209,7 +213,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		definitionConstructors[operationName] = defFunc
 
-		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors)
+		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -31,8 +31,8 @@ import (
 	matchmakerEventsForwarder "github.com/topfreegames/maestro/internal/adapters/events_forwarder/noop_forwarder"
 	instanceStorageRedis "github.com/topfreegames/maestro/internal/adapters/instance_storage/redis"
 	operationFlowRedis "github.com/topfreegames/maestro/internal/adapters/operation_flow/redis"
-	operationStorageRedis "github.com/topfreegames/maestro/internal/adapters/operation_storage/redis"
 	operationLeaseStorageRedis "github.com/topfreegames/maestro/internal/adapters/operation_lease/redis"
+	operationStorageRedis "github.com/topfreegames/maestro/internal/adapters/operation_storage/redis"
 	portAllocatorRandom "github.com/topfreegames/maestro/internal/adapters/port_allocator/random"
 	roomStorageRedis "github.com/topfreegames/maestro/internal/adapters/room_storage/redis"
 	kubernetesRuntime "github.com/topfreegames/maestro/internal/adapters/runtime/kubernetes"
@@ -50,7 +50,7 @@ const (
 	runtimeKubernetesMasterUrlPath  = "adapters.runtime.kubernetes.masterUrl"
 	runtimeKubernetesKubeconfigPath = "adapters.runtime.kubernetes.kubeconfig"
 	// Redis operation storage
-	operationStorageRedisUrlPath = "adapters.operationStorage.redis.url"
+	operationStorageRedisUrlPath      = "adapters.operationStorage.redis.url"
 	operationLeaseStorageRedisUrlPath = "adapters.operationLeaseStorage.redis.url"
 	// Redis room storage
 	roomStorageRedisUrlPath = "adapters.roomStorage.redis.url"

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -32,6 +32,7 @@ import (
 	instanceStorageRedis "github.com/topfreegames/maestro/internal/adapters/instance_storage/redis"
 	operationFlowRedis "github.com/topfreegames/maestro/internal/adapters/operation_flow/redis"
 	operationStorageRedis "github.com/topfreegames/maestro/internal/adapters/operation_storage/redis"
+	operationLeaseStorageRedis "github.com/topfreegames/maestro/internal/adapters/operation_lease/redis"
 	portAllocatorRandom "github.com/topfreegames/maestro/internal/adapters/port_allocator/random"
 	roomStorageRedis "github.com/topfreegames/maestro/internal/adapters/room_storage/redis"
 	kubernetesRuntime "github.com/topfreegames/maestro/internal/adapters/runtime/kubernetes"
@@ -50,6 +51,7 @@ const (
 	runtimeKubernetesKubeconfigPath = "adapters.runtime.kubernetes.kubeconfig"
 	// Redis operation storage
 	operationStorageRedisUrlPath = "adapters.operationStorage.redis.url"
+	operationLeaseStorageRedisUrlPath = "adapters.operationLeaseStorage.redis.url"
 	// Redis room storage
 	roomStorageRedisUrlPath = "adapters.roomStorage.redis.url"
 	// Redis instance storage
@@ -86,6 +88,15 @@ func NewOperationStorageRedis(clock ports.Clock, c config.Config) (ports.Operati
 	}
 
 	return operationStorageRedis.NewRedisOperationStorage(client, clock), nil
+}
+
+func NewOperationLeaseStorageRedis(clock ports.Clock, c config.Config) (ports.OperationLeaseStorage, error) {
+	client, err := createRedisClient(c.GetString(operationLeaseStorageRedisUrlPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Redis operation lease storage: %w", err)
+	}
+
+	return operationLeaseStorageRedis.NewRedisOperationLeaseStorage(client, clock), nil
 }
 
 func NewRoomStorageRedis(c config.Config) (ports.RoomStorage, error) {


### PR DESCRIPTION
### What?
Adds operation Manager lease methods: **GrantLease**, **RevokeLease** and **StartLeaseRenewGoRoutine**
### Why?
The worker should not communicate directly with redis-manipulation methods (repositories). The operation manager is responsible for this work. That said, we needed methods implemented on the manager being called by the worker.
### How?
GrantLease and RevokeLease are straightforward. The StartLeaseRenewGoRoutine calls a goroutine that will keep tracking the operation lease, renewing it from time to time before cancelation of finished status.