### PR TITLE
Update operations worker execution with lease mechanism

### DIFF
--- a/cmd/management_api/wire.go
+++ b/cmd/management_api/wire.go
@@ -60,6 +60,9 @@ func initializeManagementMux(ctx context.Context, conf config.Config) (*runtime.
 		handlers.ProvideOperationsHandler,
 		handlers.ProvidePingHandler,
 		provideManagementMux,
+
+		// config
+		service.NewOperationManagerConfig,
 	)
 
 	return &runtime.ServeMux{}, nil

--- a/cmd/management_api/wire_gen.go
+++ b/cmd/management_api/wire_gen.go
@@ -40,7 +40,11 @@ func initializeManagementMux(ctx context.Context, conf config.Config) (*runtime.
 	if err != nil {
 		return nil, err
 	}
-	operationManager := operation_manager.New(operationFlow, operationStorage, v, operationLeaseStorage)
+	operationManagerConfig, err := service.NewOperationManagerConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+	operationManager := operation_manager.New(operationFlow, operationStorage, v, operationLeaseStorage, operationManagerConfig)
 	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 	schedulersHandler := handlers.ProvideSchedulersHandler(schedulerManager)
 	operationsHandler := handlers.ProvideOperationsHandler(operationManager)

--- a/cmd/worker/wire.go
+++ b/cmd/worker/wire.go
@@ -50,6 +50,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 		service.NewRoomStorageRedis,
 		service.NewGameRoomInstanceStorageRedis,
 		service.NewRoomManagerConfig,
+		service.NewOperationManagerConfig,
 		service.NewEventsForwarder,
 
 		// scheduler operations

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -38,7 +38,11 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	if err != nil {
 		return nil, err
 	}
-	operationManager := operation_manager.New(operationFlow, operationStorage, v, operationLeaseStorage)
+	operationManagerConfig, err := service.NewOperationManagerConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	operationManager := operation_manager.New(operationFlow, operationStorage, v, operationLeaseStorage, operationManagerConfig)
 	runtime, err := service.NewRuntimeKubernetes(c)
 	if err != nil {
 		return nil, err

--- a/config/worker.local.yaml
+++ b/config/worker.local.yaml
@@ -39,3 +39,5 @@ services:
     roomPingTimeoutMillis: 90000
     roomInitializationTimeoutMillis: 120000
     roomDeletionTimeoutMillis: 120000
+  operationManager:
+    operationLeaseTtlMillis: 5000

--- a/internal/api/handlers/operations_handler_test.go
+++ b/internal/api/handlers/operations_handler_test.go
@@ -134,7 +134,8 @@ func TestListOperations(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 
 		operationFlow.EXPECT().ListSchedulerPendingOperationIDs(gomock.Any(), schedulerName).Return([]string{"1", "2", "3"}, nil)
 		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, "1").Return(pendingOperations[0], []byte{}, nil)
@@ -248,7 +249,8 @@ func TestListOperations(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 
 		operationFlow.EXPECT().ListSchedulerPendingOperationIDs(gomock.Any(), schedulerName).Return([]string{"1", "2", "3"}, nil)
 		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, "1").Return(pendingOperations[0], []byte{}, nil)
@@ -362,7 +364,8 @@ func TestListOperations(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 
 		operationFlow.EXPECT().ListSchedulerPendingOperationIDs(gomock.Any(), schedulerName).Return([]string{"1", "2", "3"}, nil)
 		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, "1").Return(pendingOperations[0], []byte{}, nil)
@@ -477,7 +480,8 @@ func TestListOperations(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterOperationsServiceHandlerServer(context.Background(), mux, ProvideOperationsHandler(operationManager))
@@ -507,7 +511,8 @@ func TestListOperations(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterOperationsServiceHandlerServer(context.Background(), mux, ProvideOperationsHandler(operationManager))
@@ -537,7 +542,8 @@ func TestListOperations(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 
 		operationID := "operation-1"
 		schedulerName := "zooba"
@@ -578,7 +584,8 @@ func TestCancelOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, nil, nil, nil)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, nil, nil, nil, config)
 
 		operationFlow.EXPECT().EnqueueOperationCancellationRequest(gomock.Any(), gomock.Eq(ports.OperationCancellationRequest{
 			SchedulerName: schedulerName,
@@ -605,7 +612,8 @@ func TestCancelOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, nil, nil, nil)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, nil, nil, nil, config)
 
 		operationFlow.EXPECT().EnqueueOperationCancellationRequest(gomock.Any(), gomock.Eq(ports.OperationCancellationRequest{
 			SchedulerName: schedulerName,

--- a/internal/api/handlers/schedulers_handler_test.go
+++ b/internal/api/handlers/schedulers_handler_test.go
@@ -417,7 +417,8 @@ func TestCreateScheduler(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		scheduler := &entities.Scheduler{
@@ -584,7 +585,8 @@ func TestAddRooms(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -638,7 +640,8 @@ func TestAddRooms(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, nil)
@@ -668,7 +671,8 @@ func TestRemoveRooms(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -722,7 +726,8 @@ func TestRemoveRooms(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, nil)
@@ -757,7 +762,8 @@ func TestUpdateScheduler(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -823,7 +829,8 @@ func TestUpdateScheduler(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("storage offline"))

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -93,16 +93,18 @@ type OperationManager struct {
 	flow                            ports.OperationFlow
 	storage                         ports.OperationStorage
 	leaseStorage                    ports.OperationLeaseStorage
+	config                          OperationManagerConfig
 	operationDefinitionConstructors map[string]operations.DefinitionConstructor
 }
 
-func New(flow ports.OperationFlow, storage ports.OperationStorage, operationDefinitionConstructors map[string]operations.DefinitionConstructor, leaseStorage ports.OperationLeaseStorage) *OperationManager {
+func New(flow ports.OperationFlow, storage ports.OperationStorage, operationDefinitionConstructors map[string]operations.DefinitionConstructor, leaseStorage ports.OperationLeaseStorage, config OperationManagerConfig) *OperationManager {
 	return &OperationManager{
 		flow:                            flow,
 		storage:                         storage,
 		operationDefinitionConstructors: operationDefinitionConstructors,
 		operationCancelFunctions:        NewOperationCancelFunctions(),
 		leaseStorage:                    leaseStorage,
+		config:                          config,
 	}
 }
 

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -276,8 +276,8 @@ func (om *OperationManager) cancelOperation(ctx context.Context, schedulerName, 
 	return nil
 }
 
-func (om *OperationManager) GrantLease(ctx context.Context, operation *operation.Operation, initialTTL time.Duration) error {
-	err := om.leaseStorage.GrantLease(ctx, operation.SchedulerName, operation.ID, initialTTL)
+func (om *OperationManager) GrantLease(ctx context.Context, operation *operation.Operation) error {
+	err := om.leaseStorage.GrantLease(ctx, operation.SchedulerName, operation.ID, om.config.OperationLeaseTtl)
 	if err != nil {
 		return fmt.Errorf("failed to grant lease to operation: %w", err)
 	}
@@ -294,11 +294,11 @@ func (om *OperationManager) RevokeLease(ctx context.Context, operation *operatio
 	return nil
 }
 
-func (om *OperationManager) StartLeaseRenewGoRoutine(operationCtx context.Context, op *operation.Operation, ttl time.Duration) {
+func (om *OperationManager) StartLeaseRenewGoRoutine(operationCtx context.Context, op *operation.Operation) {
 	go func() {
 		zap.L().Info("starting operation lease renew go routine")
 
-		ticker := time.NewTicker(ttl)
+		ticker := time.NewTicker(om.config.OperationLeaseTtl)
 		defer ticker.Stop()
 
 	renewLeaseLoop:
@@ -310,7 +310,7 @@ func (om *OperationManager) StartLeaseRenewGoRoutine(operationCtx context.Contex
 					break renewLeaseLoop
 				}
 
-				err := om.leaseStorage.RenewLease(operationCtx, op.SchedulerName, op.ID, ttl)
+				err := om.leaseStorage.RenewLease(operationCtx, op.SchedulerName, op.ID, om.config.OperationLeaseTtl)
 				if err != nil {
 					zap.L().
 						With(zap.String("schedulerName", op.SchedulerName)).

--- a/internal/core/services/operation_manager/operation_manager_config.go
+++ b/internal/core/services/operation_manager/operation_manager_config.go
@@ -1,0 +1,29 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package operation_manager
+
+import "time"
+
+type OperationManagerConfig struct {
+	OperationLeaseTtl time.Duration
+}

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -100,7 +100,8 @@ func TestCreateOperation(t *testing.T) {
 			operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 			definitionConstructors := operations.NewDefinitionConstructors()
 			operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-			opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+			config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+			opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 			ctx := context.Background()
 			testDefinition, _ := test.definition.(*testOperationDefinition)
@@ -142,7 +143,8 @@ func TestGetOperation(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -171,7 +173,8 @@ func TestGetOperation(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -196,7 +199,8 @@ func TestGetOperation(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -221,7 +225,8 @@ func TestGetOperation(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -249,7 +254,8 @@ func TestNextSchedulerOperation(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -281,7 +287,8 @@ func TestNextSchedulerOperation(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -302,7 +309,8 @@ func TestNextSchedulerOperation(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -329,7 +337,8 @@ func TestStartOperation(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		op := &operation.Operation{ID: uuid.NewString(), DefinitionName: (&testOperationDefinition{}).Name()}
@@ -349,7 +358,8 @@ func TestFinishOperation(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		op := &operation.Operation{
@@ -379,7 +389,8 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{
@@ -405,7 +416,8 @@ func TestListSchedulerFinishedOperations(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{
@@ -431,7 +443,8 @@ func TestListSchedulerPendingOperations(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{
@@ -463,7 +476,8 @@ func TestWatchOperationCancellationRequests(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, nil, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, nil, operationLeaseStorage, config)
 
 		cancelableContext, cancelFunction := context.WithCancel(context.Background())
 		opManager.operationCancelFunctions.putFunction(schedulerName, operationID, cancelFunction)
@@ -513,7 +527,8 @@ func TestGrantLease(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -541,7 +556,8 @@ func TestGrantLease(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -571,7 +587,8 @@ func TestRevokeLease(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -597,7 +614,8 @@ func TestRevokeLease(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -627,7 +645,8 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -655,7 +674,8 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -686,7 +706,8 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx, cancelFunction := context.WithCancel(context.Background())
 		schedulerName := "test-scheduler"
@@ -715,7 +736,8 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx, cancelFunction := context.WithCancel(context.Background())
 		schedulerName := "test-scheduler"
@@ -744,7 +766,8 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 
 		ctx, cancelFunction := context.WithCancel(context.Background())
 		schedulerName := "test-scheduler"

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -57,7 +57,8 @@ func TestAddRooms(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(ctx, gomock.Any(), gomock.Any()).Return(nil)
@@ -92,7 +93,8 @@ func TestAddRooms(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, schedulerName).Return(nil, nil)
@@ -117,7 +119,8 @@ func TestRemoveRooms(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 		//operationDefinition := remove_rooms.RemoveRoomsDefinition{Amount: 10}
 
@@ -153,7 +156,8 @@ func TestRemoveRooms(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, schedulerName).Return(nil, nil)
@@ -341,7 +345,8 @@ func TestCreateSchedulerOperation(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		operationStorage.EXPECT().CreateOperation(ctx, gomock.Any(), gomock.Any()).Return(nil)
@@ -385,7 +390,8 @@ func TestCreateSchedulerOperation(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(nil, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, scheduler.Name).Return(currentScheduler, nil)
@@ -412,7 +418,8 @@ func TestGetSchedulerVersions(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
@@ -434,7 +441,8 @@ func TestGetSchedulerVersions(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
@@ -458,7 +466,8 @@ func TestGetScheduler(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
@@ -484,7 +493,8 @@ func TestGetScheduler(t *testing.T) {
 		operationFlow := opflow.NewMockOperationFlow(mockCtrl)
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
 
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -118,6 +118,8 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 		}
 		err = w.operationManager.GrantLease(operationContext, op)
 		if err != nil {
+			w.Stop(ctx)
+			reportOperationExecutionWorkerFailed(w.schedulerName, LabelStartOperationFailed)
 			return fmt.Errorf("failed to grant lease to operation \"%s\" for the scheduler \"%s\"", op.ID, op.SchedulerName)
 		}
 		w.operationManager.StartLeaseRenewGoRoutine(operationContext, op)

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -64,7 +64,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		definitionConstructors[operationName] = defFunc
 
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",
@@ -118,7 +119,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		definitionConstructors[operationName] = defFunc
 
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",
@@ -171,7 +173,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		definitionConstructors[operationName] = defFunc
 
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",
@@ -214,7 +217,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		definitionConstructors[operationName] = defFunc
 
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		operationManager := operation_manager.New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
 		scheduler := &entities.Scheduler{Name: "random-scheduler"}
 		expectedOperation := &operation.Operation{
 			ID:             "random-operation-id",

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/topfreegames/maestro/internal/config"
+	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
 	"github.com/topfreegames/maestro/internal/core/services/room_manager"
 )
 
@@ -41,4 +42,14 @@ func NewRoomManagerConfig(c config.Config) (room_manager.RoomManagerConfig, erro
 	}
 
 	return roomManagerConfig, nil
+}
+
+func NewOperationManagerConfig(c config.Config) (operation_manager.OperationManagerConfig, error) {
+	operationLeaseTtl := time.Duration(c.GetInt("services.operationManager.operationLeaseTtlMillis")) * time.Millisecond
+
+	operationManagerConfig := operation_manager.OperationManagerConfig{
+		OperationLeaseTtl: operationLeaseTtl,
+	}
+
+	return operationManagerConfig, nil
 }


### PR DESCRIPTION
### What?
Implements lease mechanism on worker to grant/renew/revoke lease on every executed operation.
### Why?
We want to keep track on operations, to understand when they are still executing, or when they should be but the process died and the operation is stuck. It helps troubleshooting
### How?
Using the operation manager and a config variable containing the value in ms of the ttl of the lease. This value is used to keep renewing lease when the operation is still executing.