### PR TITLE
Include lease data in operation listing

### DIFF
--- a/internal/api/handlers/operations_handler_test.go
+++ b/internal/api/handlers/operations_handler_test.go
@@ -143,6 +143,9 @@ func TestListOperations(t *testing.T) {
 		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, "3").Return(pendingOperations[2], []byte{}, nil)
 		operationStorage.EXPECT().ListSchedulerFinishedOperations(gomock.Any(), schedulerName).Return(finishedOperations, nil)
 		operationStorage.EXPECT().ListSchedulerActiveOperations(gomock.Any(), schedulerName).Return(activeOperations, nil)
+		operationLeaseStorage.EXPECT().FetchLeaseTTL(gomock.Any(), schedulerName, activeOperations[0].ID).Return(time.Unix(1641306511, 0), nil)
+		operationLeaseStorage.EXPECT().FetchLeaseTTL(gomock.Any(), schedulerName, activeOperations[1].ID).Return(time.Unix(1641306522, 0), nil)
+		operationLeaseStorage.EXPECT().FetchLeaseTTL(gomock.Any(), schedulerName, activeOperations[2].ID).Return(time.Unix(1641306533, 0), nil)
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterOperationsServiceHandlerServer(context.Background(), mux, ProvideOperationsHandler(operationManager))
@@ -258,6 +261,9 @@ func TestListOperations(t *testing.T) {
 		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, "3").Return(pendingOperations[2], []byte{}, nil)
 		operationStorage.EXPECT().ListSchedulerFinishedOperations(gomock.Any(), schedulerName).Return(finishedOperations, nil)
 		operationStorage.EXPECT().ListSchedulerActiveOperations(gomock.Any(), schedulerName).Return(activeOperations, nil)
+		operationLeaseStorage.EXPECT().FetchLeaseTTL(gomock.Any(), schedulerName, activeOperations[0].ID).Return(time.Unix(1641306511, 0), nil)
+		operationLeaseStorage.EXPECT().FetchLeaseTTL(gomock.Any(), schedulerName, activeOperations[1].ID).Return(time.Unix(1641306522, 0), nil)
+		operationLeaseStorage.EXPECT().FetchLeaseTTL(gomock.Any(), schedulerName, activeOperations[2].ID).Return(time.Unix(1641306533, 0), nil)
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterOperationsServiceHandlerServer(context.Background(), mux, ProvideOperationsHandler(operationManager))
@@ -373,6 +379,9 @@ func TestListOperations(t *testing.T) {
 		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, "3").Return(pendingOperations[2], []byte{}, nil)
 		operationStorage.EXPECT().ListSchedulerFinishedOperations(gomock.Any(), schedulerName).Return(finishedOperations, nil)
 		operationStorage.EXPECT().ListSchedulerActiveOperations(gomock.Any(), schedulerName).Return(activeOperations, nil)
+		operationLeaseStorage.EXPECT().FetchLeaseTTL(gomock.Any(), schedulerName, activeOperations[0].ID).Return(time.Unix(1641306511, 0), nil)
+		operationLeaseStorage.EXPECT().FetchLeaseTTL(gomock.Any(), schedulerName, activeOperations[1].ID).Return(time.Unix(1641306522, 0), nil)
+		operationLeaseStorage.EXPECT().FetchLeaseTTL(gomock.Any(), schedulerName, activeOperations[2].ID).Return(time.Unix(1641306533, 0), nil)
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterOperationsServiceHandlerServer(context.Background(), mux, ProvideOperationsHandler(operationManager))

--- a/internal/core/entities/operation/operation.go
+++ b/internal/core/entities/operation/operation.go
@@ -49,6 +49,7 @@ type Operation struct {
 	Status         Status
 	DefinitionName string
 	SchedulerName  string
+	Lease          OperationLease
 	CreatedAt      time.Time
 }
 

--- a/internal/core/services/operation_manager/operation_cancel_functions.go
+++ b/internal/core/services/operation_manager/operation_cancel_functions.go
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package operation_manager
 
 import (

--- a/internal/core/services/operation_manager/operation_cancel_functions.go
+++ b/internal/core/services/operation_manager/operation_cancel_functions.go
@@ -1,0 +1,59 @@
+package operation_manager
+
+import (
+	"context"
+	"sync"
+
+	"github.com/topfreegames/maestro/internal/core/ports/errors"
+)
+
+type OperationCancelFunctions struct {
+	mutex     sync.RWMutex
+	functions map[string]map[string]context.CancelFunc
+}
+
+func NewOperationCancelFunctions() *OperationCancelFunctions {
+	return &OperationCancelFunctions{
+		functions: map[string]map[string]context.CancelFunc{},
+	}
+}
+
+func (of *OperationCancelFunctions) putFunction(schedulerName, operationID string, cancelFunc context.CancelFunc) {
+	of.mutex.Lock()
+	schedulerCancelFunctions := of.functions[schedulerName]
+	if schedulerCancelFunctions == nil {
+		of.functions[schedulerName] = map[string]context.CancelFunc{}
+	}
+	of.functions[schedulerName][operationID] = cancelFunc
+	of.mutex.Unlock()
+}
+
+func (of *OperationCancelFunctions) removeFunction(schedulerName, operationID string) {
+	of.mutex.Lock()
+
+	schedulerOperationCancellationFunctions := of.functions[schedulerName]
+	if schedulerOperationCancellationFunctions == nil {
+		return
+	}
+
+	delete(schedulerOperationCancellationFunctions, operationID)
+
+	of.mutex.Unlock()
+}
+
+func (of *OperationCancelFunctions) getFunction(schedulerName, operationID string) (context.CancelFunc, error) {
+	of.mutex.RLock()
+	schedulerOperationCancellationFunctions := of.functions[schedulerName]
+	if schedulerOperationCancellationFunctions == nil {
+		return nil, errors.NewErrNotFound("no cancel scheduler found for scheduler name: %s", schedulerName)
+	}
+
+	if schedulerOperationCancellationFunctions[operationID] == nil {
+		return nil, errors.NewErrNotFound("no cancel function found for scheduler name: %s and operation id: %s", schedulerName, operationID)
+	}
+
+	function := schedulerOperationCancellationFunctions[operationID]
+	of.mutex.RUnlock()
+
+	return function, nil
+}

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -36,57 +35,6 @@ import (
 	"github.com/topfreegames/maestro/internal/core/ports/errors"
 	"go.uber.org/zap"
 )
-
-type OperationCancelFunctions struct {
-	mutex     sync.RWMutex
-	functions map[string]map[string]context.CancelFunc
-}
-
-func NewOperationCancelFunctions() *OperationCancelFunctions {
-	return &OperationCancelFunctions{
-		functions: map[string]map[string]context.CancelFunc{},
-	}
-}
-
-func (of *OperationCancelFunctions) putFunction(schedulerName, operationID string, cancelFunc context.CancelFunc) {
-	of.mutex.Lock()
-	schedulerCancelFunctions := of.functions[schedulerName]
-	if schedulerCancelFunctions == nil {
-		of.functions[schedulerName] = map[string]context.CancelFunc{}
-	}
-	of.functions[schedulerName][operationID] = cancelFunc
-	of.mutex.Unlock()
-}
-
-func (of *OperationCancelFunctions) removeFunction(schedulerName, operationID string) {
-	of.mutex.Lock()
-
-	schedulerOperationCancellationFunctions := of.functions[schedulerName]
-	if schedulerOperationCancellationFunctions == nil {
-		return
-	}
-
-	delete(schedulerOperationCancellationFunctions, operationID)
-
-	of.mutex.Unlock()
-}
-
-func (of *OperationCancelFunctions) getFunction(schedulerName, operationID string) (context.CancelFunc, error) {
-	of.mutex.RLock()
-	schedulerOperationCancellationFunctions := of.functions[schedulerName]
-	if schedulerOperationCancellationFunctions == nil {
-		return nil, errors.NewErrNotFound("no cancel scheduler found for scheduler name: %s", schedulerName)
-	}
-
-	if schedulerOperationCancellationFunctions[operationID] == nil {
-		return nil, errors.NewErrNotFound("no cancel function found for scheduler name: %s and operation id: %s", schedulerName, operationID)
-	}
-
-	function := schedulerOperationCancellationFunctions[operationID]
-	of.mutex.RUnlock()
-
-	return function, nil
-}
 
 type OperationManager struct {
 	operationCancelFunctions        *OperationCancelFunctions

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -425,7 +425,8 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		operationManagerConfig := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, operationManagerConfig)
 
 		ctx := context.Background()
 
@@ -443,7 +444,8 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage)
+		operationManagerConfig := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, operationManagerConfig)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{


### PR DESCRIPTION
## What ❓ 
Add Lease field in Operation struct and modify ListSchedulerActiveOperations method from OperationManager to include lease information in its response.

## Why 🤔 
Get operations endpoint will now include lease information, so we need to change its internals to include this lease data.

## How 👀 
- Minor refactor in operation_manager file
- New field in Operation struct
- Update ListSchedulerActiveOperations method and improve its tst