### PR TITLE
refactor event forwarder ports

### DIFF
--- a/internal/adapters/events_forwarder/mock/mock.go
+++ b/internal/adapters/events_forwarder/mock/mock.go
@@ -9,6 +9,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	events "github.com/topfreegames/maestro/internal/core/entities/events"
+	forwarder "github.com/topfreegames/maestro/internal/core/entities/forwarder"
 	game_room "github.com/topfreegames/maestro/internal/core/entities/game_room"
 )
 
@@ -36,31 +38,59 @@ func (m *MockEventsForwarder) EXPECT() *MockEventsForwarderMockRecorder {
 }
 
 // ForwardPlayerEvent mocks base method.
-func (m *MockEventsForwarder) ForwardPlayerEvent(ctx context.Context, gameRoom *game_room.GameRoom, attributes map[string]interface{}, options interface{}) error {
+func (m *MockEventsForwarder) ForwardPlayerEvent(ctx context.Context, eventAttributes events.PlayerEventAttributes, forwarderOptions forwarder.ForwardOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ForwardPlayerEvent", ctx, gameRoom, attributes, options)
+	ret := m.ctrl.Call(m, "ForwardPlayerEvent", ctx, eventAttributes, forwarderOptions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ForwardPlayerEvent indicates an expected call of ForwardPlayerEvent.
-func (mr *MockEventsForwarderMockRecorder) ForwardPlayerEvent(ctx, gameRoom, attributes, options interface{}) *gomock.Call {
+func (mr *MockEventsForwarderMockRecorder) ForwardPlayerEvent(ctx, eventAttributes, forwarderOptions interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForwardPlayerEvent", reflect.TypeOf((*MockEventsForwarder)(nil).ForwardPlayerEvent), ctx, gameRoom, attributes, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForwardPlayerEvent", reflect.TypeOf((*MockEventsForwarder)(nil).ForwardPlayerEvent), ctx, eventAttributes, forwarderOptions)
+}
+
+// ForwardPlayerEventObsolete mocks base method.
+func (m *MockEventsForwarder) ForwardPlayerEventObsolete(ctx context.Context, gameRoom *game_room.GameRoom, attributes map[string]interface{}, options interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForwardPlayerEventObsolete", ctx, gameRoom, attributes, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForwardPlayerEventObsolete indicates an expected call of ForwardPlayerEventObsolete.
+func (mr *MockEventsForwarderMockRecorder) ForwardPlayerEventObsolete(ctx, gameRoom, attributes, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForwardPlayerEventObsolete", reflect.TypeOf((*MockEventsForwarder)(nil).ForwardPlayerEventObsolete), ctx, gameRoom, attributes, options)
 }
 
 // ForwardRoomEvent mocks base method.
-func (m *MockEventsForwarder) ForwardRoomEvent(ctx context.Context, gameRoom *game_room.GameRoom, instance *game_room.Instance, attributes map[string]interface{}, options interface{}) error {
+func (m *MockEventsForwarder) ForwardRoomEvent(ctx context.Context, eventAttributes events.RoomEventAttributes, forwarderOptions forwarder.ForwardOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ForwardRoomEvent", ctx, gameRoom, instance, attributes, options)
+	ret := m.ctrl.Call(m, "ForwardRoomEvent", ctx, eventAttributes, forwarderOptions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ForwardRoomEvent indicates an expected call of ForwardRoomEvent.
-func (mr *MockEventsForwarderMockRecorder) ForwardRoomEvent(ctx, gameRoom, instance, attributes, options interface{}) *gomock.Call {
+func (mr *MockEventsForwarderMockRecorder) ForwardRoomEvent(ctx, eventAttributes, forwarderOptions interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForwardRoomEvent", reflect.TypeOf((*MockEventsForwarder)(nil).ForwardRoomEvent), ctx, gameRoom, instance, attributes, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForwardRoomEvent", reflect.TypeOf((*MockEventsForwarder)(nil).ForwardRoomEvent), ctx, eventAttributes, forwarderOptions)
+}
+
+// ForwardRoomEventObsolete mocks base method.
+func (m *MockEventsForwarder) ForwardRoomEventObsolete(ctx context.Context, gameRoom *game_room.GameRoom, instance *game_room.Instance, attributes map[string]interface{}, options interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForwardRoomEventObsolete", ctx, gameRoom, instance, attributes, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForwardRoomEventObsolete indicates an expected call of ForwardRoomEventObsolete.
+func (mr *MockEventsForwarderMockRecorder) ForwardRoomEventObsolete(ctx, gameRoom, instance, attributes, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForwardRoomEventObsolete", reflect.TypeOf((*MockEventsForwarder)(nil).ForwardRoomEventObsolete), ctx, gameRoom, instance, attributes, options)
 }
 
 // Name mocks base method.

--- a/internal/adapters/events_forwarder/noop_forwarder/noop_forwarder.go
+++ b/internal/adapters/events_forwarder/noop_forwarder/noop_forwarder.go
@@ -37,13 +37,13 @@ func NewNoopForwarder() *noopForwarder {
 	return &noopForwarder{}
 }
 
-// ForwardRoomEvent forwards room events. It receives the game room, its instance, and additional attributes.
-func (f *noopForwarder) ForwardRoomEvent(ctx context.Context, eventAttributes events.RoomEventAttributes, forwarderOptions forwarder.ForwardOptions) error {
+// ForwardRoomEvent forwards room events. It receives the room event attributes and forwarder configuration.
+func (f *noopForwarder) ForwardRoomEvent(ctx context.Context, eventAttributes events.RoomEventAttributes, forwarder forwarder.Forwarder) error {
 	return nil
 }
 
-// ForwardPlayerEvent forwards a player events. It receives the game room and additional attributes.
-func (f *noopForwarder) ForwardPlayerEvent(ctx context.Context, eventAttributes events.PlayerEventAttributes, forwarderOptions forwarder.ForwardOptions) error {
+// ForwardPlayerEvent forwards a player events. It receives the player events attributes and forwarder configuration.
+func (f *noopForwarder) ForwardPlayerEvent(ctx context.Context, eventAttributes events.PlayerEventAttributes, forwarder forwarder.Forwarder) error {
 	return nil
 }
 

--- a/internal/adapters/events_forwarder/noop_forwarder/noop_forwarder.go
+++ b/internal/adapters/events_forwarder/noop_forwarder/noop_forwarder.go
@@ -25,6 +25,9 @@ package noop_forwarder
 import (
 	"context"
 
+	"github.com/topfreegames/maestro/internal/core/entities/events"
+	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
+
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 )
 
@@ -35,12 +38,22 @@ func NewNoopForwarder() *noopForwarder {
 }
 
 // ForwardRoomEvent forwards room events. It receives the game room, its instance, and additional attributes.
-func (*noopForwarder) ForwardRoomEvent(ctx context.Context, gameRoom *game_room.GameRoom, instance *game_room.Instance, attributes map[string]interface{}, options interface{}) error {
-	return nil
+func (f *noopForwarder) ForwardRoomEvent(ctx context.Context, eventAttributes events.RoomEventAttributes, forwarderOptions forwarder.ForwardOptions) error {
+	panic("implement me")
 }
 
 // ForwardPlayerEvent forwards a player events. It receives the game room and additional attributes.
-func (*noopForwarder) ForwardPlayerEvent(ctx context.Context, gameRoom *game_room.GameRoom, attributes map[string]interface{}, options interface{}) error {
+func (f *noopForwarder) ForwardPlayerEvent(ctx context.Context, eventAttributes events.PlayerEventAttributes, forwarderOptions forwarder.ForwardOptions) error {
+	panic("implement me")
+}
+
+// ForwardRoomEventObsolete forwards room events. It receives the game room, its instance, and additional attributes.
+func (*noopForwarder) ForwardRoomEventObsolete(ctx context.Context, gameRoom *game_room.GameRoom, instance *game_room.Instance, attributes map[string]interface{}, options interface{}) error {
+	return nil
+}
+
+// ForwardPlayerEventObsolete forwards a player events. It receives the game room and additional attributes.
+func (*noopForwarder) ForwardPlayerEventObsolete(ctx context.Context, gameRoom *game_room.GameRoom, attributes map[string]interface{}, options interface{}) error {
 	return nil
 }
 

--- a/internal/adapters/events_forwarder/noop_forwarder/noop_forwarder.go
+++ b/internal/adapters/events_forwarder/noop_forwarder/noop_forwarder.go
@@ -39,12 +39,12 @@ func NewNoopForwarder() *noopForwarder {
 
 // ForwardRoomEvent forwards room events. It receives the game room, its instance, and additional attributes.
 func (f *noopForwarder) ForwardRoomEvent(ctx context.Context, eventAttributes events.RoomEventAttributes, forwarderOptions forwarder.ForwardOptions) error {
-	panic("implement me")
+	return nil
 }
 
 // ForwardPlayerEvent forwards a player events. It receives the game room and additional attributes.
 func (f *noopForwarder) ForwardPlayerEvent(ctx context.Context, eventAttributes events.PlayerEventAttributes, forwarderOptions forwarder.ForwardOptions) error {
-	panic("implement me")
+	return nil
 }
 
 // ForwardRoomEventObsolete forwards room events. It receives the game room, its instance, and additional attributes.

--- a/internal/core/entities/events/player_event.go
+++ b/internal/core/entities/events/player_event.go
@@ -1,0 +1,37 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package events
+
+type PlayerEventAttributes struct {
+	RoomId    string
+	PlayerId  string
+	EventType PlayerEventType
+	Other     map[string]interface{}
+}
+
+type PlayerEventType string
+
+var (
+	PlayerLeft PlayerEventType = "playerLeft"
+	PlayerJoin PlayerEventType = "playerJoin"
+)

--- a/internal/core/entities/events/room_event.go
+++ b/internal/core/entities/events/room_event.go
@@ -1,0 +1,49 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package events
+
+type RoomEventAttributes struct {
+	Game       string
+	RoomId     string
+	Host       string
+	Port       string
+	EventType  RoomEventType
+	PingType   *RoomPingEventType
+	Attributes map[string]interface{}
+}
+
+type RoomEventType string
+
+var (
+	Ping      RoomEventType = "resync"
+	Arbitrary RoomEventType = "roomEvent"
+)
+
+type RoomPingEventType string
+
+var (
+	RoomPingReady       RoomPingEventType = "roomReady"
+	RoomPingOccupied    RoomPingEventType = "roomOccupied"
+	RoomPingTerminating RoomPingEventType = "roomOccupied"
+	RoomPingTerminated  RoomPingEventType = "roomOccupied"
+)

--- a/internal/core/ports/events_forwarder.go
+++ b/internal/core/ports/events_forwarder.go
@@ -25,14 +25,21 @@ package ports
 import (
 	"context"
 
+	"github.com/topfreegames/maestro/internal/core/entities/events"
+	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
+
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 )
 
 type EventsForwarder interface {
 	// ForwardRoomEvent forwards room events. It receives the game room, its instance, and additional attributes.
-	ForwardRoomEvent(ctx context.Context, gameRoom *game_room.GameRoom, instance *game_room.Instance, attributes map[string]interface{}, options interface{}) error
+	ForwardRoomEvent(ctx context.Context, eventAttributes events.RoomEventAttributes, forwarderOptions forwarder.ForwardOptions) error
 	// ForwardPlayerEvent forwards a player events. It receives the game room and additional attributes.
-	ForwardPlayerEvent(ctx context.Context, gameRoom *game_room.GameRoom, attributes map[string]interface{}, options interface{}) error
+	ForwardPlayerEvent(ctx context.Context, eventAttributes events.PlayerEventAttributes, forwarderOptions forwarder.ForwardOptions) error
+	// ForwardRoomEventObsolete forwards room events. It receives the game room, its instance, and additional attributes.
+	ForwardRoomEventObsolete(ctx context.Context, gameRoom *game_room.GameRoom, instance *game_room.Instance, attributes map[string]interface{}, options interface{}) error
+	// ForwardPlayerEventObsolete forwards a player events. It receives the game room and additional attributes.
+	ForwardPlayerEventObsolete(ctx context.Context, gameRoom *game_room.GameRoom, attributes map[string]interface{}, options interface{}) error
 	// Name returns the forwarder name. This name should be unique among other events forwarders.
 	Name() string
 }

--- a/internal/core/ports/events_forwarder.go
+++ b/internal/core/ports/events_forwarder.go
@@ -32,10 +32,10 @@ import (
 )
 
 type EventsForwarder interface {
-	// ForwardRoomEvent forwards room events. It receives the game room, its instance, and additional attributes.
-	ForwardRoomEvent(ctx context.Context, eventAttributes events.RoomEventAttributes, forwarderOptions forwarder.ForwardOptions) error
-	// ForwardPlayerEvent forwards a player events. It receives the game room and additional attributes.
-	ForwardPlayerEvent(ctx context.Context, eventAttributes events.PlayerEventAttributes, forwarderOptions forwarder.ForwardOptions) error
+	// ForwardRoomEvent forwards room events. It receives the room event attributes and forwarder configuration.
+	ForwardRoomEvent(ctx context.Context, eventAttributes events.RoomEventAttributes, forwarder forwarder.Forwarder) error
+	// ForwardPlayerEvent forwards a player events. It receives the player events attributes and forwarder configuration.
+	ForwardPlayerEvent(ctx context.Context, eventAttributes events.PlayerEventAttributes, forwarder forwarder.Forwarder) error
 	// ForwardRoomEventObsolete forwards room events. It receives the game room, its instance, and additional attributes.
 	ForwardRoomEventObsolete(ctx context.Context, gameRoom *game_room.GameRoom, instance *game_room.Instance, attributes map[string]interface{}, options interface{}) error
 	// ForwardPlayerEventObsolete forwards a player events. It receives the game room and additional attributes.

--- a/internal/core/services/events_forwarder/events_forwarder_service.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service.go
@@ -61,7 +61,7 @@ func (es *EventsForwarderService) ProduceEvent(ctx context.Context, event *event
 }
 
 func (es *EventsForwarderService) forwardRoomEvent(ctx context.Context, room *game_room.GameRoom, instance *game_room.Instance, attributes map[string]interface{}, options interface{}) error {
-	err := es.eventsForwarder.ForwardRoomEvent(ctx, room, instance, attributes, options)
+	err := es.eventsForwarder.ForwardRoomEventObsolete(ctx, room, instance, attributes, options)
 	if err != nil {
 		reportRoomEventForwardingFailed(room.SchedulerID)
 		es.logger.Error(fmt.Sprintf("Failed to forward room events for room %s and scheduler %s", room.ID, room.SchedulerID), zap.Error(err))
@@ -72,7 +72,7 @@ func (es *EventsForwarderService) forwardRoomEvent(ctx context.Context, room *ga
 }
 
 func (es *EventsForwarderService) forwardPlayerEvent(ctx context.Context, room *game_room.GameRoom, attributes map[string]interface{}, options interface{}) error {
-	err := es.eventsForwarder.ForwardPlayerEvent(ctx, room, attributes, options)
+	err := es.eventsForwarder.ForwardPlayerEventObsolete(ctx, room, attributes, options)
 	if err != nil {
 		reportPlayerEventForwardingFailed(room.SchedulerID)
 		es.logger.Error(fmt.Sprintf("Failed to forward player events for room %s and scheduler %s", room.ID, room.SchedulerID), zap.Error(err))


### PR DESCRIPTION
**What?**
Refactor event forwarders ports signature.

**Why?**
To make the code more expressive and clean.

**How?**
Create structs to better represent the necessary data received to make the forwarder

**Obs**
The signature that already existed in the port were just renamed to Obsolete, only to not break the already existing code. They will be replaced and deleted in the next tasks
