### PR TITLE
implements scheduler cache adapter

### DIFF
--- a/cmd/rooms_api/wire.go
+++ b/cmd/rooms_api/wire.go
@@ -51,6 +51,7 @@ func initializeRoomsMux(ctx context.Context, conf config.Config) (*runtime.Serve
 		service.NewRoomManagerConfig,
 		service.NewEventsForwarder,
 		service.NewSchedulerStoragePg,
+		service.NewEventsForwarderServiceConfig,
 
 		// services
 		events_forwarder.NewEventsForwarderService,

--- a/cmd/rooms_api/wire_gen.go
+++ b/cmd/rooms_api/wire_gen.go
@@ -49,7 +49,11 @@ func initializeRoomsMux(ctx context.Context, conf config.Config) (*runtime.Serve
 	if err != nil {
 		return nil, err
 	}
-	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, schedulerCache)
+	eventsForwarderConfig, err := service.NewEventsForwarderServiceConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, schedulerCache, eventsForwarderConfig)
 	roomManagerConfig, err := service.NewRoomManagerConfig(conf)
 	if err != nil {
 		return nil, err

--- a/cmd/runtime_watcher/wire.go
+++ b/cmd/runtime_watcher/wire.go
@@ -56,6 +56,7 @@ var RoomManagerSet = wire.NewSet(
 	service.NewEventsForwarder,
 	events_forwarder.NewEventsForwarderService,
 	room_manager.NewRoomManager,
+	service.NewEventsForwarderServiceConfig,
 )
 
 func initializeRuntimeWatcher(c config.Config) (*workers_manager.WorkersManager, error) {

--- a/cmd/runtime_watcher/wire_gen.go
+++ b/cmd/runtime_watcher/wire_gen.go
@@ -50,7 +50,11 @@ func initializeRuntimeWatcher(c config.Config) (*workers_manager.WorkersManager,
 	if err != nil {
 		return nil, err
 	}
-	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, schedulerCache)
+	eventsForwarderConfig, err := service.NewEventsForwarderServiceConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, schedulerCache, eventsForwarderConfig)
 	roomManagerConfig, err := service.NewRoomManagerConfig(c)
 	if err != nil {
 		return nil, err
@@ -72,4 +76,4 @@ func provideRuntimeWatcherBuilder() workers.WorkerBuilder {
 
 var WorkerOptionsSet = wire.NewSet(service.NewRuntimeKubernetes, RoomManagerSet, wire.Struct(new(workers.WorkerOptions), "RoomManager", "Runtime"))
 
-var RoomManagerSet = wire.NewSet(service.NewSchedulerStoragePg, service.NewClockTime, service.NewPortAllocatorRandom, service.NewRoomStorageRedis, service.NewGameRoomInstanceStorageRedis, service.NewSchedulerCacheRedis, service.NewRoomManagerConfig, service.NewEventsForwarder, events_forwarder.NewEventsForwarderService, room_manager.NewRoomManager)
+var RoomManagerSet = wire.NewSet(service.NewSchedulerStoragePg, service.NewClockTime, service.NewPortAllocatorRandom, service.NewRoomStorageRedis, service.NewGameRoomInstanceStorageRedis, service.NewSchedulerCacheRedis, service.NewRoomManagerConfig, service.NewEventsForwarder, events_forwarder.NewEventsForwarderService, room_manager.NewRoomManager, service.NewEventsForwarderServiceConfig)

--- a/cmd/worker/wire.go
+++ b/cmd/worker/wire.go
@@ -54,6 +54,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 		service.NewRoomManagerConfig,
 		service.NewOperationManagerConfig,
 		service.NewEventsForwarder,
+		service.NewEventsForwarderServiceConfig,
 
 		// scheduler operations
 		providers.ProvideDefinitionConstructors,

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -68,7 +68,11 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	if err != nil {
 		return nil, err
 	}
-	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, schedulerCache)
+	eventsForwarderConfig, err := service.NewEventsForwarderServiceConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, schedulerCache, eventsForwarderConfig)
 	roomManagerConfig, err := service.NewRoomManagerConfig(c)
 	if err != nil {
 		return nil, err

--- a/config/worker.local.yaml
+++ b/config/worker.local.yaml
@@ -44,3 +44,5 @@ services:
     roomDeletionTimeoutMillis: 120000
   operationManager:
     operationLeaseTtlMillis: 5000
+  eventsForwarder:
+    schedulerCacheTtlMillis: 120000

--- a/internal/adapters/scheduler_cache/mock/mock.go
+++ b/internal/adapters/scheduler_cache/mock/mock.go
@@ -7,6 +7,7 @@ package mock
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	entities "github.com/topfreegames/maestro/internal/core/entities"
@@ -51,15 +52,15 @@ func (mr *MockSchedulerCacheMockRecorder) GetScheduler(ctx, name interface{}) *g
 }
 
 // SetScheduler mocks base method.
-func (m *MockSchedulerCache) SetScheduler(ctx context.Context, scheduler *entities.Scheduler) error {
+func (m *MockSchedulerCache) SetScheduler(ctx context.Context, scheduler *entities.Scheduler, ttl time.Duration) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetScheduler", ctx, scheduler)
+	ret := m.ctrl.Call(m, "SetScheduler", ctx, scheduler, ttl)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetScheduler indicates an expected call of SetScheduler.
-func (mr *MockSchedulerCacheMockRecorder) SetScheduler(ctx, scheduler interface{}) *gomock.Call {
+func (mr *MockSchedulerCacheMockRecorder) SetScheduler(ctx, scheduler, ttl interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetScheduler", reflect.TypeOf((*MockSchedulerCache)(nil).SetScheduler), ctx, scheduler)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetScheduler", reflect.TypeOf((*MockSchedulerCache)(nil).SetScheduler), ctx, scheduler, ttl)
 }

--- a/internal/adapters/scheduler_cache/redis/redis.go
+++ b/internal/adapters/scheduler_cache/redis/redis.go
@@ -60,14 +60,14 @@ func (r redisSchedulerCache) GetScheduler(ctx context.Context, schedulerName str
 	return scheduler, nil
 }
 
-func (r redisSchedulerCache) SetScheduler(ctx context.Context, scheduler *entities.Scheduler) error {
+func (r redisSchedulerCache) SetScheduler(ctx context.Context, scheduler *entities.Scheduler, ttl time.Duration) error {
 	jsonScheduler, err := json.Marshal(scheduler)
 	if err != nil {
 		return err
 	}
 
 	schedulerCacheKey := r.buildSchedulerKey(scheduler.Name)
-	err = r.client.Set(ctx, schedulerCacheKey, jsonScheduler, time.Hour*24).Err()
+	err = r.client.Set(ctx, schedulerCacheKey, jsonScheduler, ttl).Err()
 	if err != nil {
 		return err
 	}

--- a/internal/adapters/scheduler_cache/redis/redis_test.go
+++ b/internal/adapters/scheduler_cache/redis/redis_test.go
@@ -78,7 +78,7 @@ func TestSetScheduler(t *testing.T) {
 		client := test.GetRedisConnection(t, redisAddress)
 		storage := NewRedisSchedulerCache(client)
 
-		err := storage.SetScheduler(context.Background(), expectedScheduler)
+		err := storage.SetScheduler(context.Background(), expectedScheduler, time.Minute)
 		require.NoError(t, err)
 
 		schedulerJson, err := client.Get(context.Background(), storage.buildSchedulerKey(expectedScheduler.Name)).Result()
@@ -92,7 +92,7 @@ func TestSetScheduler(t *testing.T) {
 
 		client.Close()
 
-		err := storage.SetScheduler(context.Background(), expectedScheduler)
+		err := storage.SetScheduler(context.Background(), expectedScheduler, time.Minute)
 		require.Error(t, err)
 	})
 }
@@ -113,7 +113,7 @@ func TestGetScheduler(t *testing.T) {
 		storage := NewRedisSchedulerCache(client)
 
 		ctx := context.Background()
-		err := storage.SetScheduler(ctx, expectedScheduler)
+		err := storage.SetScheduler(ctx, expectedScheduler, time.Minute)
 		require.NoError(t, err)
 
 		scheduler, err := storage.GetScheduler(ctx, expectedScheduler.Name)
@@ -126,7 +126,7 @@ func TestGetScheduler(t *testing.T) {
 		storage := NewRedisSchedulerCache(client)
 
 		ctx := context.Background()
-		err := storage.SetScheduler(ctx, expectedScheduler)
+		err := storage.SetScheduler(ctx, expectedScheduler, time.Minute)
 		require.NoError(t, err)
 
 		client.Close()

--- a/internal/adapters/scheduler_cache/redis/redis_test.go
+++ b/internal/adapters/scheduler_cache/redis/redis_test.go
@@ -1,0 +1,138 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build integration
+// +build integration
+
+package redis
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/topfreegames/maestro/internal/core/entities"
+	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
+	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro/test"
+)
+
+var redisAddress string
+
+var fwd = &forwarder.Forwarder{
+	Name:        "fwd",
+	Enabled:     true,
+	ForwardType: forwarder.TypeGrpc,
+	Address:     "address",
+	Options: &forwarder.ForwardOptions{
+		Timeout:  time.Second * 5,
+		Metadata: nil,
+	},
+}
+var forwarders = []*forwarder.Forwarder{fwd}
+var expectedScheduler = &entities.Scheduler{
+	Name:            "scheduler",
+	Game:            "game",
+	State:           "",
+	RollbackVersion: "",
+	Spec:            game_room.Spec{},
+	PortRange:       nil,
+	CreatedAt:       time.Time{},
+	MaxSurge:        "",
+	Forwarders:      forwarders,
+}
+
+func TestMain(m *testing.M) {
+	var code int
+	test.WithRedisContainer(func(redisContainerAddress string) {
+		redisAddress = redisContainerAddress
+		code = m.Run()
+	})
+	os.Exit(code)
+}
+
+func TestSetScheduler(t *testing.T) {
+	t.Run("with success", func(t *testing.T) {
+		client := test.GetRedisConnection(t, redisAddress)
+		storage := NewRedisSchedulerCache(client)
+
+		err := storage.SetScheduler(context.Background(), expectedScheduler)
+		require.NoError(t, err)
+
+		schedulerJson, err := client.Get(context.Background(), storage.buildSchedulerKey(expectedScheduler.Name)).Result()
+		require.NoError(t, err)
+		require.NotEmpty(t, schedulerJson)
+	})
+
+	t.Run("with error - connection to redis closed", func(t *testing.T) {
+		client := test.GetRedisConnection(t, redisAddress)
+		storage := NewRedisSchedulerCache(client)
+
+		client.Close()
+
+		err := storage.SetScheduler(context.Background(), expectedScheduler)
+		require.Error(t, err)
+	})
+}
+
+func TestGetScheduler(t *testing.T) {
+
+	t.Run("with success - Scheduler not found, but no error", func(t *testing.T) {
+		client := test.GetRedisConnection(t, redisAddress)
+		storage := NewRedisSchedulerCache(client)
+
+		scheduler, err := storage.GetScheduler(context.Background(), "schedulerName")
+		require.NoError(t, err)
+		require.Empty(t, scheduler)
+	})
+
+	t.Run("with success - Scheduler found", func(t *testing.T) {
+		client := test.GetRedisConnection(t, redisAddress)
+		storage := NewRedisSchedulerCache(client)
+
+		ctx := context.Background()
+		err := storage.SetScheduler(ctx, expectedScheduler)
+		require.NoError(t, err)
+
+		scheduler, err := storage.GetScheduler(ctx, expectedScheduler.Name)
+		require.NoError(t, err)
+		require.NotEmpty(t, scheduler)
+	})
+
+	t.Run("with error - redis connection closed", func(t *testing.T) {
+		client := test.GetRedisConnection(t, redisAddress)
+		storage := NewRedisSchedulerCache(client)
+
+		ctx := context.Background()
+		err := storage.SetScheduler(ctx, expectedScheduler)
+		require.NoError(t, err)
+
+		client.Close()
+
+		_, err = storage.GetScheduler(ctx, expectedScheduler.Name)
+		require.Error(t, err)
+	})
+
+}

--- a/internal/core/services/events_forwarder/events_forwarder_config.go
+++ b/internal/core/services/events_forwarder/events_forwarder_config.go
@@ -20,16 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package ports
+package events_forwarder
 
-import (
-	"context"
-	"time"
+import "time"
 
-	"github.com/topfreegames/maestro/internal/core/entities"
-)
-
-type SchedulerCache interface {
-	GetScheduler(ctx context.Context, name string) (*entities.Scheduler, error)
-	SetScheduler(ctx context.Context, scheduler *entities.Scheduler, ttl time.Duration) error
+type EventsForwarderConfig struct {
+	SchedulerCacheTtl time.Duration
 }

--- a/internal/core/services/events_forwarder/events_forwarder_service.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service.go
@@ -46,6 +46,7 @@ type EventsForwarderService struct {
 	schedulerStorage ports.SchedulerStorage
 	instanceStorage  ports.GameRoomInstanceStorage
 	schedulerCache   ports.SchedulerCache
+	config           EventsForwarderConfig
 }
 
 func NewEventsForwarderService(
@@ -53,6 +54,7 @@ func NewEventsForwarderService(
 	schedulerStorage ports.SchedulerStorage,
 	instanceStorage ports.GameRoomInstanceStorage,
 	schedulerCache ports.SchedulerCache,
+	config EventsForwarderConfig,
 ) interfaces.EventsService {
 	return &EventsForwarderService{
 		eventsForwarder,
@@ -60,6 +62,7 @@ func NewEventsForwarderService(
 		schedulerStorage,
 		instanceStorage,
 		schedulerCache,
+		config,
 	}
 }
 
@@ -196,7 +199,7 @@ func (es *EventsForwarderService) getScheduler(ctx context.Context, schedulerNam
 			es.logger.Error(fmt.Sprintf("Failed to get scheduler \"%v\" info", schedulerName), zap.Error(err))
 			return nil, err
 		}
-		if err = es.schedulerCache.SetScheduler(ctx, scheduler); err != nil {
+		if err = es.schedulerCache.SetScheduler(ctx, scheduler, es.config.SchedulerCacheTtl); err != nil {
 			es.logger.Error(fmt.Sprintf("Failed to set scheduler \"%v\" in cache", schedulerName), zap.Error(err))
 		}
 	}

--- a/internal/core/services/events_forwarder/events_forwarder_service_test.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service_test.go
@@ -54,8 +54,9 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 	schedulerStorage := ssMock.NewMockSchedulerStorage(mockCtrl)
 	instanceStorage := isMock.NewMockGameRoomInstanceStorage(mockCtrl)
 	schedulerCache := scMock.NewMockSchedulerCache(mockCtrl)
+	config := events_forwarder.EventsForwarderConfig{SchedulerCacheTtl: time.Minute}
 
-	eventsForwarderService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, instanceStorage, schedulerCache)
+	eventsForwarderService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, instanceStorage, schedulerCache, config)
 
 	fwd := &forwarder.Forwarder{
 		Name:        "fwd",
@@ -127,7 +128,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(scheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil).Times(0)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler).Return(nil)
+		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, config.SchedulerCacheTtl).Return(nil)
 		eventsForwarder.EXPECT().ForwardPlayerEvent(context.Background(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
@@ -148,7 +149,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil).Times(0)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler).Return(nil)
+		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler, config.SchedulerCacheTtl).Return(nil)
 		eventsForwarder.EXPECT().ForwardPlayerEvent(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
@@ -170,7 +171,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler).Return(nil)
+		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler, config.SchedulerCacheTtl).Return(nil)
 		eventsForwarder.EXPECT().ForwardRoomEvent(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
@@ -213,7 +214,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(instance, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler).Return(nil)
+		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler, config.SchedulerCacheTtl).Return(nil)
 		eventsForwarder.EXPECT().ForwardRoomEvent(context.Background(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
@@ -233,7 +234,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil).Times(0)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler).Return(nil)
+		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler, config.SchedulerCacheTtl).Return(nil)
 		eventsForwarder.EXPECT().ForwardPlayerEvent(context.Background(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
@@ -253,7 +254,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler).Return(nil)
+		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler, config.SchedulerCacheTtl).Return(nil)
 		eventsForwarder.EXPECT().ForwardRoomEvent(context.Background(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
@@ -273,7 +274,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, errors.New("scheduler not found"))
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil).Times(0)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler).Return(nil)
+		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler, config.SchedulerCacheTtl).Return(nil)
 		eventsForwarder.EXPECT().ForwardRoomEvent(context.Background(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
@@ -332,7 +333,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil).Times(0)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler).Return(nil)
+		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler, config.SchedulerCacheTtl).Return(nil)
 		eventsForwarder.EXPECT().ForwardPlayerEvent(context.Background(), gomock.Any(), gomock.Any()).Return(errors.New("error"))
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
@@ -353,7 +354,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler).Return(errors.New("error"))
+		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler, config.SchedulerCacheTtl).Return(errors.New("error"))
 		eventsForwarder.EXPECT().ForwardRoomEvent(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
@@ -374,7 +375,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, errors.New("error"))
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler).Return(errors.New("error"))
+		schedulerCache.EXPECT().SetScheduler(context.Background(), expectedScheduler, config.SchedulerCacheTtl).Return(errors.New("error"))
 		eventsForwarder.EXPECT().ForwardRoomEvent(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -25,6 +25,8 @@ package service
 import (
 	"time"
 
+	"github.com/topfreegames/maestro/internal/core/services/events_forwarder"
+
 	"github.com/topfreegames/maestro/internal/config"
 	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
 	"github.com/topfreegames/maestro/internal/core/services/room_manager"
@@ -52,4 +54,21 @@ func NewOperationManagerConfig(c config.Config) (operation_manager.OperationMana
 	}
 
 	return operationManagerConfig, nil
+}
+
+func NewEventsForwarderServiceConfig(c config.Config) (events_forwarder.EventsForwarderConfig, error) {
+	var schedulerCacheTtl time.Duration
+	defaultSchedulerCacheTtl := time.Hour * 24
+
+	if configuredSchedulerCacheTtlInt := c.GetInt("services.eventsForwarder.schedulerCacheTtlMillis"); configuredSchedulerCacheTtlInt > 0 {
+		schedulerCacheTtl = time.Duration(configuredSchedulerCacheTtlInt) * time.Millisecond
+	} else {
+		schedulerCacheTtl = defaultSchedulerCacheTtl
+	}
+
+	eventsForwarderConfig := events_forwarder.EventsForwarderConfig{
+		SchedulerCacheTtl: schedulerCacheTtl,
+	}
+
+	return eventsForwarderConfig, nil
 }


### PR DESCRIPTION
### What?
Implementation of the methods GetScheduler and SetScheduler of the Scheduler Cache adapter.
### Why?
For some functionalities (such as forwarder) we need the scheduler information constantly. To avoid querying the database for each one of these, we want to have this information stored in a cache (like redis).
### How?
Implementing a redis adapter for schedulerCache port. The SetScheduler method simply set a key to redis with 24h ttl (as a json). The GetScheduler fetch the same key and unmarshall it to scheduler entity.