### PR TITLE
implements method CreateSchedulerVersion

### DIFF
--- a/internal/adapters/scheduler_storage/mock/mock.go
+++ b/internal/adapters/scheduler_storage/mock/mock.go
@@ -50,6 +50,20 @@ func (mr *MockSchedulerStorageMockRecorder) CreateScheduler(ctx, scheduler inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateScheduler", reflect.TypeOf((*MockSchedulerStorage)(nil).CreateScheduler), ctx, scheduler)
 }
 
+// CreateSchedulerVersion mocks base method.
+func (m *MockSchedulerStorage) CreateSchedulerVersion(ctx context.Context, scheduler *entities.Scheduler) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSchedulerVersion", ctx, scheduler)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateSchedulerVersion indicates an expected call of CreateSchedulerVersion.
+func (mr *MockSchedulerStorageMockRecorder) CreateSchedulerVersion(ctx, scheduler interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSchedulerVersion", reflect.TypeOf((*MockSchedulerStorage)(nil).CreateSchedulerVersion), ctx, scheduler)
+}
+
 // DeleteScheduler mocks base method.
 func (m *MockSchedulerStorage) DeleteScheduler(ctx context.Context, scheduler *entities.Scheduler) error {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/scheduler_storage.go
+++ b/internal/core/ports/scheduler_storage.go
@@ -38,4 +38,5 @@ type SchedulerStorage interface {
 	CreateScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	UpdateScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	DeleteScheduler(ctx context.Context, scheduler *entities.Scheduler) error
+	CreateSchedulerVersion(ctx context.Context, scheduler *entities.Scheduler) error
 }


### PR DESCRIPTION
### What?
Segregates method to create a new scheduler version from CreateScheduler and UpdateScheduler methods.
### Why?
Creating a new scheduler version is different from updating or creating a scheduler. To move forward to have a "switch active version" operation we need to segregate these methods.
### How?
Implementing method CreateSchedulerVersion on scheduler_storage adapter.