### PR TITLE
Feature/create e2e tests for ping event forwarding

### DIFF
--- a/e2e/framework/maestro/servermocks/events-forwarder-grpc-send-room-resync-failure.json
+++ b/e2e/framework/maestro/servermocks/events-forwarder-grpc-send-room-resync-failure.json
@@ -1,0 +1,25 @@
+{
+  "service": "GRPCForwarder",
+  "method": "SendRoomResync",
+  "input": {
+    "contains": {
+      "room": {
+        "metadata":{
+          "eventMetadata1": "value1",
+          "eventMetadata2": "true",
+          "forwarderMetadata1": "value1",
+          "forwarderMetadata2": "245",
+          "mockIdentifier": "f7415c97-5c28-418b-b19b-87380e2d0113"
+        },
+        "roomType": "green"
+      },
+      "statusType": 2
+    }
+  },
+  "output": {
+    "data": {
+      "code": 500,
+      "message": "Internal server error from matchmaker"
+    }
+  }
+}

--- a/e2e/framework/maestro/servermocks/events-forwarder-grpc-send-room-resync-success.json
+++ b/e2e/framework/maestro/servermocks/events-forwarder-grpc-send-room-resync-success.json
@@ -1,0 +1,25 @@
+{
+  "service": "GRPCForwarder",
+  "method": "SendRoomResync",
+  "input": {
+    "contains": {
+      "room": {
+        "metadata":{
+          "eventMetadata1": "value1",
+          "eventMetadata2": "true",
+          "forwarderMetadata1": "value1",
+          "forwarderMetadata2": "245",
+          "mockIdentifier": "65e810a0-bb81-4633-93c9-826414a0062d"
+        },
+        "roomType": "green"
+      },
+      "statusType": 2
+    }
+  },
+  "output": {
+    "data": {
+      "code": 200,
+      "message": "Event received with success"
+    }
+  }
+}

--- a/internal/adapters/forwarder/events_forwarder/events_forwarder.go
+++ b/internal/adapters/forwarder/events_forwarder/events_forwarder.go
@@ -77,6 +77,9 @@ func (f *eventsForwarder) ForwardRoomEvent(ctx context.Context, eventAttributes 
 			},
 			StatusType: fromRoomPingEventTypeToRoomStatusType(*eventAttributes.PingType),
 		}
+		if roomType, ok := forwarder.Options.Metadata["roomType"].(string); ok {
+			event.Room.RoomType = roomType
+		}
 
 		eventResponse, err := f.forwarderClient.SendRoomReSync(ctx, forwarder, &event)
 		return handlerGrpcClientResponse(forwarder, eventResponse, err)

--- a/internal/api/handlers/rooms_handler.go
+++ b/internal/api/handlers/rooms_handler.go
@@ -57,7 +57,7 @@ func ProvideRoomsHandler(roomManager *room_manager.RoomManager, eventsService in
 
 func (h *RoomsHandler) ForwardRoomEvent(ctx context.Context, message *api.ForwardRoomEventRequest) (*api.ForwardRoomEventResponse, error) {
 	eventMetadata := message.Metadata.AsMap()
-	eventMetadata["eventType"] = events.Arbitrary
+	eventMetadata["eventType"] = events.FromRoomEventTypeToString(events.Arbitrary)
 	eventMetadata["roomEvent"] = message.Event
 
 	err := h.eventsService.ProduceEvent(ctx, events.NewRoomEvent(message.SchedulerName, message.RoomName, eventMetadata))

--- a/internal/api/handlers/rooms_handler_test.go
+++ b/internal/api/handlers/rooms_handler_test.go
@@ -33,8 +33,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/topfreegames/maestro/internal/core/entities/events"
-
 	mockeventsservice "github.com/topfreegames/maestro/internal/core/services/interfaces/mock/events_service"
 
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
@@ -99,7 +97,7 @@ func TestRoomsHandler_UpdateRoomWithPing(t *testing.T) {
 				return updatedGameRoom, nil
 			})
 			roomStorageMock.EXPECT().UpdateRoomStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			eventsForwarderService.EXPECT().ProduceEvent(gomock.Any(), events.NewRoomEvent("scheduler-name-1", "room-name-1", map[string]interface{}{}))
+			eventsForwarderService.EXPECT().ProduceEvent(gomock.Any(), gomock.Any())
 
 			request, err := validRawRequest.MarshalJSON()
 			require.NoError(t, err)

--- a/internal/core/entities/events/room_event.go
+++ b/internal/core/entities/events/room_event.go
@@ -74,15 +74,15 @@ func FromRoomEventTypeToString(eventType RoomEventType) string {
 
 func ConvertToRoomPingEventType(value string) (RoomPingEventType, error) {
 	switch value {
-	case "roomReady":
+	case "ready":
 		return RoomPingReady, nil
-	case "roomOccupied":
+	case "occupied":
 		return RoomPingOccupied, nil
-	case "roomTerminating":
+	case "terminating":
 		return RoomPingTerminating, nil
-	case "roomTerminated":
+	case "terminated":
 		return RoomPingTerminated, nil
 	default:
-		return "", fmt.Errorf("invalid RoomPingEventType. Should be \"roomReady\", \"roomOccupied\", \"roomTerminating\" or \"roomTerminated\"")
+		return "", fmt.Errorf("invalid RoomPingEventType. Should be \"ready\", \"occupied\", \"terminating\" or \"terminated\"")
 	}
 }

--- a/internal/core/entities/events/room_event_test.go
+++ b/internal/core/entities/events/room_event_test.go
@@ -41,21 +41,21 @@ func TestRoomEvent(t *testing.T) {
 	})
 
 	t.Run("with success when converting to RoomPingEventType", func(t *testing.T) {
-		converted, err := ConvertToRoomPingEventType("roomReady")
+		converted, err := ConvertToRoomPingEventType("ready")
 		require.NoError(t, err)
-		require.IsType(t, RoomPingEventType("roomReady"), converted)
+		require.IsType(t, RoomPingEventType("ready"), converted)
 
-		converted, err = ConvertToRoomPingEventType("roomOccupied")
+		converted, err = ConvertToRoomPingEventType("occupied")
 		require.NoError(t, err)
-		require.IsType(t, RoomPingEventType("roomOccupied"), converted)
+		require.IsType(t, RoomPingEventType("occupied"), converted)
 
-		converted, err = ConvertToRoomPingEventType("roomTerminating")
+		converted, err = ConvertToRoomPingEventType("terminating")
 		require.NoError(t, err)
-		require.IsType(t, RoomPingEventType("roomTerminating"), converted)
+		require.IsType(t, RoomPingEventType("terminating"), converted)
 
-		converted, err = ConvertToRoomPingEventType("roomTerminated")
+		converted, err = ConvertToRoomPingEventType("terminated")
 		require.NoError(t, err)
-		require.IsType(t, RoomPingEventType("roomTerminated"), converted)
+		require.IsType(t, RoomPingEventType("terminated"), converted)
 	})
 
 	t.Run("with error when converting to RoomEventType", func(t *testing.T) {

--- a/internal/core/services/events_forwarder/events_forwarder_service.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service.go
@@ -68,7 +68,7 @@ func NewEventsForwarderService(
 }
 
 func (es *EventsForwarderService) ProduceEvent(ctx context.Context, event *events.Event) error {
-	if _, ok := event.Attributes["eventType"]; !ok {
+	if _, ok := event.Attributes["eventType"].(string); !ok {
 		return errors.New("eventAttributes must contain key \"eventType\"")
 	}
 	eventType := event.Attributes["eventType"].(string)

--- a/internal/core/services/events_forwarder/events_forwarder_service_test.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service_test.go
@@ -164,7 +164,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			RoomID:      "room",
 			Attributes: map[string]interface{}{
 				"eventType": "resync",
-				"pingType":  "roomReady",
+				"pingType":  "ready",
 			},
 		}
 
@@ -198,7 +198,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			RoomID:      "room",
 			Attributes: map[string]interface{}{
 				"eventType": "resync",
-				"pingType":  "roomReady",
+				"pingType":  "ready",
 			},
 		}
 
@@ -307,7 +307,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			RoomID:      "room",
 			Attributes: map[string]interface{}{
 				"eventType": "resync",
-				"pingType":  "roomReady",
+				"pingType":  "ready",
 			},
 		}
 
@@ -347,7 +347,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			RoomID:      "room",
 			Attributes: map[string]interface{}{
 				"eventType": "resync",
-				"pingType":  "roomReady",
+				"pingType":  "ready",
 			},
 		}
 
@@ -368,7 +368,7 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			RoomID:      "room",
 			Attributes: map[string]interface{}{
 				"eventType": "resync",
-				"pingType":  "roomReady",
+				"pingType":  "ready",
 			},
 		}
 

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -158,7 +158,10 @@ func (m *RoomManager) UpdateRoom(ctx context.Context, gameRoom *game_room.GameRo
 	if err != nil {
 		return fmt.Errorf("failed to update game room status: %w", err)
 	}
-	err = m.eventsService.ProduceEvent(ctx, events.NewRoomEvent(gameRoom.SchedulerID, gameRoom.ID, map[string]interface{}{}))
+
+	gameRoom.Metadata["eventType"] = events.FromRoomEventTypeToString(events.Ping)
+	gameRoom.Metadata["pingType"] = gameRoom.PingStatus.String()
+	err = m.eventsService.ProduceEvent(ctx, events.NewRoomEvent(gameRoom.SchedulerID, gameRoom.ID, gameRoom.Metadata))
 	if err != nil {
 		m.logger.Error(fmt.Sprintf("Failed to forward ping event, error details: %s", err.Error()), zap.Error(err))
 		reportPingForwardingFailed(gameRoom.SchedulerID)

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -33,8 +33,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/topfreegames/maestro/internal/core/entities/events"
-
 	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 
 	"github.com/stretchr/testify/require"
@@ -260,14 +258,14 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 		config,
 	)
 	currentInstance := &game_room.Instance{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.InstanceStatus{Type: game_room.InstanceReady}}
-	newGameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusReady, PingStatus: game_room.GameRoomPingStatusOccupied, LastPingAt: clock.Now()}
+	newGameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusReady, PingStatus: game_room.GameRoomPingStatusOccupied, LastPingAt: clock.Now(), Metadata: map[string]interface{}{}}
 
 	t.Run("when the current game room exists then it execute without returning error", func(t *testing.T) {
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(nil)
-		eventsService.EXPECT().ProduceEvent(context.Background(), events.NewRoomEvent(newGameRoom.SchedulerID, newGameRoom.ID, map[string]interface{}{}))
+		eventsService.EXPECT().ProduceEvent(context.Background(), gomock.Any())
 
 		err := roomManager.UpdateRoom(context.Background(), newGameRoom)
 		require.NoError(t, err)
@@ -312,7 +310,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(nil)
-		eventsService.EXPECT().ProduceEvent(context.Background(), events.NewRoomEvent(newGameRoom.SchedulerID, newGameRoom.ID, map[string]interface{}{}))
+		eventsService.EXPECT().ProduceEvent(context.Background(), gomock.Any())
 
 		err := roomManager.UpdateRoom(context.Background(), newGameRoom)
 		require.NoError(t, err)


### PR DESCRIPTION
## What ❓
Add test cases for room ping forwarding with some fixes in room manager and events adapter.

## Why 🤔
To increase our feature test coverage with more test cases.

## How 👀
- Fixes in rooms manager
- Fixes in events adapter
- More test cases for ping events forwarding
- 
## Dependencies ⚠️
This PR depends on #271, review it first before reviewing this PR.