### PR TITLE
Feature/use transaction for creating new scheduler version

### DIFF
--- a/internal/adapters/scheduler_storage/mock/mock.go
+++ b/internal/adapters/scheduler_storage/mock/mock.go
@@ -64,6 +64,20 @@ func (mr *MockSchedulerStorageMockRecorder) CreateSchedulerVersion(ctx, schedule
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSchedulerVersion", reflect.TypeOf((*MockSchedulerStorage)(nil).CreateSchedulerVersion), ctx, scheduler)
 }
 
+// CreateSchedulerVersionWithTransactionFunc mocks base method.
+func (m *MockSchedulerStorage) CreateSchedulerVersionWithTransactionFunc(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(context.Context) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSchedulerVersionWithTransactionFunc", ctx, scheduler, transactionFunc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateSchedulerVersionWithTransactionFunc indicates an expected call of CreateSchedulerVersionWithTransactionFunc.
+func (mr *MockSchedulerStorageMockRecorder) CreateSchedulerVersionWithTransactionFunc(ctx, scheduler, transactionFunc interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSchedulerVersionWithTransactionFunc", reflect.TypeOf((*MockSchedulerStorage)(nil).CreateSchedulerVersionWithTransactionFunc), ctx, scheduler, transactionFunc)
+}
+
 // DeleteScheduler mocks base method.
 func (m *MockSchedulerStorage) DeleteScheduler(ctx context.Context, scheduler *entities.Scheduler) error {
 	m.ctrl.T.Helper()

--- a/internal/adapters/scheduler_storage/mock/mock.go
+++ b/internal/adapters/scheduler_storage/mock/mock.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	entities "github.com/topfreegames/maestro/internal/core/entities"
 	filters "github.com/topfreegames/maestro/internal/core/filters"
+	ports "github.com/topfreegames/maestro/internal/core/ports"
 )
 
 // MockSchedulerStorage is a mock of SchedulerStorage interface.
@@ -51,31 +52,17 @@ func (mr *MockSchedulerStorageMockRecorder) CreateScheduler(ctx, scheduler inter
 }
 
 // CreateSchedulerVersion mocks base method.
-func (m *MockSchedulerStorage) CreateSchedulerVersion(ctx context.Context, scheduler *entities.Scheduler) error {
+func (m *MockSchedulerStorage) CreateSchedulerVersion(ctx context.Context, transactionID ports.TransactionID, scheduler *entities.Scheduler) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSchedulerVersion", ctx, scheduler)
+	ret := m.ctrl.Call(m, "CreateSchedulerVersion", ctx, transactionID, scheduler)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateSchedulerVersion indicates an expected call of CreateSchedulerVersion.
-func (mr *MockSchedulerStorageMockRecorder) CreateSchedulerVersion(ctx, scheduler interface{}) *gomock.Call {
+func (mr *MockSchedulerStorageMockRecorder) CreateSchedulerVersion(ctx, transactionID, scheduler interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSchedulerVersion", reflect.TypeOf((*MockSchedulerStorage)(nil).CreateSchedulerVersion), ctx, scheduler)
-}
-
-// CreateSchedulerVersionWithTransactionFunc mocks base method.
-func (m *MockSchedulerStorage) CreateSchedulerVersionWithTransactionFunc(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(context.Context) error) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSchedulerVersionWithTransactionFunc", ctx, scheduler, transactionFunc)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateSchedulerVersionWithTransactionFunc indicates an expected call of CreateSchedulerVersionWithTransactionFunc.
-func (mr *MockSchedulerStorageMockRecorder) CreateSchedulerVersionWithTransactionFunc(ctx, scheduler, transactionFunc interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSchedulerVersionWithTransactionFunc", reflect.TypeOf((*MockSchedulerStorage)(nil).CreateSchedulerVersionWithTransactionFunc), ctx, scheduler, transactionFunc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSchedulerVersion", reflect.TypeOf((*MockSchedulerStorage)(nil).CreateSchedulerVersion), ctx, transactionID, scheduler)
 }
 
 // DeleteScheduler mocks base method.
@@ -165,6 +152,20 @@ func (m *MockSchedulerStorage) GetSchedulers(ctx context.Context, names []string
 func (mr *MockSchedulerStorageMockRecorder) GetSchedulers(ctx, names interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedulers", reflect.TypeOf((*MockSchedulerStorage)(nil).GetSchedulers), ctx, names)
+}
+
+// RunWithTransaction mocks base method.
+func (m *MockSchedulerStorage) RunWithTransaction(ctx context.Context, transactionFunc func(ports.TransactionID) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunWithTransaction", ctx, transactionFunc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunWithTransaction indicates an expected call of RunWithTransaction.
+func (mr *MockSchedulerStorageMockRecorder) RunWithTransaction(ctx, transactionFunc interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunWithTransaction", reflect.TypeOf((*MockSchedulerStorage)(nil).RunWithTransaction), ctx, transactionFunc)
 }
 
 // UpdateScheduler mocks base method.

--- a/internal/adapters/scheduler_storage/pg/pg.go
+++ b/internal/adapters/scheduler_storage/pg/pg.go
@@ -24,8 +24,9 @@ package pg
 
 import (
 	"context"
-	"fmt"
 	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/topfreegames/maestro/internal/core/ports/errors"
 
@@ -42,11 +43,15 @@ var (
 )
 
 type schedulerStorage struct {
-	db *pg.DB
+	db              *pg.DB
+	transactionsMap map[ports.TransactionID]*pg.Tx
 }
 
 func NewSchedulerStorage(opts *pg.Options) *schedulerStorage {
-	return &schedulerStorage{db: pg.Connect(opts)}
+	return &schedulerStorage{
+		db:              pg.Connect(opts),
+		transactionsMap: map[ports.TransactionID]*pg.Tx{},
+	}
 }
 
 const (
@@ -198,7 +203,7 @@ func (s schedulerStorage) CreateScheduler(ctx context.Context, scheduler *entiti
 		}
 		return errors.NewErrUnexpected("error creating scheduler %s", dbScheduler.Name).WithError(err)
 	}
-	err = s.CreateSchedulerVersion(ctx, scheduler)
+	err = s.CreateSchedulerVersion(ctx, "", scheduler)
 	if err != nil {
 		return errors.NewErrUnexpected("error creating first scheduler version %s", dbScheduler.Name).WithError(err)
 	}
@@ -231,10 +236,21 @@ func (s schedulerStorage) DeleteScheduler(ctx context.Context, scheduler *entiti
 	return nil
 }
 
-func (s schedulerStorage) CreateSchedulerVersion(ctx context.Context, scheduler *entities.Scheduler) error {
-	client := s.db.WithContext(ctx)
+func (s schedulerStorage) CreateSchedulerVersion(ctx context.Context, transactionID ports.TransactionID, scheduler *entities.Scheduler) error {
 	dbScheduler := NewDBScheduler(scheduler)
-	_, err := client.Exec(queryInsertVersion, dbScheduler.Name, dbScheduler.Version, dbScheduler.Yaml, dbScheduler.RollbackVersion)
+	var err error
+	if isInTransactionalContext(transactionID) {
+		txClient, ok := s.transactionsMap[transactionID]
+		if !ok {
+			return errors.NewErrNotFound("transaction %s not found", transactionID)
+		}
+		_, err = txClient.Exec(queryInsertVersion, dbScheduler.Name, dbScheduler.Version, dbScheduler.Yaml, dbScheduler.RollbackVersion)
+
+	} else {
+		client := s.db.WithContext(ctx)
+		_, err = client.Exec(queryInsertVersion, dbScheduler.Name, dbScheduler.Version, dbScheduler.Yaml, dbScheduler.RollbackVersion)
+	}
+
 	if err != nil {
 		if strings.Contains(err.Error(), "violates foreign key constraint") {
 			return errors.NewErrUnexpected("error creating version %s for non existent scheduler \"%s\"", dbScheduler.Version, dbScheduler.Name)
@@ -244,27 +260,41 @@ func (s schedulerStorage) CreateSchedulerVersion(ctx context.Context, scheduler 
 	return nil
 }
 
-func (s schedulerStorage) CreateSchedulerVersionWithTransactionFunc(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(ctx context.Context) error) error {
+func (s schedulerStorage) RunWithTransaction(ctx context.Context, transactionFunc func(transactionId ports.TransactionID) error) error {
 	client := s.db.WithContext(ctx)
-	err := client.RunInTransaction(func(tx *pg.Tx) error {
-		dbScheduler := NewDBScheduler(scheduler)
 
-		_, err := tx.Exec(queryInsertVersion, dbScheduler.Name, dbScheduler.Version, dbScheduler.Yaml, dbScheduler.RollbackVersion)
-		if err != nil {
-			if strings.Contains(err.Error(), "violates foreign key constraint") {
-				return errors.NewErrUnexpected("error creating version %s for non existent scheduler \"%s\"", dbScheduler.Version, dbScheduler.Name)
-			}
-			return errors.NewErrUnexpected("error creating scheduler %s version %s", dbScheduler.Name, dbScheduler.Version).WithError(err)
-		}
-		err = transactionFunc(ctx)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
+	transaction, err := client.Begin()
 	if err != nil {
-		return fmt.Errorf("failed to create scheduler version in db, transaction failed: %w", err)
+		return errors.NewErrUnexpected("error starting transaction").WithError(err)
 	}
-	return nil
+
+	transactionID := ports.TransactionID(uuid.New().String())
+	s.transactionsMap[transactionID] = transaction
+
+	defer func() {
+		if err := recover(); err != nil {
+			s.rollbackTransaction(transaction, transactionID)
+			panic(err)
+		}
+	}()
+
+	if err = transactionFunc(transactionID); err != nil {
+		s.rollbackTransaction(transaction, transactionID)
+		return err
+	}
+	return s.commitTransaction(transaction, transactionID)
+}
+
+func (s schedulerStorage) rollbackTransaction(transaction *pg.Tx, transactionID ports.TransactionID) {
+	delete(s.transactionsMap, transactionID)
+	_ = transaction.Rollback()
+}
+
+func (s schedulerStorage) commitTransaction(transaction *pg.Tx, transactionID ports.TransactionID) error {
+	delete(s.transactionsMap, transactionID)
+	return transaction.Commit()
+}
+
+func isInTransactionalContext(transactionID ports.TransactionID) bool {
+	return transactionID != ""
 }

--- a/internal/adapters/scheduler_storage/pg/pg_test.go
+++ b/internal/adapters/scheduler_storage/pg/pg_test.go
@@ -33,6 +33,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/topfreegames/maestro/internal/core/ports"
+
 	golangMigrate "github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -265,7 +267,7 @@ func TestSchedulerStorage_GetSchedulerWithFilter(t *testing.T) {
 
 		err := storage.CreateScheduler(context.Background(), expectedScheduler)
 		require.NoError(t, err)
-		err = storage.CreateSchedulerVersion(context.Background(), expectedScheduler)
+		err = storage.CreateSchedulerVersion(context.Background(), "", expectedScheduler)
 		require.NoError(t, err)
 
 		actualScheduler, err := storage.GetSchedulerWithFilter(context.Background(), &filters.SchedulerFilter{
@@ -292,7 +294,7 @@ func TestSchedulerStorage_GetSchedulerWithFilter(t *testing.T) {
 		storage := NewSchedulerStorage(db.Options())
 
 		require.NoError(t, storage.CreateScheduler(context.Background(), expectedScheduler))
-		require.NoError(t, storage.CreateSchedulerVersion(context.Background(), expectedScheduler))
+		require.NoError(t, storage.CreateSchedulerVersion(context.Background(), "", expectedScheduler))
 
 		_, err := db.Exec("UPDATE schedulers SET yaml = 'invalid yaml' WHERE name = 'scheduler' and version = 'v1' ")
 		require.NoError(t, err)
@@ -328,7 +330,7 @@ func TestSchedulerStorage_GetSchedulerVersions(t *testing.T) {
 		storage := NewSchedulerStorage(db.Options())
 
 		require.NoError(t, storage.CreateScheduler(context.Background(), expectedScheduler))
-		require.NoError(t, storage.CreateSchedulerVersion(context.Background(), expectedScheduler))
+		require.NoError(t, storage.CreateSchedulerVersion(context.Background(), "", expectedScheduler))
 
 		versions, err := storage.GetSchedulerVersions(context.Background(), expectedScheduler.Name)
 
@@ -352,7 +354,7 @@ func TestSchedulerStorage_CreateScheduler(t *testing.T) {
 		storage := NewSchedulerStorage(db.Options())
 
 		require.NoError(t, storage.CreateScheduler(context.Background(), expectedScheduler))
-		require.NoError(t, storage.CreateSchedulerVersion(context.Background(), expectedScheduler))
+		require.NoError(t, storage.CreateSchedulerVersion(context.Background(), "", expectedScheduler))
 
 		dbScheduler, dbVersions := getDBSchedulerAndVersions(t, db, expectedScheduler.Name)
 		require.NotNil(t, dbScheduler)
@@ -365,7 +367,7 @@ func TestSchedulerStorage_CreateScheduler(t *testing.T) {
 		storage := NewSchedulerStorage(db.Options())
 
 		require.NoError(t, storage.CreateScheduler(context.Background(), expectedScheduler))
-		require.NoError(t, storage.CreateSchedulerVersion(context.Background(), expectedScheduler))
+		require.NoError(t, storage.CreateSchedulerVersion(context.Background(), "", expectedScheduler))
 		err := storage.CreateScheduler(context.Background(), expectedScheduler)
 		require.Error(t, err)
 		require.ErrorIs(t, errors.ErrAlreadyExists, err)
@@ -378,7 +380,7 @@ func TestSchedulerStorage_UpdateScheduler(t *testing.T) {
 		storage := NewSchedulerStorage(db.Options())
 
 		require.NoError(t, storage.CreateScheduler(context.Background(), expectedScheduler))
-		require.NoError(t, storage.CreateSchedulerVersion(context.Background(), expectedScheduler))
+		require.NoError(t, storage.CreateSchedulerVersion(context.Background(), "", expectedScheduler))
 
 		expectedScheduler.RollbackVersion = "v1"
 		expectedScheduler.Spec.Version = "v2"
@@ -430,48 +432,6 @@ func TestSchedulerStorage_DeleteScheduler(t *testing.T) {
 }
 
 func TestSchedulerStorage_CreateSchedulerVersion(t *testing.T) {
-	t.Run("should succeed - scheduler version created for scheduler", func(t *testing.T) {
-		db := getPostgresDB(t)
-		storage := NewSchedulerStorage(db.Options())
-
-		require.NoError(t, storage.CreateScheduler(context.Background(), expectedScheduler))
-		err := storage.CreateSchedulerVersion(context.Background(), expectedScheduler)
-		require.NoError(t, err)
-		versions, err := storage.GetSchedulerVersions(context.Background(), expectedScheduler.Name)
-		require.NoError(t, err)
-		require.Len(t, versions, 1)
-	})
-
-	t.Run("should fail - scheduler does not exist", func(t *testing.T) {
-		db := getPostgresDB(t)
-		storage := NewSchedulerStorage(db.Options())
-
-		err := storage.CreateSchedulerVersion(context.Background(), expectedScheduler)
-		require.Error(t, err)
-		require.Equal(t, err.Error(), fmt.Sprintf("error creating version %s for non existent scheduler \"%s\"", expectedScheduler.Spec.Version, expectedScheduler.Name))
-	})
-
-	t.Run("should fail - scheduler version invalid", func(t *testing.T) {
-		db := getPostgresDB(t)
-		storage := NewSchedulerStorage(db.Options())
-
-		require.NoError(t, storage.CreateScheduler(context.Background(), expectedScheduler))
-
-		expectedScheduler.Name = ""
-
-		err := storage.CreateSchedulerVersion(context.Background(), expectedScheduler)
-		require.Error(t, err)
-	})
-}
-
-func TestSchedulerStorage_CreateSchedulerVersionWithTransactionFunc(t *testing.T) {
-	someStruct := struct {
-		Scheduler *Scheduler
-		Version   string
-	}{
-		&Scheduler{},
-		"v1",
-	}
 	var firstVersionScheduler = entities.Scheduler{
 		Name:            "scheduler",
 		Game:            "game",
@@ -490,61 +450,72 @@ func TestSchedulerStorage_CreateSchedulerVersionWithTransactionFunc(t *testing.T
 			End:   60000,
 		},
 	}
-
 	newVersionScheduler := firstVersionScheduler
 	newVersionScheduler.Spec.Version = "v2"
 
-	successTransactionFunc := func(ctx context.Context) error {
-		if someStruct.Version == "v1" {
-			return nil
-		}
-		return errors.NewErrUnexpected("some_error")
-	}
-
-	failTransactionFunc := func(ctx context.Context) error {
-		if someStruct.Version == "v2" {
-			return nil
-		}
-		return errors.NewErrUnexpected("some_error")
-	}
-
-	t.Run("should succeed - scheduler version created for scheduler", func(t *testing.T) {
+	t.Run("should succeed - scheduler version created for scheduler without transactional context", func(t *testing.T) {
 		db := getPostgresDB(t)
 		storage := NewSchedulerStorage(db.Options())
 
 		require.NoError(t, storage.CreateScheduler(context.Background(), &firstVersionScheduler))
-
-		err := storage.CreateSchedulerVersionWithTransactionFunc(context.Background(), &newVersionScheduler, successTransactionFunc)
+		err := storage.CreateSchedulerVersion(context.Background(), "", &newVersionScheduler)
 		require.NoError(t, err)
-		versions, err := storage.GetSchedulerVersions(context.Background(), newVersionScheduler.Name)
+		versions, err := storage.GetSchedulerVersions(context.Background(), firstVersionScheduler.Name)
 		require.NoError(t, err)
-		// Should be 2 versions, one for v1 and one for v2
 		require.Len(t, versions, 2)
 	})
 
-	t.Run("should fail - transactionFunc fails", func(t *testing.T) {
+	t.Run("should succeed - scheduler version created for scheduler with transactional context", func(t *testing.T) {
+		db := getPostgresDB(t)
+		storage := NewSchedulerStorage(db.Options())
+		require.NoError(t, storage.CreateScheduler(context.Background(), &firstVersionScheduler))
+
+		err := storage.RunWithTransaction(context.Background(), func(transactionId ports.TransactionID) error {
+			err := storage.CreateSchedulerVersion(context.Background(), transactionId, &newVersionScheduler)
+			return err
+		})
+		require.NoError(t, err)
+
+		versions, err := storage.GetSchedulerVersions(context.Background(), firstVersionScheduler.Name)
+		require.NoError(t, err)
+		require.Len(t, versions, 2)
+	})
+
+	t.Run("should fail - scheduler version is not created for scheduler with transactional context if some error occurs", func(t *testing.T) {
+		db := getPostgresDB(t)
+		storage := NewSchedulerStorage(db.Options())
+		require.NoError(t, storage.CreateScheduler(context.Background(), &firstVersionScheduler))
+
+		err := storage.RunWithTransaction(context.Background(), func(transactionId ports.TransactionID) error {
+			_ = storage.CreateSchedulerVersion(context.Background(), transactionId, &newVersionScheduler)
+			return errors.NewErrUnexpected("some_error")
+		})
+		require.EqualError(t, err, "some_error")
+
+		versions, err := storage.GetSchedulerVersions(context.Background(), firstVersionScheduler.Name)
+		require.NoError(t, err)
+		require.Len(t, versions, 1)
+	})
+
+	t.Run("should fail - transaction not found when using transactional context", func(t *testing.T) {
 		db := getPostgresDB(t)
 		storage := NewSchedulerStorage(db.Options())
 
 		require.NoError(t, storage.CreateScheduler(context.Background(), &firstVersionScheduler))
-
-		err := storage.CreateSchedulerVersionWithTransactionFunc(context.Background(), &newVersionScheduler, failTransactionFunc)
-		require.EqualError(t, err, "failed to create scheduler version in db, transaction failed: some_error")
-
-		versions, err := storage.GetSchedulerVersions(context.Background(), newVersionScheduler.Name)
+		err := storage.CreateSchedulerVersion(context.Background(), "id-123", &newVersionScheduler)
+		require.EqualError(t, err, "transaction id-123 not found")
+		versions, err := storage.GetSchedulerVersions(context.Background(), firstVersionScheduler.Name)
 		require.NoError(t, err)
 		require.Len(t, versions, 1)
-		// Should be 1 versions, one for v1 and none for v2
-		require.Equal(t, firstVersionScheduler.Spec.Version, versions[0].Version)
 	})
 
 	t.Run("should fail - scheduler does not exist", func(t *testing.T) {
 		db := getPostgresDB(t)
 		storage := NewSchedulerStorage(db.Options())
 
-		err := storage.CreateSchedulerVersionWithTransactionFunc(context.Background(), &newVersionScheduler, successTransactionFunc)
+		err := storage.CreateSchedulerVersion(context.Background(), "", &firstVersionScheduler)
 		require.Error(t, err)
-		require.Equal(t, err.Error(), fmt.Sprintf("failed to create scheduler version in db, transaction failed: error creating version %s for non existent scheduler \"%s\"", newVersionScheduler.Spec.Version, newVersionScheduler.Name))
+		require.Equal(t, err.Error(), fmt.Sprintf("error creating version %s for non existent scheduler \"%s\"", firstVersionScheduler.Spec.Version, expectedScheduler.Name))
 	})
 
 	t.Run("should fail - scheduler version invalid", func(t *testing.T) {
@@ -553,16 +524,76 @@ func TestSchedulerStorage_CreateSchedulerVersionWithTransactionFunc(t *testing.T
 
 		require.NoError(t, storage.CreateScheduler(context.Background(), &firstVersionScheduler))
 
-		newVersionScheduler.Name = ""
+		firstVersionScheduler.Name = ""
 
-		err := storage.CreateSchedulerVersionWithTransactionFunc(context.Background(), &newVersionScheduler, successTransactionFunc)
+		err := storage.CreateSchedulerVersion(context.Background(), "", &firstVersionScheduler)
 		require.Error(t, err)
+	})
+}
+
+func TestSchedulerStorage_RunWithTransaction(t *testing.T) {
+
+	var firstVersionScheduler = entities.Scheduler{
+		Name:            "scheduler",
+		Game:            "game",
+		State:           entities.StateCreating,
+		MaxSurge:        "10%",
+		RollbackVersion: "",
+		Spec: game_room.Spec{
+			Version:                "v1",
+			TerminationGracePeriod: 60,
+			Containers:             []game_room.Container{},
+			Toleration:             "toleration",
+			Affinity:               "affinity",
+		},
+		PortRange: &entities.PortRange{
+			Start: 40000,
+			End:   60000,
+		},
+	}
+	secondVersionScheduler := firstVersionScheduler
+	secondVersionScheduler.Spec.Version = "v2"
+	thirdVersionScheduler := firstVersionScheduler
+	thirdVersionScheduler.Spec.Version = "v3"
+
+	t.Run("should succeed - return nil and commit operations when no error occurs", func(t *testing.T) {
+		db := getPostgresDB(t)
+		storage := NewSchedulerStorage(db.Options())
+		require.NoError(t, storage.CreateScheduler(context.Background(), &firstVersionScheduler))
+
+		err := storage.RunWithTransaction(context.Background(), func(transactionId ports.TransactionID) error {
+			err := storage.CreateSchedulerVersion(context.Background(), transactionId, &secondVersionScheduler)
+			if err != nil {
+				return err
+			}
+			err = storage.CreateSchedulerVersion(context.Background(), transactionId, &thirdVersionScheduler)
+
+			return err
+		})
+		require.NoError(t, err)
+
+		versions, err := storage.GetSchedulerVersions(context.Background(), firstVersionScheduler.Name)
+		require.NoError(t, err)
+		require.Len(t, versions, 3)
+	})
+
+	t.Run("should fail - return error and don't commit operations when some error occurs", func(t *testing.T) {
+		db := getPostgresDB(t)
+		storage := NewSchedulerStorage(db.Options())
+		require.NoError(t, storage.CreateScheduler(context.Background(), &firstVersionScheduler))
+
+		err := storage.RunWithTransaction(context.Background(), func(transactionId ports.TransactionID) error {
+			_ = storage.CreateSchedulerVersion(context.Background(), transactionId, &secondVersionScheduler)
+
+			_ = storage.CreateSchedulerVersion(context.Background(), transactionId, &thirdVersionScheduler)
+
+			return errors.NewErrUnexpected("some_error")
+		})
+		require.EqualError(t, err, "some_error")
 
 		versions, err := storage.GetSchedulerVersions(context.Background(), firstVersionScheduler.Name)
 		require.NoError(t, err)
 		require.Len(t, versions, 1)
-		// Should be 1 versions, one for v1 and none for v2
-		require.Equal(t, firstVersionScheduler.Spec.Version, versions[0].Version)
 	})
 
 }

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -86,7 +86,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Execute(ctx context.Context, op *op
 		}
 	}
 
-	err = ex.createNewSchedulerVersionAndEnqueueSwitchVersionOp(ctx, newScheduler, logger)
+	err = ex.createNewSchedulerVersionAndEnqueueSwitchVersionOp(ctx, newScheduler, logger, isSchedulerMajorVersion)
 	if err != nil {
 		return err
 	}
@@ -103,9 +103,9 @@ func (ex *CreateNewSchedulerVersionExecutor) Name() string {
 	return OperationName
 }
 
-func (ex *CreateNewSchedulerVersionExecutor) createNewSchedulerVersionAndEnqueueSwitchVersionOp(ctx context.Context, newScheduler *entities.Scheduler, logger *zap.Logger) error {
+func (ex *CreateNewSchedulerVersionExecutor) createNewSchedulerVersionAndEnqueueSwitchVersionOp(ctx context.Context, newScheduler *entities.Scheduler, logger *zap.Logger, replacePods bool) error {
 	transactionFunc := func(ctx context.Context) error {
-		_, err := ex.schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, newScheduler)
+		_, err := ex.schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, newScheduler, replacePods)
 		if err != nil {
 			// TODO(guilhermbrsp): Maybe we should rollback the creation of the new scheduler version if some error happens here
 			logger.Error("error enqueuing switch active version operation", zap.Error(err))

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -104,15 +104,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Name() string {
 }
 
 func (ex *CreateNewSchedulerVersionExecutor) createNewSchedulerVersionAndEnqueueSwitchVersionOp(ctx context.Context, newScheduler *entities.Scheduler, logger *zap.Logger, replacePods bool) error {
-	transactionFunc := func(ctx context.Context) error {
-		_, err := ex.schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, newScheduler, replacePods)
-		if err != nil {
-			logger.Error("error enqueuing switch active version operation", zap.Error(err))
-			return fmt.Errorf("error enqueuing switch active version operation: %w", err)
-		}
-		return nil
-	}
-	err := ex.schedulerManager.CreateNewSchedulerVersionWithTransaction(ctx, newScheduler, transactionFunc)
+	err := ex.schedulerManager.CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx, newScheduler, replacePods)
 	if err != nil {
 		logger.Error("error creating new scheduler version in db", zap.Error(err))
 		return fmt.Errorf("error creating new scheduler version in db: %w", err)

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -113,7 +113,7 @@ func (ex *CreateNewSchedulerVersionExecutor) createNewSchedulerVersionAndEnqueue
 		}
 		return nil
 	}
-	err := ex.schedulerManager.CreateNewSchedulerVersionInTransaction(ctx, newScheduler, transactionFunc)
+	err := ex.schedulerManager.CreateNewSchedulerVersionWithTransaction(ctx, newScheduler, transactionFunc)
 	if err != nil {
 		logger.Error("error creating new scheduler version in db", zap.Error(err))
 		return fmt.Errorf("error creating new scheduler version in db: %w", err)

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -107,7 +107,6 @@ func (ex *CreateNewSchedulerVersionExecutor) createNewSchedulerVersionAndEnqueue
 	transactionFunc := func(ctx context.Context) error {
 		_, err := ex.schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, newScheduler, replacePods)
 		if err != nil {
-			// TODO(guilhermbrsp): Maybe we should rollback the creation of the new scheduler version if some error happens here
 			logger.Error("error enqueuing switch active version operation", zap.Error(err))
 			return fmt.Errorf("error enqueuing switch active version operation: %w", err)
 		}

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -102,7 +102,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		newSchedulerWithNewVersion.RollbackVersion = "v1.0.0"
 
 		// mocks for SchedulerManager CreateNewSchedulerVersion method
-		mocksForExecutor.schedulerStorage.EXPECT().CreateSchedulerVersionWithTransactionFunc(gomock.Any(), &newSchedulerWithNewVersion, gomock.Any())
+		mocksForExecutor.schedulerStorage.EXPECT().RunWithTransaction(gomock.Any(), gomock.Any())
 
 		// mocks for RoomManager CreateRoom
 		mocksForExecutor.portAllocator.EXPECT().Allocate(gomock.Any(), gomock.Any()).Return([]int32{8080}, nil)
@@ -178,7 +178,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		mocksForExecutor.schedulerStorage.EXPECT().GetScheduler(gomock.Any(), newScheduler.Name).Return(currentActiveScheduler, nil)
 
 		// mocks for SchedulerManager CreateNewSchedulerVersion method
-		mocksForExecutor.schedulerStorage.EXPECT().CreateSchedulerVersionWithTransactionFunc(gomock.Any(), &newSchedulerWithNewVersion, gomock.Any())
+		mocksForExecutor.schedulerStorage.EXPECT().RunWithTransaction(gomock.Any(), gomock.Any())
 
 		result := executor.Execute(context.Background(), operation, operationDef)
 
@@ -206,7 +206,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		mocksForExecutor.schedulerStorage.EXPECT().GetScheduler(gomock.Any(), newScheduler.Name).Return(currentActiveScheduler, nil)
 
 		// mocks for SchedulerManager CreateNewSchedulerVersion method
-		mocksForExecutor.schedulerStorage.EXPECT().CreateSchedulerVersionWithTransactionFunc(gomock.Any(), &newSchedulerWithNewVersion, gomock.Any()).Return(errors.NewErrUnexpected("some error"))
+		mocksForExecutor.schedulerStorage.EXPECT().RunWithTransaction(gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("some error"))
 
 		result := executor.Execute(context.Background(), operation, operationDef)
 

--- a/internal/core/ports/scheduler_storage.go
+++ b/internal/core/ports/scheduler_storage.go
@@ -39,4 +39,5 @@ type SchedulerStorage interface {
 	UpdateScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	DeleteScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	CreateSchedulerVersion(ctx context.Context, scheduler *entities.Scheduler) error
+	CreateSchedulerVersionWithTransactionFunc(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(ctx context.Context) error) error
 }

--- a/internal/core/ports/scheduler_storage.go
+++ b/internal/core/ports/scheduler_storage.go
@@ -38,6 +38,8 @@ type SchedulerStorage interface {
 	CreateScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	UpdateScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	DeleteScheduler(ctx context.Context, scheduler *entities.Scheduler) error
-	CreateSchedulerVersion(ctx context.Context, scheduler *entities.Scheduler) error
-	CreateSchedulerVersionWithTransactionFunc(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(ctx context.Context) error) error
+	CreateSchedulerVersion(ctx context.Context, transactionID TransactionID, scheduler *entities.Scheduler) error
+	RunWithTransaction(ctx context.Context, transactionFunc func(transactionId TransactionID) error) error
 }
+
+type TransactionID string

--- a/internal/core/services/interfaces/scheduler_manager.go
+++ b/internal/core/services/interfaces/scheduler_manager.go
@@ -34,7 +34,7 @@ type SchedulerManager interface {
 	SwitchActiveScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	GetActiveScheduler(ctx context.Context, schedulerName string) (*entities.Scheduler, error)
 	IsMajorVersionUpdate(currentScheduler, newScheduler *entities.Scheduler) bool
-	CreateNewSchedulerVersionInTransaction(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(ctx context.Context) error) error
+	CreateNewSchedulerVersionWithTransaction(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(ctx context.Context) error) error
 	CreateNewSchedulerVersion(ctx context.Context, scheduler *entities.Scheduler) error
 	EnqueueSwitchActiveVersionOperation(ctx context.Context, newScheduler *entities.Scheduler, replacePods bool) (*operation.Operation, error)
 }

--- a/internal/core/services/interfaces/scheduler_manager.go
+++ b/internal/core/services/interfaces/scheduler_manager.go
@@ -34,6 +34,7 @@ type SchedulerManager interface {
 	SwitchActiveScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	GetActiveScheduler(ctx context.Context, schedulerName string) (*entities.Scheduler, error)
 	IsMajorVersionUpdate(currentScheduler, newScheduler *entities.Scheduler) bool
+	CreateNewSchedulerVersionInTransaction(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(ctx context.Context) error) error
 	CreateNewSchedulerVersion(ctx context.Context, scheduler *entities.Scheduler) error
 	EnqueueSwitchActiveVersionOperation(ctx context.Context, newScheduler *entities.Scheduler, replacePods bool) (*operation.Operation, error)
 }

--- a/internal/core/services/interfaces/scheduler_manager.go
+++ b/internal/core/services/interfaces/scheduler_manager.go
@@ -34,7 +34,7 @@ type SchedulerManager interface {
 	SwitchActiveScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	GetActiveScheduler(ctx context.Context, schedulerName string) (*entities.Scheduler, error)
 	IsMajorVersionUpdate(currentScheduler, newScheduler *entities.Scheduler) bool
-	CreateNewSchedulerVersionWithTransaction(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(ctx context.Context) error) error
+	CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error
 	CreateNewSchedulerVersion(ctx context.Context, scheduler *entities.Scheduler) error
 	EnqueueSwitchActiveVersionOperation(ctx context.Context, newScheduler *entities.Scheduler, replacePods bool) (*operation.Operation, error)
 }

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -97,7 +97,7 @@ func (s *SchedulerManager) CreateNewSchedulerVersion(ctx context.Context, schedu
 	return nil
 }
 
-func (s *SchedulerManager) CreateNewSchedulerVersionInTransaction(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(ctx context.Context) error) error {
+func (s *SchedulerManager) CreateNewSchedulerVersionWithTransaction(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(ctx context.Context) error) error {
 	err := scheduler.Validate()
 	if err != nil {
 		return fmt.Errorf("failing in creating schedule: %w", err)

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -97,6 +97,19 @@ func (s *SchedulerManager) CreateNewSchedulerVersion(ctx context.Context, schedu
 	return nil
 }
 
+func (s *SchedulerManager) CreateNewSchedulerVersionInTransaction(ctx context.Context, scheduler *entities.Scheduler, transactionFunc func(ctx context.Context) error) error {
+	err := scheduler.Validate()
+	if err != nil {
+		return fmt.Errorf("failing in creating schedule: %w", err)
+	}
+
+	err = s.schedulerStorage.CreateSchedulerVersionWithTransactionFunc(ctx, scheduler, transactionFunc)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *SchedulerManager) GetAllSchedulers(ctx context.Context) ([]*entities.Scheduler, error) {
 	return s.schedulerStorage.GetAllSchedulers(ctx)
 }

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -151,6 +151,53 @@ func TestCreateNewSchedulerVersion(t *testing.T) {
 
 }
 
+func TestCreateNewSchedulerVersionInTransaction(t *testing.T) {
+	err := validations.RegisterValidations()
+	if err != nil {
+		t.Errorf("unexpected error %d'", err)
+	}
+
+	ctx := context.Background()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
+	operationFlow := opflow.NewMockOperationFlow(mockCtrl)
+	operationStorage := opstorage.NewMockOperationStorage(mockCtrl)
+	operationLeaseStorage := oplstorage.NewMockOperationLeaseStorage(mockCtrl)
+	config := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+	operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, config)
+	schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
+	transactionFunc := func(ctx context.Context) error {
+		return nil
+	}
+
+	t.Run("with valid scheduler it returns no error when creating it", func(t *testing.T) {
+		scheduler := newValidScheduler()
+
+		schedulerStorage.EXPECT().CreateSchedulerVersionWithTransactionFunc(ctx, scheduler, gomock.Any()).Return(nil)
+
+		err := schedulerManager.CreateNewSchedulerVersionInTransaction(ctx, scheduler, transactionFunc)
+		require.NoError(t, err)
+	})
+
+	t.Run("with valid scheduler it returns with error if some error occurs when creating new version on storage", func(t *testing.T) {
+		scheduler := newValidScheduler()
+
+		schedulerStorage.EXPECT().CreateSchedulerVersionWithTransactionFunc(ctx, scheduler, gomock.Any()).Return(errors.NewErrUnexpected("some error"))
+
+		err := schedulerManager.CreateNewSchedulerVersionInTransaction(ctx, scheduler, transactionFunc)
+		require.Error(t, err, "some error")
+	})
+
+	t.Run("with invalid scheduler it return invalid scheduler error", func(t *testing.T) {
+		scheduler := newInvalidScheduler()
+
+		err := schedulerManager.CreateNewSchedulerVersionInTransaction(ctx, scheduler, transactionFunc)
+		require.Error(t, err)
+	})
+
+}
+
 func TestAddRooms(t *testing.T) {
 	schedulerName := "scheduler-name-1"
 

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -176,7 +176,7 @@ func TestCreateNewSchedulerVersionInTransaction(t *testing.T) {
 
 		schedulerStorage.EXPECT().CreateSchedulerVersionWithTransactionFunc(ctx, scheduler, gomock.Any()).Return(nil)
 
-		err := schedulerManager.CreateNewSchedulerVersionInTransaction(ctx, scheduler, transactionFunc)
+		err := schedulerManager.CreateNewSchedulerVersionWithTransaction(ctx, scheduler, transactionFunc)
 		require.NoError(t, err)
 	})
 
@@ -185,14 +185,14 @@ func TestCreateNewSchedulerVersionInTransaction(t *testing.T) {
 
 		schedulerStorage.EXPECT().CreateSchedulerVersionWithTransactionFunc(ctx, scheduler, gomock.Any()).Return(errors.NewErrUnexpected("some error"))
 
-		err := schedulerManager.CreateNewSchedulerVersionInTransaction(ctx, scheduler, transactionFunc)
+		err := schedulerManager.CreateNewSchedulerVersionWithTransaction(ctx, scheduler, transactionFunc)
 		require.Error(t, err, "some error")
 	})
 
 	t.Run("with invalid scheduler it return invalid scheduler error", func(t *testing.T) {
 		scheduler := newInvalidScheduler()
 
-		err := schedulerManager.CreateNewSchedulerVersionInTransaction(ctx, scheduler, transactionFunc)
+		err := schedulerManager.CreateNewSchedulerVersionWithTransaction(ctx, scheduler, transactionFunc)
 		require.Error(t, err)
 	})
 


### PR DESCRIPTION
## What ❓
Use transaction for creating new scheduler version in new_scheduler_version operation.

## Why 🤔
Currently, on new_version operation, if the switch_active_version operation enqueuing fails, we would have to perform a manual rollback in the new version created in the DB.

## How
- Add CreateSchedulerVersionWithTransactionFunc method in scheduler storage 
- Add CreateNewSchedulerVersionInTransaction to scheduler manager