### PR TITLE
switch active version e2e test

### DIFF
--- a/config/runtime-watcher.local.yaml
+++ b/config/runtime-watcher.local.yaml
@@ -39,6 +39,6 @@ workers:
   stopTimeoutDuration: 1m
 services:
   roomManager:
-    roomPingTimeoutMillis: 90000
+    roomPingTimeoutMillis: 240000
     roomInitializationTimeoutMillis: 120000
     roomDeletionTimeoutMillis: 120000

--- a/e2e/suites/management/add_rooms_test.go
+++ b/e2e/suites/management/add_rooms_test.go
@@ -48,7 +48,7 @@ func TestAddRooms(t *testing.T) {
 		roomsStorage := roomStorageRedis.NewRedisStateStorage(redisClient)
 		instanceStorage := instanceStorageRedis.NewRedisInstanceStorage(redisClient, 10)
 
-		t.Run("when created rooms does not reply its state back then it finishes the operation successfully", func(t *testing.T) {
+		t.Run("when created rooms does not reply its state back then they're finished", func(t *testing.T) {
 			t.Parallel()
 
 			schedulerName, err := createSchedulerAndWaitForIt(
@@ -82,10 +82,10 @@ func TestAddRooms(t *testing.T) {
 			require.NotEmpty(t, pods.Items)
 
 			require.Eventually(t, func() bool {
-				instance, err := instanceStorage.GetInstance(context.Background(), schedulerName, pods.Items[0].ObjectMeta.Name)
+				_, err := instanceStorage.GetInstance(context.Background(), schedulerName, pods.Items[0].ObjectMeta.Name)
 
-				return err == nil && instance.Status.Type == game_room.InstanceReady
-			}, time.Minute, time.Second)
+				return err != nil
+			}, 4*time.Minute, time.Second)
 		})
 
 		t.Run("when created rooms replies its state back then it finishes the operation successfully", func(t *testing.T) {

--- a/e2e/suites/management/switch_active_version_test.go
+++ b/e2e/suites/management/switch_active_version_test.go
@@ -1,0 +1,362 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package management
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	maestroApiV1 "github.com/topfreegames/maestro/pkg/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/go-redis/redis/v8"
+
+	"github.com/topfreegames/maestro/e2e/framework/maestro"
+
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro/e2e/framework"
+	"k8s.io/client-go/kubernetes"
+)
+
+func TestSwitchActiveVersion(t *testing.T) {
+	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
+		t.Run("Should Succeed - create minor version, rollback version", func(t *testing.T) {
+			t.Parallel()
+
+			schedulerName, err := createSchedulerWithRoomsAndWaitForIt(t, maestro, managementApiClient, kubeClient)
+
+			podsBeforeUpdate, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			// Update scheduler
+			updateRequest := &maestroApiV1.NewSchedulerVersionRequest{
+				Name:                   schedulerName,
+				Game:                   "test",
+				MaxSurge:               "10%",
+				TerminationGracePeriod: 15,
+				Containers: []*maestroApiV1.Container{
+					{
+						Name:  "example",
+						Image: "alpine",
+						Command: []string{"/bin/sh", "-c", "apk add curl && curl --request POST " +
+							"$ROOMS_API_ADDRESS:9097/scheduler/$MAESTRO_SCHEDULER_NAME/rooms/$MAESTRO_ROOM_ID/ping " +
+							"--data-raw '{\"status\": \"ready\",\"timestamp\": \"12312312313\"}' && tail -f /dev/null"},
+						ImagePullPolicy: "Always",
+						Environment: []*maestroApiV1.ContainerEnvironment{
+							{
+								Name:  "ROOMS_API_ADDRESS",
+								Value: maestro.RoomsApiServer.ContainerInternalAddress,
+							},
+						},
+						Requests: &maestroApiV1.ContainerResources{
+							Memory: "20Mi",
+							Cpu:    "10m",
+						},
+						Limits: &maestroApiV1.ContainerResources{
+							Memory: "20Mi",
+							Cpu:    "10m",
+						},
+						Ports: []*maestroApiV1.ContainerPort{
+							{
+								Name:     "default",
+								Protocol: "tcp",
+								Port:     80,
+							},
+						},
+					},
+				},
+				PortRange: &maestroApiV1.PortRange{
+					Start: 80,
+					End:   8000,
+				},
+			}
+			updateResponse := &maestroApiV1.NewSchedulerVersionResponse{}
+
+			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s", schedulerName), updateRequest, updateResponse)
+			require.NoError(t, err)
+			require.NotNil(t, updateResponse.OperationId, schedulerName)
+
+			waitForOperationToFinish(t, managementApiClient, schedulerName, "create_new_scheduler_version")
+			waitForOperationToFinish(t, managementApiClient, schedulerName, "switch_active_version")
+
+			podsAfterUpdate, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t, podsAfterUpdate.Items)
+
+			getSchedulerRequest := &maestroApiV1.GetSchedulerRequest{SchedulerName: schedulerName}
+			getSchedulerResponse := &maestroApiV1.GetSchedulerResponse{}
+			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", schedulerName), getSchedulerRequest, getSchedulerResponse)
+			require.NoError(t, err)
+
+			// Don't replace pods since is a minor change
+			for i := 0; i < 2; i++ {
+				require.Equal(t, podsAfterUpdate.Items[i].Name, podsBeforeUpdate.Items[i].Name)
+			}
+
+			// Switches to version v1.2.0
+			require.Equal(t, "v1.2.0", getSchedulerResponse.Scheduler.Version)
+
+			// Update scheduler
+			switchActiveVersionRequest := &maestroApiV1.SwitchActiveVersionRequest{
+				SchedulerName: schedulerName,
+				Version:       "v1.1",
+			}
+			switchActiveVersionResponse := &maestroApiV1.SwitchActiveVersionResponse{}
+
+			err = managementApiClient.Do("PUT", fmt.Sprintf("/schedulers/%s", schedulerName), switchActiveVersionRequest, switchActiveVersionResponse)
+			require.NoError(t, err)
+
+			// New Switch Active Version
+			waitForOperationToFinishByOperationId(t, managementApiClient, schedulerName, switchActiveVersionResponse.OperationId)
+
+			getSchedulerAfterSwitchResponse := &maestroApiV1.GetSchedulerResponse{}
+			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", schedulerName), getSchedulerRequest, getSchedulerAfterSwitchResponse)
+			require.NoError(t, err)
+			require.NotEqual(t, getSchedulerAfterSwitchResponse.Scheduler.Version, getSchedulerResponse.Scheduler.Version)
+
+			podsAfterRollback, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t,  podsAfterRollback.Items)
+
+			// Pods don't change since it's a minor rollback
+			for i := 0; i < 2; i++ {
+				require.Equal(t, podsAfterUpdate.Items[i].Name, podsAfterRollback.Items[i].Name)
+			}
+		})
+
+		t.Run("Should Succeed - create major change, rollback version", func(t *testing.T) {
+			t.Parallel()
+
+			schedulerName, err := createSchedulerWithRoomsAndWaitForIt(t, maestro, managementApiClient, kubeClient)
+
+			podsBeforeUpdate, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			updateRequest := &maestroApiV1.NewSchedulerVersionRequest{
+				Name:                   schedulerName,
+				Game:                   "test",
+				MaxSurge:               "10%",
+				TerminationGracePeriod: 15,
+				Containers: []*maestroApiV1.Container{
+					{
+						Name:  "example-update",
+						Image: "alpine",
+						Command: []string{"/bin/sh", "-c", "apk add curl && curl --request POST " +
+							"$ROOMS_API_ADDRESS:9097/scheduler/$MAESTRO_SCHEDULER_NAME/rooms/$MAESTRO_ROOM_ID/ping " +
+							"--data-raw '{\"status\": \"ready\",\"timestamp\": \"12312312313\"}' && tail -f /dev/null"},
+						ImagePullPolicy: "Always",
+						Environment: []*maestroApiV1.ContainerEnvironment{
+							{
+								Name:  "ROOMS_API_ADDRESS",
+								Value: maestro.RoomsApiServer.ContainerInternalAddress,
+							},
+						},
+						Requests: &maestroApiV1.ContainerResources{
+							Memory: "20Mi",
+							Cpu:    "10m",
+						},
+						Limits: &maestroApiV1.ContainerResources{
+							Memory: "20Mi",
+							Cpu:    "10m",
+						},
+						Ports: []*maestroApiV1.ContainerPort{
+							{
+								Name:     "default",
+								Protocol: "tcp",
+								Port:     80,
+							},
+						},
+					},
+				},
+				PortRange: &maestroApiV1.PortRange{
+					Start: 80,
+					End:   8000,
+				},
+			}
+			updateResponse := &maestroApiV1.NewSchedulerVersionResponse{}
+
+			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s", schedulerName), updateRequest, updateResponse)
+			require.NoError(t, err)
+			require.NotNil(t, updateResponse.OperationId, schedulerName)
+
+			waitForOperationToFinish(t, managementApiClient, schedulerName, "create_new_scheduler_version")
+			waitForOperationToFinish(t, managementApiClient, schedulerName, "switch_active_version")
+
+			getSchedulerRequest := &maestroApiV1.GetSchedulerRequest{SchedulerName: schedulerName}
+			getSchedulerResponse := &maestroApiV1.GetSchedulerResponse{}
+
+			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", schedulerName), getSchedulerRequest, getSchedulerResponse)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				podsAfterUpdate, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+				require.NoError(t, err)
+				require.NotEmpty(t, podsAfterUpdate.Items)
+
+				if len(podsAfterUpdate.Items) == 2 {
+					return true
+				}
+
+				return false
+			}, 2*time.Minute, time.Second)
+
+			podsAfterUpdate, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t, podsAfterUpdate.Items)
+
+			for i := 0; i < 2; i++ {
+				require.NotEqual(t, podsAfterUpdate.Items[i].Spec, podsBeforeUpdate.Items[i].Spec)
+				require.Equal(t, "example-update", podsAfterUpdate.Items[i].Spec.Containers[0].Name)
+			}
+
+			require.Equal(t, "v2.0.0", getSchedulerResponse.Scheduler.Version)
+
+			// Rollback scheduler version
+			switchActiveVersionRequest := &maestroApiV1.SwitchActiveVersionRequest{
+				SchedulerName: schedulerName,
+				Version:       "v1.1",
+			}
+			switchActiveVersionResponse := &maestroApiV1.SwitchActiveVersionResponse{}
+
+			err = managementApiClient.Do("PUT", fmt.Sprintf("/schedulers/%s", schedulerName), switchActiveVersionRequest, switchActiveVersionResponse)
+			require.NoError(t, err)
+
+			// New Switch Active Version
+			waitForOperationToFinishByOperationId(t, managementApiClient, schedulerName, switchActiveVersionResponse.OperationId)
+
+			getSchedulerAfterSwitchResponse := &maestroApiV1.GetSchedulerResponse{}
+			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", schedulerName), getSchedulerRequest, getSchedulerAfterSwitchResponse)
+			require.NoError(t, err)
+			require.NotEqual(t, getSchedulerAfterSwitchResponse.Scheduler.Version, getSchedulerResponse.Scheduler.Version)
+
+			podsAfterRollback, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t,  podsAfterRollback.Items)
+
+			// Pods change since it's a major rollback
+			for i := 0; i < 2; i++ {
+				require.NotEqual(t, podsAfterUpdate.Items[i].Name, podsAfterRollback.Items[i].Name)
+			}
+		})
+
+		t.Run("Should fail - version does not exist", func(t *testing.T) {
+			t.Parallel()
+
+			schedulerName, err := createSchedulerWithRoomsAndWaitForIt(t, maestro, managementApiClient, kubeClient)
+
+			podsBeforeUpdate, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			updateRequest := &maestroApiV1.NewSchedulerVersionRequest{
+				Name:                   schedulerName,
+				Game:                   "test",
+				MaxSurge:               "10%",
+				TerminationGracePeriod: 15,
+				Containers: []*maestroApiV1.Container{
+					{
+						Name:  "example-update",
+						Image: "alpine",
+						Command: []string{"/bin/sh", "-c", "apk add curl && curl --request POST " +
+							"$ROOMS_API_ADDRESS:9097/scheduler/$MAESTRO_SCHEDULER_NAME/rooms/$MAESTRO_ROOM_ID/ping " +
+							"--data-raw '{\"status\": \"ready\",\"timestamp\": \"12312312313\"}' && tail -f /dev/null"},
+						ImagePullPolicy: "Always",
+						Environment: []*maestroApiV1.ContainerEnvironment{
+							{
+								Name:  "ROOMS_API_ADDRESS",
+								Value: maestro.RoomsApiServer.ContainerInternalAddress,
+							},
+						},
+						Requests: &maestroApiV1.ContainerResources{
+							Memory: "20Mi",
+							Cpu:    "10m",
+						},
+						Limits: &maestroApiV1.ContainerResources{
+							Memory: "20Mi",
+							Cpu:    "10m",
+						},
+						Ports: []*maestroApiV1.ContainerPort{
+							{
+								Name:     "default",
+								Protocol: "tcp",
+								Port:     80,
+							},
+						},
+					},
+				},
+				PortRange: &maestroApiV1.PortRange{
+					Start: 80,
+					End:   8000,
+				},
+			}
+			updateResponse := &maestroApiV1.NewSchedulerVersionResponse{}
+
+			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s", schedulerName), updateRequest, updateResponse)
+			require.NoError(t, err)
+			require.NotNil(t, updateResponse.OperationId, schedulerName)
+
+			waitForOperationToFinish(t, managementApiClient, schedulerName, "create_new_scheduler_version")
+			waitForOperationToFinish(t, managementApiClient, schedulerName, "switch_active_version")
+
+			getSchedulerRequest := &maestroApiV1.GetSchedulerRequest{SchedulerName: schedulerName}
+			getSchedulerResponse := &maestroApiV1.GetSchedulerResponse{}
+
+			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", schedulerName), getSchedulerRequest, getSchedulerResponse)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				podsAfterUpdate, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+				require.NoError(t, err)
+				require.NotEmpty(t, podsAfterUpdate.Items)
+
+				if len(podsAfterUpdate.Items) == 2 {
+					return true
+				}
+
+				return false
+			}, 2*time.Minute, time.Second)
+
+			podsAfterUpdate, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t, podsAfterUpdate.Items)
+
+			for i := 0; i < 2; i++ {
+				require.NotEqual(t, podsAfterUpdate.Items[i].Spec, podsBeforeUpdate.Items[i].Spec)
+				require.Equal(t, "example-update", podsAfterUpdate.Items[i].Spec.Containers[0].Name)
+			}
+
+			require.Equal(t, "v2.0.0", getSchedulerResponse.Scheduler.Version)
+
+			// Rollback scheduler version
+			switchActiveVersionRequest := &maestroApiV1.SwitchActiveVersionRequest{
+				SchedulerName: schedulerName,
+				Version:       "DOES_NOT_EXIST",
+			}
+			switchActiveVersionResponse := &maestroApiV1.SwitchActiveVersionResponse{}
+
+			err = managementApiClient.Do("PUT", fmt.Sprintf("/schedulers/%s", schedulerName), switchActiveVersionRequest, switchActiveVersionResponse)
+			require.Error(t, err)
+		})
+	})
+}

--- a/e2e/suites/management/utils.go
+++ b/e2e/suites/management/utils.go
@@ -267,6 +267,25 @@ func waitForOperationToFinish(t *testing.T, managementApiClient *framework.APICl
 	}, 4*time.Minute, time.Second)
 }
 
+func waitForOperationToFinishByOperationId(t *testing.T, managementApiClient *framework.APIClient, schedulerName, operationId string) {
+	require.Eventually(t, func() bool {
+		listOperationsRequest := &maestroApiV1.ListOperationsRequest{}
+		listOperationsResponse := &maestroApiV1.ListOperationsResponse{}
+		err := managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", schedulerName), listOperationsRequest, listOperationsResponse)
+		require.NoError(t, err)
+
+		if len(listOperationsResponse.FinishedOperations) >= 1 {
+			for _, _operation := range listOperationsResponse.FinishedOperations {
+				if _operation.Id == operationId {
+					return true
+				}
+			}
+		}
+
+		return false
+	}, 4*time.Minute, time.Second)
+}
+
 func waitForOperationToFail(t *testing.T, managementApiClient *framework.APIClient, schedulerName, operation string) {
 	require.Eventually(t, func() bool {
 		listOperationsRequest := &maestroApiV1.ListOperationsRequest{}

--- a/internal/api/handlers/schedulers_handler.go
+++ b/internal/api/handlers/schedulers_handler.go
@@ -71,7 +71,14 @@ func (h *SchedulersHandler) ListSchedulers(ctx context.Context, message *api.Lis
 func (h *SchedulersHandler) GetScheduler(ctx context.Context, request *api.GetSchedulerRequest) (*api.GetSchedulerResponse, error) {
 	var scheduler *entities.Scheduler
 	var err error
-	scheduler, err = h.schedulerManager.GetScheduler(ctx, request.GetSchedulerName(), request.GetVersion())
+
+	schedulerName := request.GetSchedulerName()
+	queryVersion := request.GetVersion()
+	if queryVersion != "" {
+		scheduler, err = h.schedulerManager.GetScheduler(ctx, schedulerName, queryVersion)
+	} else {
+		scheduler, err = h.schedulerManager.GetActiveScheduler(ctx, schedulerName)
+	}
 
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {

--- a/internal/api/handlers/schedulers_handler_test.go
+++ b/internal/api/handlers/schedulers_handler_test.go
@@ -170,7 +170,7 @@ func TestGetScheduler(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil)
 
-		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(&entities.Scheduler{
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(&entities.Scheduler{
 			Name:            "zooba-us",
 			Game:            "zooba",
 			State:           entities.StateInSync,
@@ -243,7 +243,7 @@ func TestGetScheduler(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil)
 
-		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrNotFound("scheduler NonExistentSchedule not found"))
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrNotFound("scheduler NonExistentSchedule not found"))
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterSchedulersServiceHandlerServer(context.Background(), mux, ProvideSchedulersHandler(schedulerManager))
@@ -275,7 +275,7 @@ func TestGetScheduler(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil)
 
-		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrInvalidArgument("Error"))
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrInvalidArgument("Error"))
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterSchedulersServiceHandlerServer(context.Background(), mux, ProvideSchedulersHandler(schedulerManager))
@@ -885,6 +885,7 @@ func TestSwitchActiveVersion(t *testing.T) {
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
 		operationStorage.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		operationFlow.EXPECT().InsertOperationID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
@@ -939,6 +940,7 @@ func TestSwitchActiveVersion(t *testing.T) {
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
 		operationStorage.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("internal error"))
 
 		mux := runtime.NewServeMux()

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -93,6 +93,7 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 		}
 	}
 
+	logger.Sugar().Debugf("switching version to %v", scheduler.Spec.Version)
 	err := ex.schedulerManager.UpdateScheduler(ctx, scheduler)
 	if err != nil {
 		logger.Error("Error switching active scheduler version on scheduler manager")


### PR DESCRIPTION
### What?
Implement e2e tests for switch active version use case.
### Why?
Sometimes, the client wants to rollback a scheduler version to an older version. To be able to do that, we needed a 
functionality to switch the active version of a scheduler. To guarantee the whole thing is happening as expected, we implement an e2e test.
### How?
Following the pattern of other e2e tests.
