### PR TITLE
chore(readme): add gh-pages info

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-      - next
+      - main
     paths:
       - "docs/*"
       - "**.md"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Maestro: Kubernetes Game Room Scheduler
 ## Docs
 All documentation regarding this version (v10.x, AKA NEXT) can be accessed at https://topfreegames.github.io/maestro/.
 
-The .MD files can be found on the branch "gh-pages" in this repository.
-
 ## Dependencies
 
 ### Grpc gateway

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Maestro: Kubernetes Game Room Scheduler
 [![Build Status](https://github.com/topfreegames/maestro/actions/workflows/test.yaml/badge.svg?branch=next)](https://github.com/topfreegames/maestro/actions/workflows/test.yaml)
 [![Codecov Status](https://codecov.io/gh/topfreegames/maestro/branch/next/graph/badge.svg?token=KCN2SZDRJF)](https://codecov.io/gh/topfreegames/maestro)
 
+## Docs
+All documentation regarding this version (v10.x, AKA NEXT) can be accessed at https://topfreegames.github.io/maestro/.
+
+The .MD files can be found on the branch "gh-pages" in this repository.
+
 ## Dependencies
 
 ### Grpc gateway
@@ -39,9 +44,40 @@ To test if the service (with dependencies) is up and running, try to create a sc
 curl --location --request POST 'http://localhost:8080/schedulers' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-    "name": "zooba-blue",
-    "game": "zooba",
-    "version": "1.0.0"
+    "name": "scheduler-test",
+    "game": "test",
+    "version": "v1.1",
+    "terminationGracePeriod": "100",
+    "maxSurge": "10",
+    "containers": [
+        {
+            "name": "example",
+            "image": "alpine",
+            "imagePullPolicy": "Always",
+            "command": ["sh", "-c", "tail -f /dev/null"],
+            "environment": [],
+            "requests": {
+                "memory": "20Mi",
+                "cpu": "10m"
+            },
+            "limits": {
+                "memory": "20Mi",
+                "cpu": "10m"
+            },
+            "ports": [
+                {
+                    "name": "default",
+                    "protocol": "tcp",
+                    "port": 80,
+                    "hostPort": 80
+                }
+            ]
+        }
+    ],
+    "portRange": {
+        "start": 0,
+        "end": 100
+    }
 }'
 ```
 


### PR DESCRIPTION
### What?
Adds gh-pages info to README.MD file.
### Why?
All documentation regarding maestro v10 (aka NEXT) can be found on a specific link provided by github pages, but it was not documented on the project markdown.
### How?
Adding a new section "DOCS" on the markdown file of the project.