### PR TITLE
Add warning to use correct cgroup version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ All documentation regarding this version (v10.x, AKA NEXT) can be accessed at ht
 
 ## Dependencies
 
+> **⚠ WARNING: Ensure using cgroupv1**
+> K3s needs to use the deprecated `cgroupv1`, to successfully run the project in your machine ensure that your current docker use this version.
+
 ### Grpc gateway
 In order to run make generate with success, you need to have grpc-gateway dependencies installed with the following command:
 ```shell


### PR DESCRIPTION
### Why
Currently, the Docker for Mac version equals or greater than 4.20 use the new `cgroupv2`. But the `k3sP  needs `cgroupv1` to work properly.
 
### What
This PR proposes to add an alert message to new developers to pay attention to the correct version of `cgroup`.