### PR TITLE
Feat/add game filter to scheduler manager domain

### DIFF
--- a/internal/adapters/scheduler_storage/mock/mock.go
+++ b/internal/adapters/scheduler_storage/mock/mock.go
@@ -154,6 +154,21 @@ func (mr *MockSchedulerStorageMockRecorder) GetSchedulers(ctx, names interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedulers", reflect.TypeOf((*MockSchedulerStorage)(nil).GetSchedulers), ctx, names)
 }
 
+// GetSchedulersWithFilter mocks base method.
+func (m *MockSchedulerStorage) GetSchedulersWithFilter(ctx context.Context, schedulerFilter *filters.SchedulerFilter) ([]*entities.Scheduler, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSchedulersWithFilter", ctx, schedulerFilter)
+	ret0, _ := ret[0].([]*entities.Scheduler)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSchedulersWithFilter indicates an expected call of GetSchedulersWithFilter.
+func (mr *MockSchedulerStorageMockRecorder) GetSchedulersWithFilter(ctx, schedulerFilter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedulersWithFilter", reflect.TypeOf((*MockSchedulerStorage)(nil).GetSchedulersWithFilter), ctx, schedulerFilter)
+}
+
 // RunWithTransaction mocks base method.
 func (m *MockSchedulerStorage) RunWithTransaction(ctx context.Context, transactionFunc func(ports.TransactionID) error) error {
 	m.ctrl.T.Helper()

--- a/internal/adapters/scheduler_storage/pg/pg.go
+++ b/internal/adapters/scheduler_storage/pg/pg.go
@@ -70,10 +70,10 @@ SELECT
 FROM schedulers s join scheduler_versions v
 	ON s.name=v.name
 WHERE s.name = ?`
-	queryGetSchedulers    = `SELECT * FROM schedulers WHERE name IN (?)`
+	queryGetSchedulers       = `SELECT * FROM schedulers WHERE name IN (?)`
 	querySimpleGetSchedulers = `SELECT * FROM schedulers`
-	queryGetAllSchedulers = `SELECT * FROM schedulers`
-	queryInsertScheduler  = `
+	queryGetAllSchedulers    = `SELECT * FROM schedulers`
+	queryInsertScheduler     = `
 INSERT INTO schedulers (name, game, yaml, state, version, state_last_changed_at)
 	VALUES (?name, ?game, ?yaml, ?state, ?version, extract(epoch from now()))
 	RETURNING id`
@@ -212,8 +212,8 @@ func createWhereClauses(schedulerFilter *filters.SchedulerFilter) (string, []int
 		}
 
 		if schedulerFilter.Name != "" {
-			if thereIsOne == true {
-				clauses = clauses  + " and"
+			if thereIsOne {
+				clauses = clauses + " and"
 			}
 
 			clauses = clauses + " name = ?"
@@ -222,8 +222,8 @@ func createWhereClauses(schedulerFilter *filters.SchedulerFilter) (string, []int
 		}
 
 		if schedulerFilter.Version != "" {
-			if thereIsOne == true {
-				clauses = clauses  + " and"
+			if thereIsOne {
+				clauses = clauses + " and"
 			}
 
 			clauses = clauses + " version = ?"

--- a/internal/adapters/scheduler_storage/pg/pg.go
+++ b/internal/adapters/scheduler_storage/pg/pg.go
@@ -71,6 +71,7 @@ FROM schedulers s join scheduler_versions v
 	ON s.name=v.name
 WHERE s.name = ?`
 	queryGetSchedulers    = `SELECT * FROM schedulers WHERE name IN (?)`
+	querySimpleGetSchedulers = `SELECT * FROM schedulers`
 	queryGetAllSchedulers = `SELECT * FROM schedulers`
 	queryInsertScheduler  = `
 INSERT INTO schedulers (name, game, yaml, state, version, state_last_changed_at)
@@ -173,6 +174,69 @@ func (s schedulerStorage) GetSchedulers(ctx context.Context, names []string) ([]
 		schedulers[i] = scheduler
 	}
 	return schedulers, nil
+}
+
+func (s schedulerStorage) GetSchedulersWithFilter(ctx context.Context, schedulerFilter *filters.SchedulerFilter) ([]*entities.Scheduler, error) {
+	client := s.db.WithContext(ctx)
+	var dbSchedulers []Scheduler
+	queryString := querySimpleGetSchedulers
+
+	where_clauses, arrayValues := createWhereClauses(schedulerFilter)
+
+	queryString = queryString + where_clauses
+	_, err := client.Query(&dbSchedulers, queryString, arrayValues...)
+	if err != nil {
+		return nil, errors.NewErrUnexpected("error getting schedulers").WithError(err)
+	}
+	schedulers := make([]*entities.Scheduler, len(dbSchedulers))
+	for i := range dbSchedulers {
+		scheduler, err := dbSchedulers[i].ToScheduler()
+		if err != nil {
+			return nil, errors.NewErrEncoding("error decoding scheduler %s", dbSchedulers[i].Name).WithError(err)
+		}
+		schedulers[i] = scheduler
+	}
+	return schedulers, nil
+}
+
+func createWhereClauses(schedulerFilter *filters.SchedulerFilter) (string, []interface{}) {
+	clauses := ""
+	values := make([]interface{}, 0, 3)
+
+	if schedulerFilter != nil {
+		thereIsOne := false
+		if schedulerFilter.Game != "" {
+			clauses = clauses + " game = ?"
+			values = append(values, schedulerFilter.Game)
+			thereIsOne = true
+		}
+
+		if schedulerFilter.Name != "" {
+			if thereIsOne == true {
+				clauses = clauses  + " and"
+			}
+
+			clauses = clauses + " name = ?"
+			values = append(values, schedulerFilter.Name)
+			thereIsOne = true
+		}
+
+		if schedulerFilter.Version != "" {
+			if thereIsOne == true {
+				clauses = clauses  + " and"
+			}
+
+			clauses = clauses + " version = ?"
+			values = append(values, schedulerFilter.Version)
+			thereIsOne = true
+		}
+
+		if thereIsOne {
+			clauses = " WHERE" + clauses
+		}
+	}
+
+	return clauses, values
 }
 
 func (s schedulerStorage) GetAllSchedulers(ctx context.Context) ([]*entities.Scheduler, error) {

--- a/internal/adapters/scheduler_storage/pg/pg_test.go
+++ b/internal/adapters/scheduler_storage/pg/pg_test.go
@@ -303,28 +303,28 @@ func TestSchedulerStorage_GetSchedulersWithFilter(t *testing.T) {
 	require.NoError(t, storage.CreateScheduler(context.Background(), scheduler1))
 	require.NoError(t, storage.CreateScheduler(context.Background(), scheduler2))
 
-	t.Run("when filter is nil should return all schedulers", func(t *testing.T){
+	t.Run("when filter is nil should return all schedulers", func(t *testing.T) {
 		actualSchedulers, err := storage.GetSchedulersWithFilter(context.Background(), nil)
 		require.NoError(t, err)
 
 		assertSchedulers(t, []*entities.Scheduler{scheduler1, scheduler2}, actualSchedulers)
 	})
 
-	t.Run("when filter is empty should return all schedulers", func(t *testing.T){
+	t.Run("when filter is empty should return all schedulers", func(t *testing.T) {
 		actualSchedulers, err := storage.GetSchedulersWithFilter(context.Background(), &filters.SchedulerFilter{})
 		require.NoError(t, err)
 
 		assertSchedulers(t, []*entities.Scheduler{scheduler1, scheduler2}, actualSchedulers)
 	})
 
-	t.Run("where there is a filter should filter schedulers", func(t *testing.T){
+	t.Run("where there is a filter should filter schedulers", func(t *testing.T) {
 		actualSchedulers, err := storage.GetSchedulersWithFilter(context.Background(), &filters.SchedulerFilter{Game: "game"})
 		require.NoError(t, err)
 
 		assertSchedulers(t, []*entities.Scheduler{scheduler1}, actualSchedulers)
 	})
 
-	t.Run("where there is a filter and there is no record should return empty array", func(t *testing.T){
+	t.Run("where there is a filter and there is no record should return empty array", func(t *testing.T) {
 		actualSchedulers, err := storage.GetSchedulersWithFilter(context.Background(), &filters.SchedulerFilter{Game: "NON_EXISTENT_GAME"})
 		require.NoError(t, err)
 		require.Empty(t, actualSchedulers)
@@ -677,89 +677,89 @@ func TestSchedulerStorage_createWhereClauses(t *testing.T) {
 	})
 
 	t.Run("should return the where clause and your values", func(t *testing.T) {
-		testCases := []struct{
-			title string
-			schedulerFilter *filters.SchedulerFilter
+		testCases := []struct {
+			title               string
+			schedulerFilter     *filters.SchedulerFilter
 			expectedWhereClause string
-			expectedValues []interface{}
+			expectedValues      []interface{}
 		}{
 			{
 				title: "when none present",
 				schedulerFilter: &filters.SchedulerFilter{
-					Game: "",
-					Name: "",
+					Game:    "",
+					Name:    "",
 					Version: "",
 				},
 				expectedWhereClause: "",
-				expectedValues: []interface{}{},
-			},{
+				expectedValues:      []interface{}{},
+			}, {
 				title: "when present: name, version",
 				schedulerFilter: &filters.SchedulerFilter{
-					Game: "",
-					Name: "Test Name",
+					Game:    "",
+					Name:    "Test Name",
 					Version: "Test Version",
 				},
 				expectedWhereClause: " WHERE name = ? and version = ?",
-				expectedValues: []interface{}{"Test Name", "Test Version"},
-			},{
+				expectedValues:      []interface{}{"Test Name", "Test Version"},
+			}, {
 				title: "when present: game, version",
 				schedulerFilter: &filters.SchedulerFilter{
-					Game: "Test Game",
-					Name: "",
+					Game:    "Test Game",
+					Name:    "",
 					Version: "Test Version",
 				},
 				expectedWhereClause: " WHERE game = ? and version = ?",
-				expectedValues: []interface{}{"Test Game", "Test Version"},
-			},{
+				expectedValues:      []interface{}{"Test Game", "Test Version"},
+			}, {
 				title: "when present: game, name",
 				schedulerFilter: &filters.SchedulerFilter{
-					Game: "Test Game",
-					Name: "Test Name",
+					Game:    "Test Game",
+					Name:    "Test Name",
 					Version: "",
 				},
 				expectedWhereClause: " WHERE game = ? and name = ?",
-				expectedValues: []interface{}{"Test Game", "Test Name"},
-			},{
+				expectedValues:      []interface{}{"Test Game", "Test Name"},
+			}, {
 				title: "when present: version",
 				schedulerFilter: &filters.SchedulerFilter{
-					Game: "",
-					Name: "",
+					Game:    "",
+					Name:    "",
 					Version: "Test Version",
 				},
 				expectedWhereClause: " WHERE version = ?",
-				expectedValues: []interface{}{"Test Version"},
-			},{
+				expectedValues:      []interface{}{"Test Version"},
+			}, {
 				title: "when present: game",
 				schedulerFilter: &filters.SchedulerFilter{
-					Game: "Test Game",
-					Name: "",
+					Game:    "Test Game",
+					Name:    "",
 					Version: "",
 				},
 				expectedWhereClause: " WHERE game = ?",
-				expectedValues: []interface{}{"Test Game"},
-			},{
+				expectedValues:      []interface{}{"Test Game"},
+			}, {
 				title: "when present: name",
 				schedulerFilter: &filters.SchedulerFilter{
-					Game: "",
-					Name: "Test Name",
+					Game:    "",
+					Name:    "Test Name",
 					Version: "",
 				},
 				expectedWhereClause: " WHERE name = ?",
-				expectedValues: []interface{}{"Test Name"},
-			},{
+				expectedValues:      []interface{}{"Test Name"},
+			}, {
 				title: "when present: game, name, version",
 				schedulerFilter: &filters.SchedulerFilter{
-					Game: "Test Game",
-					Name: "Test Name",
+					Game:    "Test Game",
+					Name:    "Test Name",
 					Version: "Test Version",
 				},
 				expectedWhereClause: " WHERE game = ? and name = ? and version = ?",
-				expectedValues: []interface{}{"Test Game", "Test Name", "Test Version"},
+				expectedValues:      []interface{}{"Test Game", "Test Name", "Test Version"},
 			},
 		}
 
-		for _, testCase := range(testCases) {
-			t.Run(testCase.title, func(t *testing.T){
+		for _, testCase := range testCases {
+			t.Run(testCase.title, func(t *testing.T) {
 				whereClause, arrayValues := createWhereClauses(testCase.schedulerFilter)
 				require.Equal(t, testCase.expectedWhereClause, whereClause)
 				require.Equal(t, testCase.expectedValues, arrayValues)

--- a/internal/api/handlers/schedulers_handler.go
+++ b/internal/api/handlers/schedulers_handler.go
@@ -53,7 +53,7 @@ func ProvideSchedulersHandler(schedulerManager *scheduler_manager.SchedulerManag
 }
 
 func (h *SchedulersHandler) ListSchedulers(ctx context.Context, message *api.ListSchedulersRequest) (*api.ListSchedulersResponse, error) {
-	schedulerEntities, err := h.schedulerManager.GetAllSchedulers(ctx)
+	schedulerEntities, err := h.schedulerManager.GetSchedulersWithFilter(ctx, nil)
 	if err != nil {
 		return nil, status.Error(codes.Unknown, err.Error())
 	}

--- a/internal/api/handlers/schedulers_handler_test.go
+++ b/internal/api/handlers/schedulers_handler_test.go
@@ -53,7 +53,7 @@ import (
 	api "github.com/topfreegames/maestro/pkg/api/v1"
 )
 
-func TestGetAllSchedulers(t *testing.T) {
+func TestListSchedulers(t *testing.T) {
 
 	t.Run("with valid request and persisted scheduler", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
@@ -61,7 +61,7 @@ func TestGetAllSchedulers(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil)
 
-		schedulerStorage.EXPECT().GetAllSchedulers(gomock.Any()).Return([]*entities.Scheduler{
+		schedulerStorage.EXPECT().GetSchedulersWithFilter(gomock.Any(), gomock.Any()).Return([]*entities.Scheduler{
 			{
 				Name:            "zooba-us",
 				Game:            "zooba",
@@ -105,7 +105,7 @@ func TestGetAllSchedulers(t *testing.T) {
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil)
 
-		schedulerStorage.EXPECT().GetAllSchedulers(gomock.Any()).Return([]*entities.Scheduler{}, nil)
+		schedulerStorage.EXPECT().GetSchedulersWithFilter(gomock.Any(), gomock.Any()).Return([]*entities.Scheduler{}, nil)
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterSchedulersServiceHandlerServer(context.Background(), mux, ProvideSchedulersHandler(schedulerManager))

--- a/internal/core/filters/scheduler_filter.go
+++ b/internal/core/filters/scheduler_filter.go
@@ -23,6 +23,7 @@
 package filters
 
 type SchedulerFilter struct {
+	Game    string
 	Name    string
 	Version string
 }

--- a/internal/core/ports/scheduler_storage.go
+++ b/internal/core/ports/scheduler_storage.go
@@ -34,6 +34,7 @@ type SchedulerStorage interface {
 	GetSchedulerWithFilter(ctx context.Context, schedulerFilter *filters.SchedulerFilter) (*entities.Scheduler, error)
 	GetSchedulerVersions(ctx context.Context, name string) ([]*entities.SchedulerVersion, error)
 	GetSchedulers(ctx context.Context, names []string) ([]*entities.Scheduler, error)
+	GetSchedulersWithFilter(ctx context.Context, schedulerFilter *filters.SchedulerFilter) ([]*entities.Scheduler, error)
 	GetAllSchedulers(ctx context.Context) ([]*entities.Scheduler, error)
 	CreateScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	UpdateScheduler(ctx context.Context, scheduler *entities.Scheduler) error

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -118,8 +118,8 @@ func (s *SchedulerManager) CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx 
 	return nil
 }
 
-func (s *SchedulerManager) GetAllSchedulers(ctx context.Context) ([]*entities.Scheduler, error) {
-	return s.schedulerStorage.GetAllSchedulers(ctx)
+func (s *SchedulerManager) GetSchedulersWithFilter(ctx context.Context, schedulerFilter *filters.SchedulerFilter) ([]*entities.Scheduler, error) {
+	return s.schedulerStorage.GetSchedulersWithFilter(ctx, schedulerFilter)
 }
 
 func (s *SchedulerManager) GetScheduler(ctx context.Context, schedulerName, version string) (*entities.Scheduler, error) {

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -472,35 +472,36 @@ func TestGetScheduler(t *testing.T) {
 	})
 }
 
-func TestGetAllSchedulers(t *testing.T) {
+func TestGetSchedulersWithFilter(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
-	t.Run("returns a list of schedulers when no error occurs", func(t *testing.T) {
+	t.Run("when no error occurs returns a list of schedulers", func(t *testing.T) {
 		scheduler := newValidScheduler()
 
 		ctx := context.Background()
+		schedulerFilter := &filters.SchedulerFilter{}
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		schedulers := []*entities.Scheduler{scheduler}
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
-		schedulerStorage.EXPECT().GetAllSchedulers(ctx).Return(schedulers, nil)
+		schedulerStorage.EXPECT().GetSchedulersWithFilter(ctx, gomock.Any()).Return(schedulers, nil)
 
-		retScheduler, err := schedulerManager.GetAllSchedulers(ctx)
+		retScheduler, err := schedulerManager.GetSchedulersWithFilter(ctx, schedulerFilter)
 		require.NoError(t, err)
 		require.NotNil(t, retScheduler)
 		require.Equal(t, retScheduler, schedulers)
 	})
 
-	t.Run("returns error when some error occurs", func(t *testing.T) {
+	t.Run("when some error occurs returns error", func(t *testing.T) {
 		ctx := context.Background()
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
-		schedulerStorage.EXPECT().GetAllSchedulers(ctx).Return([]*entities.Scheduler{}, errors.NewErrUnexpected("some error"))
+		schedulerStorage.EXPECT().GetSchedulersWithFilter(ctx, gomock.Any()).Return(nil, errors.NewErrUnexpected("some error"))
 
-		retScheduler, err := schedulerManager.GetAllSchedulers(ctx)
+		retScheduler, err := schedulerManager.GetSchedulersWithFilter(ctx)
 		require.Error(t, err, "some error")
 		require.Empty(t, retScheduler)
 	})

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -495,13 +495,14 @@ func TestGetSchedulersWithFilter(t *testing.T) {
 
 	t.Run("when some error occurs returns error", func(t *testing.T) {
 		ctx := context.Background()
+		schedulerFilter := &filters.SchedulerFilter{}
 		schedulerStorage := schedulerStorageMock.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager)
 
 		schedulerStorage.EXPECT().GetSchedulersWithFilter(ctx, gomock.Any()).Return(nil, errors.NewErrUnexpected("some error"))
 
-		retScheduler, err := schedulerManager.GetSchedulersWithFilter(ctx)
+		retScheduler, err := schedulerManager.GetSchedulersWithFilter(ctx, schedulerFilter)
 		require.Error(t, err, "some error")
 		require.Empty(t, retScheduler)
 	})


### PR DESCRIPTION
### Why
Maestro core `SchedulerManager` doesn't have any filter.

### What

Add feature to filter by Game.

### How
This MR proposes to add in `SchedulerManager` the function `GetSchedulersWithFilter` and add this to the storage as well.