### PR TITLE
chore(viper configs): renames variables out of pattern

### DIFF
--- a/cmd/managementapi/management_api.go
+++ b/cmd/managementapi/management_api.go
@@ -102,19 +102,19 @@ func runManagementServer(ctx context.Context, configs config.Config, mux *runtim
 	muxWithMetrics := std.Handler("", mdlw, mux)
 
 	httpServer := &http.Server{
-		Addr:    fmt.Sprintf(":%s", configs.GetString("management_api.port")),
+		Addr:    fmt.Sprintf(":%s", configs.GetString("managementApi.port")),
 		Handler: muxWithMetrics,
 	}
 
 	go func() {
-		zap.L().Info(fmt.Sprintf("started HTTP management server at :%s", configs.GetString("management_api.port")))
+		zap.L().Info(fmt.Sprintf("started HTTP management server at :%s", configs.GetString("managementApi.port")))
 		if err := httpServer.ListenAndServe(); err != http.ErrServerClosed {
 			zap.L().With(zap.Error(err)).Fatal("failed to start HTTP management server")
 		}
 	}()
 
 	return func() error {
-		shutdownCtx, cancelShutdownFn := context.WithTimeout(context.Background(), configs.GetDuration("management_api.gracefulShutdownTimeout"))
+		shutdownCtx, cancelShutdownFn := context.WithTimeout(context.Background(), configs.GetDuration("managementApi.gracefulShutdownTimeout"))
 		defer cancelShutdownFn()
 
 		zap.L().Info("stopping HTTP management server")

--- a/cmd/roomsapi/rooms_api.go
+++ b/cmd/roomsapi/rooms_api.go
@@ -100,19 +100,19 @@ func runRoomsServer(configs config.Config, mux *runtime.ServeMux) func() error {
 	muxWithMetrics := std.Handler("", mdlw, mux)
 
 	httpServer := &http.Server{
-		Addr:    fmt.Sprintf(":%s", configs.GetString("rooms_api.port")),
+		Addr:    fmt.Sprintf(":%s", configs.GetString("roomsApi.port")),
 		Handler: muxWithMetrics,
 	}
 
 	go func() {
-		zap.L().Info(fmt.Sprintf("started HTTP rooms server at :%s", configs.GetString("rooms_api.port")))
+		zap.L().Info(fmt.Sprintf("started HTTP rooms server at :%s", configs.GetString("roomsApi.port")))
 		if err := httpServer.ListenAndServe(); err != http.ErrServerClosed {
 			zap.L().With(zap.Error(err)).Fatal("failed to start HTTP rooms server")
 		}
 	}()
 
 	return func() error {
-		shutdownCtx, cancelShutdownFn := context.WithTimeout(context.Background(), configs.GetDuration("rooms_api.gracefulShutdownTimeout"))
+		shutdownCtx, cancelShutdownFn := context.WithTimeout(context.Background(), configs.GetDuration("roomsApi.gracefulShutdownTimeout"))
 		defer cancelShutdownFn()
 
 		zap.L().Info("stopping HTTP rooms server")

--- a/config/management-api.local.yaml
+++ b/config/management-api.local.yaml
@@ -1,11 +1,11 @@
-internal_api:
+internalApi:
   port: 8081
   gracefulShutdownTimeout: 10s
   metrics:
     enabled: true
   healthcheck:
     enabled: true
-management_api:
+managementApi:
   port: 8080
   gracefulShutdownTimeout: 10s
 adapters:

--- a/config/rooms-api.local.yaml
+++ b/config/rooms-api.local.yaml
@@ -1,11 +1,11 @@
-internal_api:
+internalApi:
   port: 8081
   gracefulShutdownTimeout: 10s
   metrics:
     enabled: true
   healthcheck:
     enabled: true
-rooms_api:
+roomsApi:
   port: 8080
   gracefulShutdownTimeout: 10s
 adapters:

--- a/config/runtime-watcher.local.yaml
+++ b/config/runtime-watcher.local.yaml
@@ -1,4 +1,4 @@
-internal_api:
+internalApi:
   port: 8081
   gracefulShutdownTimeout: 10s
   metrics:

--- a/config/worker.local.yaml
+++ b/config/worker.local.yaml
@@ -1,4 +1,4 @@
-internal_api:
+internalApi:
   port: 8081
   gracefulShutdownTimeout: 10s
   metrics:

--- a/internal/api/handlers/ping_handler_test.go
+++ b/internal/api/handlers/ping_handler_test.go
@@ -47,9 +47,9 @@ func TestPingHandler(t *testing.T) {
 
 		config := configmock.NewMockConfig(mockCtrl)
 
-		config.EXPECT().GetBool("management_api.enable").Return(true).AnyTimes()
-		config.EXPECT().GetString("management_api.port").Return("8081").AnyTimes()
-		config.EXPECT().GetString("management_api.gracefulShutdownTimeout").Return("10000").AnyTimes()
+		config.EXPECT().GetBool("managementApi.enable").Return(true).AnyTimes()
+		config.EXPECT().GetString("managementApi.port").Return("8081").AnyTimes()
+		config.EXPECT().GetString("managementApi.gracefulShutdownTimeout").Return("10000").AnyTimes()
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterPingServiceHandlerServer(context.Background(), mux, ProvidePingHandler())
@@ -79,9 +79,9 @@ func TestPingHandler(t *testing.T) {
 
 		config := configmock.NewMockConfig(mockCtrl)
 
-		config.EXPECT().GetBool("management_api.enable").Return(true).AnyTimes()
-		config.EXPECT().GetString("management_api.port").Return("8081").AnyTimes()
-		config.EXPECT().GetString("management_api.gracefulShutdownTimeout").Return("10000").AnyTimes()
+		config.EXPECT().GetBool("managementApi.enable").Return(true).AnyTimes()
+		config.EXPECT().GetString("managementApi.port").Return("8081").AnyTimes()
+		config.EXPECT().GetString("managementApi.gracefulShutdownTimeout").Return("10000").AnyTimes()
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterPingServiceHandlerServer(context.Background(), mux, ProvidePingHandler())
@@ -111,9 +111,9 @@ func TestPingHandler(t *testing.T) {
 
 		config := configmock.NewMockConfig(mockCtrl)
 
-		config.EXPECT().GetBool("management_api.enable").Return(true).AnyTimes()
-		config.EXPECT().GetString("management_api.port").Return("8081").AnyTimes()
-		config.EXPECT().GetString("management_api.gracefulShutdownTimeout").Return("10000").AnyTimes()
+		config.EXPECT().GetBool("managementApi.enable").Return(true).AnyTimes()
+		config.EXPECT().GetString("managementApi.port").Return("8081").AnyTimes()
+		config.EXPECT().GetString("managementApi.gracefulShutdownTimeout").Return("10000").AnyTimes()
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterPingServiceHandlerServer(context.Background(), mux, ProvidePingHandler())

--- a/internal/service/internal_api.go
+++ b/internal/service/internal_api.go
@@ -38,30 +38,30 @@ import (
 // - metrics
 func RunInternalServer(ctx context.Context, configs config.Config) func() error {
 	mux := http.NewServeMux()
-	if configs.GetBool("internal_api.healthcheck.enabled") {
+	if configs.GetBool("internalApi.healthcheck.enabled") {
 		zap.L().Info("adding healthcheck handler to internal API")
 		mux.HandleFunc("/health", handleHealth)
 		mux.HandleFunc("/healthz", handleHealth)
 	}
-	if configs.GetBool("internal_api.metrics.enabled") {
+	if configs.GetBool("internalApi.metrics.enabled") {
 		zap.L().Info("adding metrics handler to internal API")
 		mux.Handle("/metrics", promhttp.Handler())
 	}
 
 	httpServer := &http.Server{
-		Addr:    fmt.Sprintf(":%s", configs.GetString("internal_api.port")),
+		Addr:    fmt.Sprintf(":%s", configs.GetString("internalApi.port")),
 		Handler: mux,
 	}
 
 	go func() {
-		zap.L().Info(fmt.Sprintf("started HTTP internal at :%s", configs.GetString("internal_api.port")))
+		zap.L().Info(fmt.Sprintf("started HTTP internal at :%s", configs.GetString("internalApi.port")))
 		if err := httpServer.ListenAndServe(); err != http.ErrServerClosed {
 			zap.L().With(zap.Error(err)).Fatal("failed to start HTTP internal server")
 		}
 	}()
 
 	return func() error {
-		shutdownCtx, cancelShutdownFn := context.WithTimeout(context.Background(), configs.GetDuration("internal_api.gracefulShutdownTimeout"))
+		shutdownCtx, cancelShutdownFn := context.WithTimeout(context.Background(), configs.GetDuration("internalApi.gracefulShutdownTimeout"))
 		defer cancelShutdownFn()
 
 		zap.L().Info("stopping HTTP internal server")


### PR DESCRIPTION
### What?
Renames config variables declared out of pattern
### Why?
The snake case pattern is not a good choice in this case since every env variable is a mix of the nested variables separated with an underscore. Because of it, it becomes ambiguous in the deployment in which context the variable belongs to.
### How?
Simply renaming the variables in the local files and in the code where they are used.