### PR TITLE
fix(kube config): checks if inCluster

### DIFF
--- a/config/rooms-api.local.yaml
+++ b/config/rooms-api.local.yaml
@@ -26,5 +26,6 @@ adapters:
       url: "redis://localhost:6379/0"
   runtime:
     kubernetes:
+      inCluster: false
       masterUrl: "https://127.0.0.1:6443"
       kubeconfig: "./kubeconfig.yaml"

--- a/config/runtime-watcher.local.yaml
+++ b/config/runtime-watcher.local.yaml
@@ -20,6 +20,7 @@ adapters:
       url: "redis://localhost:6379/0"
   runtime:
     kubernetes:
+      inCluster: false
       masterUrl: "https://127.0.0.1:6443"
       kubeconfig: "./kubeconfig.yaml"
   portAllocator:

--- a/config/worker.local.yaml
+++ b/config/worker.local.yaml
@@ -20,6 +20,7 @@ adapters:
       url: "redis://localhost:6379/0"
   runtime:
     kubernetes:
+      inCluster: false
       masterUrl: "https://127.0.0.1:6443"
       kubeconfig: "./kubeconfig.yaml"
   portAllocator:

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -56,6 +56,7 @@ const (
 	// Kubernetes runtime
 	runtimeKubernetesMasterUrlPath  = "adapters.runtime.kubernetes.masterUrl"
 	runtimeKubernetesKubeconfigPath = "adapters.runtime.kubernetes.kubeconfig"
+	runtimeKubernetesInCluster      = "adapters.runtime.kubernetes.inCluster"
 	// Redis operation storage
 	operationStorageRedisUrlPath      = "adapters.operationStorage.redis.url"
 	operationLeaseStorageRedisUrlPath = "adapters.operationLeaseStorage.redis.url"
@@ -91,10 +92,16 @@ func NewEventsForwarder(c config.Config) (forwarder.EventsForwarder, error) {
 }
 
 func NewRuntimeKubernetes(c config.Config) (ports.Runtime, error) {
-	clientSet, err := createKubernetesClient(
-		c.GetString(runtimeKubernetesMasterUrlPath),
-		c.GetString(runtimeKubernetesKubeconfigPath),
-	)
+	var masterUrl string
+	var kubeConfigPath string
+
+	inCluster := c.GetBool(runtimeKubernetesInCluster)
+	if !inCluster {
+		masterUrl = c.GetString(runtimeKubernetesMasterUrlPath)
+		kubeConfigPath = c.GetString(runtimeKubernetesKubeconfigPath)
+	}
+
+	clientSet, err := createKubernetesClient(masterUrl, kubeConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Kubernetes runtime: %w", err)
 	}


### PR DESCRIPTION
### Why?
To deploy maestro next, we have to check if we are inCluster