### PR TITLE
e2e refactor utils to return scheduler instead scheduler name

### DIFF
--- a/e2e/suites/management/add_rooms_test.go
+++ b/e2e/suites/management/add_rooms_test.go
@@ -61,12 +61,12 @@ func TestAddRooms(t *testing.T) {
 
 			addRoomsRequest := &maestroApiV1.AddRoomsRequest{SchedulerName: scheduler.Name, Amount: 1}
 			addRoomsResponse := &maestroApiV1.AddRoomsResponse{}
-			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s/add-rooms", schedulerName), addRoomsRequest, addRoomsResponse)
+			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s/add-rooms", scheduler.Name), addRoomsRequest, addRoomsResponse)
 
 			require.Eventually(t, func() bool {
 				listOperationsRequest := &maestroApiV1.ListOperationsRequest{}
 				listOperationsResponse := &maestroApiV1.ListOperationsResponse{}
-				err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", schedulerName), listOperationsRequest, listOperationsResponse)
+				err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", scheduler.Name), listOperationsRequest, listOperationsResponse)
 				require.NoError(t, err)
 
 				if len(listOperationsResponse.FinishedOperations) < 2 {
@@ -77,12 +77,12 @@ func TestAddRooms(t *testing.T) {
 				return true
 			}, 240*time.Second, time.Second)
 
-			pods, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			pods, err := kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
 			require.NoError(t, err)
 			require.NotEmpty(t, pods.Items)
 
 			require.Eventually(t, func() bool {
-				_, err := instanceStorage.GetInstance(context.Background(), schedulerName, pods.Items[0].ObjectMeta.Name)
+				_, err := instanceStorage.GetInstance(context.Background(), scheduler.Name, pods.Items[0].ObjectMeta.Name)
 
 				return err != nil
 			}, 4*time.Minute, time.Second)
@@ -101,12 +101,12 @@ func TestAddRooms(t *testing.T) {
 
 			addRoomsRequest := &maestroApiV1.AddRoomsRequest{SchedulerName: scheduler.Name, Amount: 1}
 			addRoomsResponse := &maestroApiV1.AddRoomsResponse{}
-			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s/add-rooms", schedulerName), addRoomsRequest, addRoomsResponse)
+			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s/add-rooms", scheduler.Name), addRoomsRequest, addRoomsResponse)
 
 			require.Eventually(t, func() bool {
 				listOperationsRequest := &maestroApiV1.ListOperationsRequest{}
 				listOperationsResponse := &maestroApiV1.ListOperationsResponse{}
-				err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", schedulerName), listOperationsRequest, listOperationsResponse)
+				err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", scheduler.Name), listOperationsRequest, listOperationsResponse)
 				require.NoError(t, err)
 
 				if len(listOperationsResponse.FinishedOperations) < 2 {
@@ -117,12 +117,12 @@ func TestAddRooms(t *testing.T) {
 				return true
 			}, 240*time.Second, time.Second)
 
-			pods, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			pods, err := kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
 			require.NoError(t, err)
 			require.NotEmpty(t, pods.Items)
 
 			require.Eventually(t, func() bool {
-				room, err := roomsStorage.GetRoom(context.Background(), schedulerName, pods.Items[0].ObjectMeta.Name)
+				room, err := roomsStorage.GetRoom(context.Background(), scheduler.Name, pods.Items[0].ObjectMeta.Name)
 
 				return err == nil && room.Status == game_room.GameStatusReady
 			}, time.Minute, time.Second)

--- a/e2e/suites/management/add_rooms_test.go
+++ b/e2e/suites/management/add_rooms_test.go
@@ -51,7 +51,7 @@ func TestAddRooms(t *testing.T) {
 		t.Run("when created rooms does not reply its state back then they're finished", func(t *testing.T) {
 			t.Parallel()
 
-			schedulerName, err := createSchedulerAndWaitForIt(
+			scheduler, err := createSchedulerAndWaitForIt(
 				t,
 				maestro,
 				managementApiClient,
@@ -59,7 +59,7 @@ func TestAddRooms(t *testing.T) {
 				[]string{"sh", "-c", "tail -f /dev/null"},
 			)
 
-			addRoomsRequest := &maestroApiV1.AddRoomsRequest{SchedulerName: schedulerName, Amount: 1}
+			addRoomsRequest := &maestroApiV1.AddRoomsRequest{SchedulerName: scheduler.Name, Amount: 1}
 			addRoomsResponse := &maestroApiV1.AddRoomsResponse{}
 			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s/add-rooms", schedulerName), addRoomsRequest, addRoomsResponse)
 
@@ -91,7 +91,7 @@ func TestAddRooms(t *testing.T) {
 		t.Run("when created rooms replies its state back then it finishes the operation successfully", func(t *testing.T) {
 			t.Parallel()
 
-			schedulerName, err := createSchedulerAndWaitForIt(t,
+			scheduler, err := createSchedulerAndWaitForIt(t,
 				maestro,
 				managementApiClient,
 				kubeClient,
@@ -99,7 +99,7 @@ func TestAddRooms(t *testing.T) {
 					"$ROOMS_API_ADDRESS:9097/scheduler/$MAESTRO_SCHEDULER_NAME/rooms/$MAESTRO_ROOM_ID/ping " +
 					"--data-raw '{\"status\": \"ready\",\"timestamp\": \"12312312313\"}'"})
 
-			addRoomsRequest := &maestroApiV1.AddRoomsRequest{SchedulerName: schedulerName, Amount: 1}
+			addRoomsRequest := &maestroApiV1.AddRoomsRequest{SchedulerName: scheduler.Name, Amount: 1}
 			addRoomsResponse := &maestroApiV1.AddRoomsResponse{}
 			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s/add-rooms", schedulerName), addRoomsRequest, addRoomsResponse)
 

--- a/e2e/suites/management/events_forwarding_test.go
+++ b/e2e/suites/management/events_forwarding_test.go
@@ -496,7 +496,7 @@ func TestEventsForwarding(t *testing.T) {
 }
 
 func createSchedulerWithRooms(t *testing.T, maestro *maestro.MaestroInstance, kubeClient kubernetes.Interface, managementApiClient *framework.APIClient) (string, string) {
-	schedulerName, err := createSchedulerAndWaitForIt(t,
+	scheduler, err := createSchedulerAndWaitForIt(t,
 		maestro,
 		managementApiClient,
 		kubeClient,
@@ -505,14 +505,14 @@ func createSchedulerWithRooms(t *testing.T, maestro *maestro.MaestroInstance, ku
 			"--data-raw '{\"status\": \"ready\",\"timestamp\": \"12312312313\"}'"},
 	)
 
-	addRoomsRequest := &maestroApiV1.AddRoomsRequest{SchedulerName: schedulerName, Amount: 1}
+	addRoomsRequest := &maestroApiV1.AddRoomsRequest{SchedulerName: scheduler.Name, Amount: 1}
 	addRoomsResponse := &maestroApiV1.AddRoomsResponse{}
-	err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s/add-rooms", schedulerName), addRoomsRequest, addRoomsResponse)
+	err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s/add-rooms", scheduler.Name), addRoomsRequest, addRoomsResponse)
 
 	require.Eventually(t, func() bool {
 		listOperationsRequest := &maestroApiV1.ListOperationsRequest{}
 		listOperationsResponse := &maestroApiV1.ListOperationsResponse{}
-		err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", schedulerName), listOperationsRequest, listOperationsResponse)
+		err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", scheduler.Name), listOperationsRequest, listOperationsResponse)
 		require.NoError(t, err)
 
 		if len(listOperationsResponse.FinishedOperations) < 2 {
@@ -523,11 +523,11 @@ func createSchedulerWithRooms(t *testing.T, maestro *maestro.MaestroInstance, ku
 		return true
 	}, 240*time.Second, time.Second)
 
-	pods, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+	pods, err := kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.NotEmpty(t, pods.Items)
 
-	return schedulerName, pods.Items[0].Name
+	return scheduler.Name, pods.Items[0].Name
 }
 
 func createSchedulerWithForwarderAndRooms(t *testing.T, maestro *maestro.MaestroInstance, kubeClient kubernetes.Interface, managementApiClient *framework.APIClient, forwarderAddress string) (string, string) {

--- a/e2e/suites/management/get_scheduler_test.go
+++ b/e2e/suites/management/get_scheduler_test.go
@@ -42,7 +42,7 @@ func TestGetScheduler(t *testing.T) {
 		t.Run("Should Succeed - Get scheduler without query parameter version", func(t *testing.T) {
 			t.Parallel()
 
-			schedulerName, err := createSchedulerAndWaitForIt(
+			scheduler, err := createSchedulerAndWaitForIt(
 				t,
 				maestro,
 				managementApiClient,
@@ -53,16 +53,16 @@ func TestGetScheduler(t *testing.T) {
 			getSchedulerRequest := &maestroApiV1.GetSchedulerRequest{}
 			getSchedulerResponse := &maestroApiV1.GetSchedulerResponse{}
 
-			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", schedulerName), getSchedulerRequest, getSchedulerResponse)
+			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", scheduler.Name), getSchedulerRequest, getSchedulerResponse)
 
 			require.NoError(t, err)
-			require.Equal(t, getSchedulerResponse.Scheduler.Name, schedulerName)
+			require.Equal(t, getSchedulerResponse.Scheduler.Name, scheduler.Name)
 		})
 
 		t.Run("Should Fail - Get scheduler 404 with non-existent query version", func(t *testing.T) {
 			t.Parallel()
 
-			schedulerName, err := createSchedulerAndWaitForIt(
+			scheduler, err := createSchedulerAndWaitForIt(
 				t,
 				maestro,
 				managementApiClient,
@@ -70,12 +70,12 @@ func TestGetScheduler(t *testing.T) {
 				[]string{"sh", "-c", "tail -f /dev/null"},
 			)
 
-			getSchedulerRequest := &maestroApiV1.GetSchedulerRequest{SchedulerName: schedulerName}
+			getSchedulerRequest := &maestroApiV1.GetSchedulerRequest{SchedulerName: scheduler.Name}
 			getSchedulerResponse := &maestroApiV1.GetSchedulerResponse{}
 
-			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s?version=non-existent", schedulerName), getSchedulerRequest, getSchedulerResponse)
+			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s?version=non-existent", scheduler.Name), getSchedulerRequest, getSchedulerResponse)
 
-			require.Error(t, err, "failed with status 404, response body: {\"code\":5, \"message\":\"scheduler "+schedulerName+" not found\", \"details\":[]}")
+			require.Error(t, err, "failed with status 404, response body: {\"code\":5, \"message\":\"scheduler "+scheduler.Name+" not found\", \"details\":[]}")
 		})
 
 		t.Run("Should Fail - non-existent scheduler", func(t *testing.T) {
@@ -92,7 +92,7 @@ func TestGetScheduler(t *testing.T) {
 		t.Run("Should succeed - Get scheduler with query version", func(t *testing.T) {
 			t.Parallel()
 
-			schedulerName, err := createSchedulerAndWaitForIt(
+			scheduler, err := createSchedulerAndWaitForIt(
 				t,
 				maestro,
 				managementApiClient,
@@ -100,13 +100,13 @@ func TestGetScheduler(t *testing.T) {
 				[]string{"sh", "-c", "tail -f /dev/null"},
 			)
 
-			getSchedulerRequest := &maestroApiV1.GetSchedulerRequest{SchedulerName: schedulerName}
+			getSchedulerRequest := &maestroApiV1.GetSchedulerRequest{SchedulerName: scheduler.Name}
 			getSchedulerResponse := &maestroApiV1.GetSchedulerResponse{}
 
-			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s?version=v1.1", schedulerName), getSchedulerRequest, getSchedulerResponse)
+			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s?version=v1.1", scheduler.Name), getSchedulerRequest, getSchedulerResponse)
 
 			require.NoError(t, err)
-			require.Equal(t, getSchedulerResponse.Scheduler.Name, schedulerName)
+			require.Equal(t, getSchedulerResponse.Scheduler.Name, scheduler.Name)
 			require.Equal(t, getSchedulerResponse.Scheduler.GetVersion(), "v1.1")
 		})
 

--- a/e2e/suites/management/utils.go
+++ b/e2e/suites/management/utils.go
@@ -44,7 +44,7 @@ func createSchedulerAndWaitForIt(
 	maestro *maestro.MaestroInstance,
 	managementApiClient *framework.APIClient,
 	kubeClient kubernetes.Interface,
-	gruCommand []string) (string, error) {
+	gruCommand []string) (*maestroApiV1.Scheduler, error) {
 	schedulerName := framework.GenerateSchedulerName()
 	createRequest := &maestroApiV1.CreateSchedulerRequest{
 		Name:                   schedulerName,
@@ -119,7 +119,7 @@ func createSchedulerAndWaitForIt(
 
 		return len(svcAccs.Items) > 0
 	}, 5*time.Second, time.Second)
-	return schedulerName, err
+	return createResponse.Scheduler, err
 }
 
 func createSchedulerWithForwardersAndWaitForIt(

--- a/e2e/suites/management/utils.go
+++ b/e2e/suites/management/utils.go
@@ -227,7 +227,7 @@ func addStubRequestToMockedGrpcServer(stubFileName string) error {
 
 func createSchedulerWithRoomsAndWaitForIt(t *testing.T, maestro *maestro.MaestroInstance, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface) (string, error) {
 	// Create scheduler
-	schedulerName, err := createSchedulerAndWaitForIt(
+	scheduler, err := createSchedulerAndWaitForIt(
 		t,
 		maestro,
 		managementApiClient,
@@ -239,13 +239,13 @@ func createSchedulerWithRoomsAndWaitForIt(t *testing.T, maestro *maestro.Maestro
 
 	// Add rooms to the created scheduler
 	// TODO(guilhermecarvalho): when autoscaling is implemented, this part of the test can be deleted
-	addRoomsRequest := &maestroApiV1.AddRoomsRequest{SchedulerName: schedulerName, Amount: 2}
+	addRoomsRequest := &maestroApiV1.AddRoomsRequest{SchedulerName: scheduler.Name, Amount: 2}
 	addRoomsResponse := &maestroApiV1.AddRoomsResponse{}
-	err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s/add-rooms", schedulerName), addRoomsRequest, addRoomsResponse)
+	err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s/add-rooms", scheduler.Name), addRoomsRequest, addRoomsResponse)
 	require.NoError(t, err)
 
-	waitForOperationToFinish(t, managementApiClient, schedulerName, "add_rooms")
-	return schedulerName, err
+	waitForOperationToFinish(t, managementApiClient, scheduler.Name, "add_rooms")
+	return scheduler.Name, err
 }
 
 func waitForOperationToFinish(t *testing.T, managementApiClient *framework.APIClient, schedulerName, operation string) {

--- a/e2e/suites/management/utils.go
+++ b/e2e/suites/management/utils.go
@@ -129,7 +129,7 @@ func createSchedulerWithForwardersAndWaitForIt(
 	kubeClient kubernetes.Interface,
 	gruCommand []string,
 	forwarders []*maestroApiV1.Forwarder,
-) (string, error) {
+) (*maestroApiV1.Scheduler, error) {
 	schedulerName := framework.GenerateSchedulerName()
 	createRequest := &maestroApiV1.CreateSchedulerRequest{
 		Name:                   schedulerName,
@@ -201,7 +201,7 @@ func createSchedulerWithForwardersAndWaitForIt(
 
 		return len(svcAccs.Items) > 0
 	}, 5*time.Second, time.Second)
-	return schedulerName, err
+	return createResponse.Scheduler, err
 }
 
 func addStubRequestToMockedGrpcServer(stubFileName string) error {
@@ -225,7 +225,7 @@ func addStubRequestToMockedGrpcServer(stubFileName string) error {
 	return nil
 }
 
-func createSchedulerWithRoomsAndWaitForIt(t *testing.T, maestro *maestro.MaestroInstance, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface) (string, error) {
+func createSchedulerWithRoomsAndWaitForIt(t *testing.T, maestro *maestro.MaestroInstance, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface) (*maestroApiV1.Scheduler, error) {
 	// Create scheduler
 	scheduler, err := createSchedulerAndWaitForIt(
 		t,
@@ -245,7 +245,7 @@ func createSchedulerWithRoomsAndWaitForIt(t *testing.T, maestro *maestro.Maestro
 	require.NoError(t, err)
 
 	waitForOperationToFinish(t, managementApiClient, scheduler.Name, "add_rooms")
-	return scheduler.Name, err
+	return scheduler, err
 }
 
 func waitForOperationToFinish(t *testing.T, managementApiClient *framework.APIClient, schedulerName, operation string) {


### PR DESCRIPTION
### Why
Currently, e2e utils functions return the scheduler name, but we need other fields to use along with tests.

### What
Return entire Scheduler in utils functions.

### How
Refactoring utils functions to return a scheduler.
Refactoring tests to use scheduler instead of scheduler name.