### PR TITLE
chore(validations): create validation for kube resource name

### DIFF
--- a/internal/core/entities/game_room/container.go
+++ b/internal/core/entities/game_room/container.go
@@ -23,7 +23,7 @@
 package game_room
 
 type Container struct {
-	Name            string                 `validate:"required"`
+	Name            string                 `validate:"required,kube_resource_name"`
 	Image           string                 `validate:"required"`
 	ImagePullPolicy string                 `validate:"required,image_pull_policy"`
 	Command         []string               `validate:"required"`

--- a/internal/core/entities/scheduler.go
+++ b/internal/core/entities/scheduler.go
@@ -48,7 +48,7 @@ const (
 )
 
 type Scheduler struct {
-	Name            string `validate:"required"`
+	Name            string `validate:"required,kube_resource_name"`
 	Game            string `validate:"required"`
 	State           string `validate:"required"`
 	RollbackVersion string

--- a/internal/core/ports/mock/rooms_ports_mock.go
+++ b/internal/core/ports/mock/rooms_ports_mock.go
@@ -155,20 +155,6 @@ func (mr *MockRoomManagerMockRecorder) UpdateRoomInstance(ctx, gameRoomInstance 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoomInstance", reflect.TypeOf((*MockRoomManager)(nil).UpdateRoomInstance), ctx, gameRoomInstance)
 }
 
-// ValidateGameRoomCreation mocks base method.
-func (m *MockRoomManager) ValidateGameRoomCreation(ctx context.Context, scheduler *entities.Scheduler) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateGameRoomCreation", ctx, scheduler)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ValidateGameRoomCreation indicates an expected call of ValidateGameRoomCreation.
-func (mr *MockRoomManagerMockRecorder) ValidateGameRoomCreation(ctx, scheduler interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateGameRoomCreation", reflect.TypeOf((*MockRoomManager)(nil).ValidateGameRoomCreation), ctx, scheduler)
-}
-
 // WaitRoomStatus mocks base method.
 func (m *MockRoomManager) WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status game_room.GameRoomStatus) error {
 	m.ctrl.T.Helper()

--- a/internal/core/validations/validations.go
+++ b/internal/core/validations/validations.go
@@ -80,10 +80,10 @@ func IsVersionValid(version string) bool {
 	return err == nil
 }
 
-// IsNameValidOnKube check if name is valid for kubernetes resources (RFC 1123)
+// IsKubeResourceNameValid check if name is valid for kubernetes resources (RFC 1123)
 // Since regexp does not support lookbehind, we test directly the last character before
 // matching the string name.
-func IsNameValidOnKube(name string) bool {
+func IsKubeResourceNameValid(name string) bool {
 	const (
 		minNameLength           = 1
 		maxNameLength           = 63

--- a/internal/core/validations/validations_test.go
+++ b/internal/core/validations/validations_test.go
@@ -26,78 +26,78 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsMaxSurgeValid(t *testing.T) {
 	t.Run("with success when max surge is a number greater than zero", func(t *testing.T) {
 		maxSurgeValid := IsMaxSurgeValid("5")
-		require.True(t, maxSurgeValid)
+		assert.True(t, maxSurgeValid)
 	})
 
 	t.Run("with success when maxSurge is a number greater than zero with suffix '%'", func(t *testing.T) {
 		maxSurgeValid := IsMaxSurgeValid("5%")
-		require.True(t, maxSurgeValid)
+		assert.True(t, maxSurgeValid)
 	})
 
 	t.Run("fails when maxSurge is empty", func(t *testing.T) {
 		maxSurgeValid := IsMaxSurgeValid("")
-		require.False(t, maxSurgeValid)
+		assert.False(t, maxSurgeValid)
 	})
 
 	t.Run("fails when maxSurge is less or equal zero", func(t *testing.T) {
 		maxSurgeValid := IsMaxSurgeValid("0")
-		require.False(t, maxSurgeValid)
+		assert.False(t, maxSurgeValid)
 	})
 }
 
 func TestIsImagePullPolicySupported(t *testing.T) {
 	t.Run("with success when policy is supported by maestro", func(t *testing.T) {
 		supported := IsImagePullPolicySupported("Always")
-		require.True(t, supported)
+		assert.True(t, supported)
 	})
 
 	t.Run("fails when policy is not supported by maestro", func(t *testing.T) {
 		wrongPolicy := "unsupported"
 		supported := IsImagePullPolicySupported(wrongPolicy)
-		require.False(t, supported)
+		assert.False(t, supported)
 	})
 }
 
 func TestIsProtocolSupported(t *testing.T) {
 	t.Run("with success when port protocol is supported by maestro", func(t *testing.T) {
 		supported := IsProtocolSupported("tcp")
-		require.True(t, supported)
+		assert.True(t, supported)
 	})
 
 	t.Run("fails when port protocol is not supported by maestro", func(t *testing.T) {
 		wrongProtocol := "unsupported"
 		supported := IsProtocolSupported(wrongProtocol)
-		require.False(t, supported)
+		assert.False(t, supported)
 	})
 }
 
 func TestIsVersionValid(t *testing.T) {
 	t.Run("with success when semantic version is valid", func(t *testing.T) {
 		valid := IsVersionValid("1.0.0-rc")
-		require.True(t, valid)
+		assert.True(t, valid)
 	})
 
 	t.Run("fails when policy is not supported by maestro", func(t *testing.T) {
 		invalid := IsVersionValid("0x0x0")
-		require.False(t, invalid)
+		assert.False(t, invalid)
 	})
 }
 
-func TestIsNameValidOnKube(t *testing.T) {
+func TestIsKubeResourceNameValid(t *testing.T) {
 	t.Run("should succeed - name is valid", func(t *testing.T) {
 		nameMinLength := "a"
 		usualName := "pod-sdf123-g1"
 		nameMaxLength := "pod-bgvaoifdbgalsidubalisdfgalisdfbgaidsfgyubalosidbyasolfugyba"
 
-		require.True(t, IsNameValidOnKube(nameMinLength))
-		require.True(t, IsNameValidOnKube(usualName))
-		require.True(t, IsNameValidOnKube(nameMaxLength))
+		assert.True(t, IsKubeResourceNameValid(nameMinLength))
+		assert.True(t, IsKubeResourceNameValid(usualName))
+		assert.True(t, IsKubeResourceNameValid(nameMaxLength))
 	})
 
 	invalidCharactersBorders := "-$*_./#%()&^'\"\\Ωœ∑ø˚¬≤µ˜∫≈çå"
@@ -105,26 +105,26 @@ func TestIsNameValidOnKube(t *testing.T) {
 	t.Run("should fail - name starts with invalid characters", func(t *testing.T) {
 		for _, char := range invalidCharactersBorders {
 			name := fmt.Sprintf("%cpod", char)
-			require.False(t, IsNameValidOnKube(name))
+			assert.False(t, IsKubeResourceNameValid(name))
 		}
 	})
 
 	t.Run("should fail - name have invalid characters", func(t *testing.T) {
 		for _, char := range invalidCharactersMiddle {
 			name := fmt.Sprintf("pod%cpod", char)
-			require.False(t, IsNameValidOnKube(name))
+			assert.False(t, IsKubeResourceNameValid(name))
 		}
 	})
 
 	t.Run("should fail - name ends with invalid characters", func(t *testing.T) {
 		for _, char := range invalidCharactersBorders {
 			name := fmt.Sprintf("pod%c", char)
-			require.False(t, IsNameValidOnKube(name))
+			assert.False(t, IsKubeResourceNameValid(name))
 		}
 	})
 
 	t.Run("should fail - name is too long", func(t *testing.T) {
 		nameMaxLengthPlusOne := "pod-bgvaoifdbgalsidubalisdfgalisdfbgaidsfgyubalosidbyasolfugyba1"
-		require.False(t, IsNameValidOnKube(nameMaxLengthPlusOne))
+		assert.False(t, IsKubeResourceNameValid(nameMaxLengthPlusOne))
 	})
 }

--- a/internal/core/validations/validations_test.go
+++ b/internal/core/validations/validations_test.go
@@ -23,6 +23,7 @@
 package validations
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -85,5 +86,45 @@ func TestIsVersionValid(t *testing.T) {
 	t.Run("fails when policy is not supported by maestro", func(t *testing.T) {
 		invalid := IsVersionValid("0x0x0")
 		require.False(t, invalid)
+	})
+}
+
+func TestIsNameValidOnKube(t *testing.T) {
+	t.Run("should succeed - name is valid", func(t *testing.T) {
+		nameMinLength := "a"
+		usualName := "pod-sdf123-g1"
+		nameMaxLength := "pod-bgvaoifdbgalsidubalisdfgalisdfbgaidsfgyubalosidbyasolfugyba"
+
+		require.True(t, IsNameValidOnKube(nameMinLength))
+		require.True(t, IsNameValidOnKube(usualName))
+		require.True(t, IsNameValidOnKube(nameMaxLength))
+	})
+
+	invalidCharactersBorders := "-$*_./#%()&^'\"\\Ωœ∑ø˚¬≤µ˜∫≈çå"
+	invalidCharactersMiddle := "$*_./#%()&^'\"\\Ωœ∑ø˚¬≤µ˜∫≈çå"
+	t.Run("should fail - name starts with invalid characters", func(t *testing.T) {
+		for _, char := range invalidCharactersBorders {
+			name := fmt.Sprintf("%cpod", char)
+			require.False(t, IsNameValidOnKube(name))
+		}
+	})
+
+	t.Run("should fail - name have invalid characters", func(t *testing.T) {
+		for _, char := range invalidCharactersMiddle {
+			name := fmt.Sprintf("pod%cpod", char)
+			require.False(t, IsNameValidOnKube(name))
+		}
+	})
+
+	t.Run("should fail - name ends with invalid characters", func(t *testing.T) {
+		for _, char := range invalidCharactersBorders {
+			name := fmt.Sprintf("pod%c", char)
+			require.False(t, IsNameValidOnKube(name))
+		}
+	})
+
+	t.Run("should fail - name is too long", func(t *testing.T) {
+		nameMaxLengthPlusOne := "pod-bgvaoifdbgalsidubalisdfgalisdfbgaidsfgyubalosidbyasolfugyba1"
+		require.False(t, IsNameValidOnKube(nameMaxLengthPlusOne))
 	})
 }

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -57,6 +57,11 @@ func RegisterValidations() error {
 		return errors.New("could not register maxSurgeValidate")
 	}
 
+	err = Validate.RegisterValidation("kube_resource_name", kubeResourceNameValidate)
+	if err != nil {
+		return errors.New("could not register kubeResourceNameValidate")
+	}
+
 	if Validate == nil {
 		return errors.New("it was not possible to register validations")
 	}
@@ -77,4 +82,8 @@ func maxSurgeValidate(fl validator.FieldLevel) bool {
 
 func semanticValidate(fl validator.FieldLevel) bool {
 	return validations.IsVersionValid(fl.Field().String())
+}
+
+func kubeResourceNameValidate(fl validator.FieldLevel) bool {
+	return validations.IsNameValidOnKube(fl.Field().String())
 }

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -85,5 +85,5 @@ func semanticValidate(fl validator.FieldLevel) bool {
 }
 
 func kubeResourceNameValidate(fl validator.FieldLevel) bool {
-	return validations.IsNameValidOnKube(fl.Field().String())
+	return validations.IsKubeResourceNameValid(fl.Field().String())
 }


### PR DESCRIPTION
### What?
- Create validation methods for kube resources names.
### Why?
- Since containers and schedulers are completely related to Kubernetes pods and namespaces, we need to validate if they follow the kubernetes rules for naming, otherwise Maestro will not be able to create those resources, resulting in an error.
### How?
- Following the RFC 1123 through kubernetes documentation. https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
