### PR TITLE
removing scheduler when create scheduler operation fails

### DIFF
--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -68,7 +68,7 @@ func ProvideExecutors(
 ) map[string]operations.Executor {
 
 	executors := map[string]operations.Executor{}
-	executors[create_scheduler.OperationName] = create_scheduler.NewExecutor(runtime, schedulerStorage)
+	executors[create_scheduler.OperationName] = create_scheduler.NewExecutor(runtime, schedulerManager)
 	executors[add_rooms.OperationName] = add_rooms.NewExecutor(roomManager, schedulerStorage)
 	executors[remove_rooms.OperationName] = remove_rooms.NewExecutor(roomManager)
 	executors[test_operation.OperationName] = test_operation.NewExecutor()

--- a/internal/core/ports/mock/rooms_ports_mock.go
+++ b/internal/core/ports/mock/rooms_ports_mock.go
@@ -155,20 +155,6 @@ func (mr *MockRoomManagerMockRecorder) UpdateRoomInstance(ctx, gameRoomInstance 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoomInstance", reflect.TypeOf((*MockRoomManager)(nil).UpdateRoomInstance), ctx, gameRoomInstance)
 }
 
-// ValidateGameRoomCreation mocks base method.
-func (m *MockRoomManager) ValidateGameRoomCreation(ctx context.Context, scheduler *entities.Scheduler) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateGameRoomCreation", ctx, scheduler)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ValidateGameRoomCreation indicates an expected call of ValidateGameRoomCreation.
-func (mr *MockRoomManagerMockRecorder) ValidateGameRoomCreation(ctx, scheduler interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateGameRoomCreation", reflect.TypeOf((*MockRoomManager)(nil).ValidateGameRoomCreation), ctx, scheduler)
-}
-
 // WaitRoomStatus mocks base method.
 func (m *MockRoomManager) WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status game_room.GameRoomStatus) error {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/mock/scheduler_ports_mock.go
+++ b/internal/core/ports/mock/scheduler_ports_mock.go
@@ -67,6 +67,20 @@ func (mr *MockSchedulerManagerMockRecorder) CreateNewSchedulerVersionAndEnqueueS
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewSchedulerVersionAndEnqueueSwitchVersion", reflect.TypeOf((*MockSchedulerManager)(nil).CreateNewSchedulerVersionAndEnqueueSwitchVersion), ctx, scheduler, replacePods)
 }
 
+// DeleteScheduler mocks base method.
+func (m *MockSchedulerManager) DeleteScheduler(ctx context.Context, schedulerName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteScheduler", ctx, schedulerName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteScheduler indicates an expected call of DeleteScheduler.
+func (mr *MockSchedulerManagerMockRecorder) DeleteScheduler(ctx, schedulerName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScheduler", reflect.TypeOf((*MockSchedulerManager)(nil).DeleteScheduler), ctx, schedulerName)
+}
+
 // EnqueueSwitchActiveVersionOperation mocks base method.
 func (m *MockSchedulerManager) EnqueueSwitchActiveVersionOperation(ctx context.Context, newScheduler *entities.Scheduler, replacePods bool) (*operation.Operation, error) {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/scheduler_ports.go
+++ b/internal/core/ports/scheduler_ports.go
@@ -41,6 +41,7 @@ type SchedulerManager interface {
 	EnqueueSwitchActiveVersionOperation(ctx context.Context, newScheduler *entities.Scheduler, replacePods bool) (*operation.Operation, error)
 	SwitchActiveVersion(ctx context.Context, schedulerName string, targetVersion string) (*operation.Operation, error)
 	GetSchedulersInfo(ctx context.Context, filter *filters.SchedulerFilter) ([]*entities.SchedulerInfo, error)
+	DeleteScheduler(ctx context.Context, schedulerName string) error
 }
 
 // Secondary ports (output, driven ports)

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -262,6 +262,20 @@ func (s *SchedulerManager) GetSchedulersInfo(ctx context.Context, filter *filter
 	return schedulersInfo, nil
 }
 
+func (s *SchedulerManager) DeleteScheduler(ctx context.Context, schedulerName string) error {
+	scheduler, err := s.schedulerStorage.GetScheduler(ctx, schedulerName)
+	if err != nil {
+		return fmt.Errorf("no scheduler found to delete: %w", err)
+	}
+
+	err = s.schedulerStorage.DeleteScheduler(ctx, scheduler)
+	if err != nil {
+		return fmt.Errorf("not able to delete scheduler %s: %w", schedulerName, err)
+	}
+
+	return nil
+}
+
 func (s *SchedulerManager) newSchedulerInfo(ctx context.Context, scheduler *entities.Scheduler) (*entities.SchedulerInfo, error) {
 	ready, err := s.roomStorage.GetRoomCountByStatus(ctx, scheduler.Name, game_room.GameStatusReady)
 	if err != nil {


### PR DESCRIPTION
### What?
Changing behavior from CreateSchedulerOperationOnError func. For now, we'll delete scheduler when error occur on execute operation. 
### How?
- Since we already have a func to delete a scheduler on adapter layer. I implementing a new func on domain services to deal with this action.
- On OnError func we changes the behavior, instead of update status with error now we are deleting scheduler from database with cascade mode.