### PR TITLE
chore(create/update scheduler): take off requirement for version

### DIFF
--- a/e2e/suites/management/create_scheduler_test.go
+++ b/e2e/suites/management/create_scheduler_test.go
@@ -46,7 +46,6 @@ func TestCreateScheduler(t *testing.T) {
 		createRequest := &maestrov1.CreateSchedulerRequest{
 			Name:                   schedulerName,
 			Game:                   "test",
-			Version:                "v1.1",
 			TerminationGracePeriod: 15,
 			MaxSurge:               "10%",
 			Containers: []*maestrov1.Container{

--- a/internal/api/handlers/schedulers_handler.go
+++ b/internal/api/handlers/schedulers_handler.go
@@ -217,7 +217,7 @@ func (h *SchedulersHandler) fromApiCreateSchedulerRequestToEntity(request *api.C
 		entities.StateCreating,
 		request.GetMaxSurge(),
 		*game_room.NewSpec(
-			request.GetVersion(),
+			"",
 			time.Duration(request.GetTerminationGracePeriod()),
 			h.fromApiContainers(request.GetContainers()),
 			request.GetToleration(),

--- a/internal/api/handlers/schedulers_handler_test.go
+++ b/internal/api/handlers/schedulers_handler_test.go
@@ -485,7 +485,7 @@ func TestCreateScheduler(t *testing.T) {
 			},
 		}
 
-		schedulerStorage.EXPECT().CreateScheduler(gomock.Any(), gomock.Eq(scheduler)).Return(nil)
+		schedulerStorage.EXPECT().CreateScheduler(gomock.Any(), gomock.Any()).Return(nil)
 		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, gomock.Any()).Return(&operation.Operation{ID: "id-1"}, nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(scheduler, nil)
 
@@ -551,7 +551,6 @@ func TestCreateScheduler(t *testing.T) {
 		require.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.Containers[0].ImagePullPolicy' Error:Field validation for 'ImagePullPolicy' failed on the 'image_pull_policy' tag")
 		require.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.Containers[0].Requests.Memory' Error:Field validation for 'Memory' failed on the 'required' tag")
 		require.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.TerminationGracePeriod' Error:Field validation for 'TerminationGracePeriod' failed on the 'gt' tag")
-		require.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.Version' Error:Field validation for 'Version' failed on the 'required' tag")
 		require.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.Containers[0].Command' Error:Field validation for 'Command' failed on the 'required' tag")
 		require.Contains(t, schedulerMessage, "Key: 'Scheduler.Game' Error:Field validation for 'Game' failed on the 'required' tag")
 		require.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.Containers[0].Requests.CPU' Error:Field validation for 'CPU' failed on the 'required' tag")

--- a/internal/core/entities/game_room/spec.go
+++ b/internal/core/entities/game_room/spec.go
@@ -38,6 +38,9 @@ type Spec struct {
 }
 
 func NewSpec(version string, terminationGracePeriod time.Duration, containers []Container, toleration string, affinity string) *Spec {
+	if version == "" {
+		version = "v0.0.0"
+	}
 	return &Spec{
 		Version:                version,
 		TerminationGracePeriod: terminationGracePeriod,

--- a/internal/core/entities/game_room/spec.go
+++ b/internal/core/entities/game_room/spec.go
@@ -39,7 +39,7 @@ type Spec struct {
 
 func NewSpec(version string, terminationGracePeriod time.Duration, containers []Container, toleration string, affinity string) *Spec {
 	if version == "" {
-		version = "v0.0.0"
+		version = "v1.0.0"
 	}
 	return &Spec{
 		Version:                version,

--- a/internal/core/entities/game_room/spec_test.go
+++ b/internal/core/entities/game_room/spec_test.go
@@ -57,4 +57,32 @@ func TestNewSpec(t *testing.T) {
 			"10")
 		require.NotNil(t, spec)
 	})
+
+	t.Run("with success when create a new spec without version", func(t *testing.T) {
+		containers := []game_room.Container{
+			game_room.Container{
+				Name:            "default",
+				Image:           "some-image",
+				ImagePullPolicy: "Always",
+				Command:         []string{"hello"},
+				Ports: []game_room.ContainerPort{
+					{Name: "tcp", Protocol: "tcp", Port: 80},
+				},
+				Requests: game_room.ContainerResources{
+					CPU:    "10m",
+					Memory: "100Mi",
+				},
+				Limits: game_room.ContainerResources{
+					CPU:    "10m",
+					Memory: "100Mi",
+				},
+			}}
+		spec := game_room.NewSpec(
+			"",
+			10,
+			containers,
+			"10",
+			"10")
+		require.NotNil(t, spec)
+	})
 }


### PR DESCRIPTION
### What?
- Make version not required at creating or updating scheduler.
### Why?
- "Version" should only be a Maestro concern. The client should not control whenever is a minor or a major version, only see it.
### How?
- When we create a new scheduler, if we don't offer it a value for version, it will have a default value: v0.0.0.

### Missing (still in draft)
- Change .proto file to not include version on create scheduler/create new version.