### PR TITLE
validate if scheduler and operations exists when try to cancel operation

### DIFF
--- a/cmd/managementapi/wire_gen.go
+++ b/cmd/managementapi/wire_gen.go
@@ -42,7 +42,7 @@ func initializeManagementMux(ctx context.Context, conf config.Config) (*runtime.
 	if err != nil {
 		return nil, err
 	}
-	operationManager := service.NewOperationManager(operationFlow, operationStorage, v, operationLeaseStorage, operationManagerConfig)
+	operationManager := service.NewOperationManager(operationFlow, operationStorage, v, operationLeaseStorage, operationManagerConfig, schedulerStorage)
 	roomStorage, err := service.NewRoomStorageRedis(conf)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -41,7 +41,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	if err != nil {
 		return nil, err
 	}
-	operationManager := service.NewOperationManager(operationFlow, operationStorage, v, operationLeaseStorage, operationManagerConfig)
+	operationManager := service.NewOperationManager(operationFlow, operationStorage, v, operationLeaseStorage, operationManagerConfig, schedulerStorage)
 	runtime, err := service.NewRuntimeKubernetes(c)
 	if err != nil {
 		return nil, err

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -340,7 +340,7 @@ func newMockRoomAndSchedulerManager(mockCtrl *gomock.Controller) *mockRoomAndSch
 	operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 	operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 	opConfig := operation_manager.OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-	operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, opConfig)
+	operationManager := operation_manager.New(operationFlow, operationStorage, operations.NewDefinitionConstructors(), operationLeaseStorage, opConfig, schedulerStorage)
 	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
 
 	return &mockRoomAndSchedulerManager{

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -29,9 +29,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
+	"github.com/topfreegames/maestro/internal/core/entities"
+	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 	"github.com/topfreegames/maestro/internal/core/ports"
 
 	"github.com/golang/mock/gomock"
@@ -98,10 +101,11 @@ func TestCreateOperation(t *testing.T) {
 			schedulerName := "scheduler_name"
 			operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 			operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+			schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 			definitionConstructors := operations.NewDefinitionConstructors()
 			operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 			config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-			opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+			opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 			ctx := context.Background()
 			testDefinition, _ := test.definition.(*testOperationDefinition)
@@ -139,11 +143,12 @@ func TestGetOperation(t *testing.T) {
 
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -169,10 +174,11 @@ func TestGetOperation(t *testing.T) {
 
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -196,8 +202,9 @@ func TestGetOperation(t *testing.T) {
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -219,10 +226,11 @@ func TestGetOperation(t *testing.T) {
 
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -249,8 +257,9 @@ func TestNextSchedulerOperation(t *testing.T) {
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -280,9 +289,10 @@ func TestNextSchedulerOperation(t *testing.T) {
 
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -301,9 +311,10 @@ func TestNextSchedulerOperation(t *testing.T) {
 
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -327,10 +338,11 @@ func TestStartOperation(t *testing.T) {
 
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		op := &operation.Operation{ID: uuid.NewString(), DefinitionName: (&testOperationDefinition{}).Name()}
@@ -347,10 +359,11 @@ func TestFinishOperation(t *testing.T) {
 
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		op := &operation.Operation{
@@ -378,9 +391,10 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{
@@ -410,9 +424,10 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		var operationsResult []*operation.Operation
@@ -431,8 +446,9 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManagerConfig := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, operationManagerConfig)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, operationManagerConfig, schedulerStorage)
 
 		ctx := context.Background()
 
@@ -449,8 +465,9 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManagerConfig := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, operationManagerConfig)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, operationManagerConfig, schedulerStorage)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{
@@ -475,8 +492,9 @@ func TestListSchedulerFinishedOperations(t *testing.T) {
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{
@@ -500,9 +518,10 @@ func TestListSchedulerPendingOperations(t *testing.T) {
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		operationsResult := []*operation.Operation{
@@ -532,9 +551,10 @@ func TestWatchOperationCancellationRequests(t *testing.T) {
 
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, nil, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, nil, operationLeaseStorage, config, schedulerStorage)
 
 		cancelableContext, cancelFunction := context.WithCancel(context.Background())
 		opManager.OperationCancelFunctions.putFunction(schedulerName, operationID, cancelFunction)
@@ -581,10 +601,11 @@ func TestGrantLease(t *testing.T) {
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -609,9 +630,10 @@ func TestGrantLease(t *testing.T) {
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -638,9 +660,10 @@ func TestRevokeLease(t *testing.T) {
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -664,9 +687,10 @@ func TestRevokeLease(t *testing.T) {
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -693,10 +717,11 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -721,9 +746,10 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx := context.Background()
 		schedulerName := "test-scheduler"
@@ -753,7 +779,8 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx, cancelFunction := context.WithCancel(context.Background())
 		schedulerName := "test-scheduler"
@@ -778,10 +805,11 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx, cancelFunction := context.WithCancel(context.Background())
 		schedulerName := "test-scheduler"
@@ -807,9 +835,10 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 		definitionConstructors := operations.NewDefinitionConstructors()
 		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		definitionConstructors[defFunc().Name()] = defFunc
 		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config)
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
 
 		ctx, cancelFunction := context.WithCancel(context.Background())
 		schedulerName := "test-scheduler"
@@ -825,4 +854,145 @@ func TestStartLeaseRenewGoRoutine(t *testing.T) {
 			return ctx.Err() == context.Canceled
 		}, time.Second, time.Millisecond*100)
 	})
+}
+
+func TestEnqueueOperationCancellationRequest(t *testing.T) {
+	schedulerName := "scheduler-name"
+	operationID := "123"
+	defFunc := func() operations.Definition { return &testOperationDefinition{} }
+	operation := &operation.Operation{ID: operationID, SchedulerName: schedulerName, DefinitionName: defFunc().Name()}
+
+	t.Run("it returns nil when cancelled operation with success", func(t *testing.T) {
+		t.Parallel()
+		mockCtrl := gomock.NewController(t)
+		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
+		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		definitionConstructors[defFunc().Name()] = defFunc
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerName).Return(newValidScheduler(), nil)
+		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, operationID).Return(
+			operation,
+			[]byte{},
+			nil,
+		)
+		operationFlow.EXPECT().EnqueueOperationCancellationRequest(gomock.Any(), gomock.Any()).Return(nil)
+
+		err := opManager.EnqueueOperationCancellationRequest(context.Background(), schedulerName, operationID)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("it returns error when scheduler was not found", func(t *testing.T) {
+		t.Parallel()
+		mockCtrl := gomock.NewController(t)
+		defFunc := func() operations.Definition { return &testOperationDefinition{} }
+		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
+		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		definitionConstructors[defFunc().Name()] = defFunc
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerName).Return(nil, errors.New("err"))
+
+		err := opManager.EnqueueOperationCancellationRequest(context.Background(), schedulerName, operationID)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch scheduler from storage")
+	})
+
+	t.Run("it returns error when operation was not found", func(t *testing.T) {
+		t.Parallel()
+		mockCtrl := gomock.NewController(t)
+		defFunc := func() operations.Definition { return &testOperationDefinition{} }
+		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
+		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		definitionConstructors[defFunc().Name()] = defFunc
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerName).Return(newValidScheduler(), nil)
+		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, operationID).Return(
+			nil,
+			[]byte{},
+			errors.New("err"),
+		)
+
+		err := opManager.EnqueueOperationCancellationRequest(context.Background(), schedulerName, operationID)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch operation from storage")
+	})
+
+	t.Run("it returns error when operation couldn't enqueued", func(t *testing.T) {
+		t.Parallel()
+		mockCtrl := gomock.NewController(t)
+		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
+		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+		definitionConstructors := operations.NewDefinitionConstructors()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
+		definitionConstructors[defFunc().Name()] = defFunc
+		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
+		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerName).Return(newValidScheduler(), nil)
+		operationStorage.EXPECT().GetOperation(gomock.Any(), schedulerName, operationID).Return(
+			operation,
+			[]byte{},
+			nil,
+		)
+		operationFlow.EXPECT().EnqueueOperationCancellationRequest(gomock.Any(), gomock.Any()).Return(errors.New("err"))
+
+		err := opManager.EnqueueOperationCancellationRequest(context.Background(), schedulerName, operationID)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to enqueue operation cancellation request:")
+	})
+}
+
+// newValidScheduler generates a valid scheduler with the required fields.
+func newValidScheduler() *entities.Scheduler {
+	return &entities.Scheduler{
+		Name:            "scheduler",
+		Game:            "game",
+		State:           entities.StateCreating,
+		MaxSurge:        "10%",
+		RollbackVersion: "",
+		Spec: game_room.Spec{
+			Version:                "v1",
+			TerminationGracePeriod: 60,
+			Toleration:             "toleration",
+			Affinity:               "affinity",
+			Containers: []game_room.Container{
+				{
+					Name:            "default",
+					Image:           "some-image",
+					ImagePullPolicy: "Always",
+					Command:         []string{"hello"},
+					Ports: []game_room.ContainerPort{
+						{Name: "tcp", Protocol: "tcp", Port: 80},
+					},
+					Requests: game_room.ContainerResources{
+						CPU:    "10m",
+						Memory: "100Mi",
+					},
+					Limits: game_room.ContainerResources{
+						CPU:    "10m",
+						Memory: "100Mi",
+					},
+				},
+			},
+		},
+		PortRange: &entities.PortRange{
+			Start: 40000,
+			End:   60000,
+		},
+	}
 }

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -29,7 +29,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
@@ -39,6 +38,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -27,10 +27,11 @@ package operation_manager
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"testing"
 	"time"
+
+	"errors"
+	"fmt"
 
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
@@ -41,10 +42,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
-
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/operations"
+
+	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
+
 	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 )
 

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -75,7 +75,7 @@ const (
 	operationFlowRedisUrlPath = "adapters.operationFlow.redis.url"
 )
 
-func NewOperationManager(flow ports.OperationFlow, storage ports.OperationStorage, operationDefinitionConstructors map[string]operations.DefinitionConstructor, leaseStorage ports.OperationLeaseStorage, config operation_manager.OperationManagerConfig) ports.OperationManager {
+func NewOperationManager(flow ports.OperationFlow, storage ports.OperationStorage, operationDefinitionConstructors map[string]operations.DefinitionConstructor, leaseStorage ports.OperationLeaseStorage, config operation_manager.OperationManagerConfig, schedulerStorage ports.SchedulerStorage) ports.OperationManager {
 	return &operation_manager.OperationManager{
 		Flow:                            flow,
 		Storage:                         storage,
@@ -83,6 +83,7 @@ func NewOperationManager(flow ports.OperationFlow, storage ports.OperationStorag
 		OperationCancelFunctions:        operation_manager.NewOperationCancelFunctions(),
 		LeaseStorage:                    leaseStorage,
 		Config:                          config,
+		SchedulerStorage:                schedulerStorage,
 	}
 }
 


### PR DESCRIPTION
### What?
Validating if the scheduler and the operation exist to be cancelled

### Why?
Because when user try to cancel and inexistent operation we are returning 200 instead of 404 when scheduler or operation doesn't exists from storage.

### How?
Implementing scheduler and operation validation and return error if someone doesn't found from storage
Implementing unit tests that didn't exist before