### PR TITLE
chore(newSpec): remove-scheduler-version-requirement

### DIFF
--- a/e2e/suites/management/create_scheduler_test.go
+++ b/e2e/suites/management/create_scheduler_test.go
@@ -48,7 +48,6 @@ func TestCreateScheduler(t *testing.T) {
 			Game:     "test",
 			MaxSurge: "10%",
 			Spec: &maestrov1.Spec{
-				Version:                "v1.1",
 				TerminationGracePeriod: 15,
 				Containers: []*maestrov1.Container{
 					{

--- a/e2e/suites/management/utils.go
+++ b/e2e/suites/management/utils.go
@@ -52,7 +52,6 @@ func createSchedulerAndWaitForIt(
 		Game:     game,
 		MaxSurge: "10%",
 		Spec: &maestroApiV1.Spec{
-			Version:                "v1.1",
 			TerminationGracePeriod: 15,
 			Containers: []*maestroApiV1.Container{
 				{
@@ -138,7 +137,6 @@ func createSchedulerWithForwardersAndWaitForIt(
 		Name: schedulerName,
 		Game: "test",
 		Spec: &maestroApiV1.Spec{
-			Version:                "v1.1",
 			TerminationGracePeriod: 15,
 			Containers: []*maestroApiV1.Container{
 				{

--- a/internal/api/handlers/schedulers_handler.go
+++ b/internal/api/handlers/schedulers_handler.go
@@ -282,13 +282,13 @@ func (h *SchedulersHandler) fromEntitySchedulerVersionListToResponse(entity []*e
 }
 
 func (h *SchedulersHandler) fromApiSpec(apiSpec *api.Spec) *game_room.Spec {
-	return &game_room.Spec{
-		Version:                apiSpec.GetVersion(),
-		TerminationGracePeriod: time.Duration(apiSpec.GetTerminationGracePeriod()),
-		Containers:             h.fromApiContainers(apiSpec.GetContainers()),
-		Toleration:             apiSpec.GetToleration(),
-		Affinity:               apiSpec.GetAffinity(),
-	}
+	return game_room.NewSpec(
+		"",
+		time.Duration(apiSpec.GetTerminationGracePeriod()),
+		h.fromApiContainers(apiSpec.GetContainers()),
+		apiSpec.GetToleration(),
+		apiSpec.GetAffinity(),
+	)
 }
 
 func (h *SchedulersHandler) fromApiContainers(apiContainers []*api.Container) []game_room.Container {

--- a/internal/api/handlers/schedulers_handler_test.go
+++ b/internal/api/handlers/schedulers_handler_test.go
@@ -556,7 +556,6 @@ func TestCreateScheduler(t *testing.T) {
 		assert.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.Containers[0].ImagePullPolicy' Error:Field validation for 'ImagePullPolicy' failed on the 'image_pull_policy' tag")
 		assert.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.Containers[0].Requests.Memory' Error:Field validation for 'Memory' failed on the 'required' tag")
 		assert.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.TerminationGracePeriod' Error:Field validation for 'TerminationGracePeriod' failed on the 'gt' tag")
-		assert.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.Version' Error:Field validation for 'Version' failed on the 'required' tag")
 		assert.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.Containers[0].Command' Error:Field validation for 'Command' failed on the 'required' tag")
 		assert.Contains(t, schedulerMessage, "Key: 'Scheduler.Game' Error:Field validation for 'Game' failed on the 'required' tag")
 		assert.Contains(t, schedulerMessage, "Key: 'Scheduler.Spec.Containers[0].Requests.CPU' Error:Field validation for 'CPU' failed on the 'required' tag")

--- a/internal/core/entities/game_room/spec.go
+++ b/internal/core/entities/game_room/spec.go
@@ -38,6 +38,9 @@ type Spec struct {
 }
 
 func NewSpec(version string, terminationGracePeriod time.Duration, containers []Container, toleration string, affinity string) *Spec {
+	if version == "" {
+		version = "v1.0.0"
+	}
 	return &Spec{
 		Version:                version,
 		TerminationGracePeriod: terminationGracePeriod,


### PR DESCRIPTION
### What?
Make version not required at creating or updating scheduler.
### Why?
"Version" should only be a Maestro concern. The client should not control whenever is a minor or a major version, only see it.
### How?
When we create a new scheduler, if we don't offer it a value for version, it will have a default value: v1.0.0.

### About proto files:
If we take off "version" from Spec message, we cannot retrieve it from GET requests. Because of that, simply ignoring it on handler is enough.