### PR TITLE
adds upsert instance in create room method

### DIFF
--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -102,6 +102,11 @@ func (m *RoomManager) CreateRoomAndWaitForReadiness(ctx context.Context, schedul
 		LastPingAt:  m.Clock.Now(),
 	}
 
+	err = m.InstanceStorage.UpsertInstance(ctx, instance)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	err = m.RoomStorage.CreateRoom(ctx, room)
 	if err != nil {
 		return nil, nil, err

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -94,6 +94,11 @@ func (m *RoomManager) CreateRoomAndWaitForReadiness(ctx context.Context, schedul
 		return nil, nil, err
 	}
 
+	err = m.InstanceStorage.UpsertInstance(ctx, instance)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	room := &game_room.GameRoom{
 		ID:          instance.ID,
 		SchedulerID: scheduler.Name,
@@ -101,12 +106,6 @@ func (m *RoomManager) CreateRoomAndWaitForReadiness(ctx context.Context, schedul
 		Status:      game_room.GameStatusPending,
 		LastPingAt:  m.Clock.Now(),
 	}
-
-	err = m.InstanceStorage.UpsertInstance(ctx, instance)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	err = m.RoomStorage.CreateRoom(ctx, room)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
### What?
Adds upsert instance method on `CreateRoomAndWaitForReadiness`.

### Why?
We were relaying on watcher to call this method, but there's no specific reason to not do that at this time (with the instance creation)

### How?
Calling the method `UpsertInstance` from `instanceStorage` right after the creation of the instance
