### PR TITLE
bump integration tests go and k3s versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.16.3'
+        go-version: '1.17.3'
     - name: Checkout
       uses: actions/checkout@v2
     - name: Restore cache
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.16.3'
+        go-version: '1.17.3'
     - name: Checkout
       uses: actions/checkout@v2
     - name: Restore cache
@@ -48,14 +48,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k3s-version: [v1.19.11, v1.20.7, v1.21.1]
+        k3s-version: [v1.19.11, v1.20.7, v1.21.1, v1.22.7]
     env:
       K3S_VERSION:  ${{ matrix.k3s-version }}
     steps:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.16.3'
+        go-version: '1.17.3'
     - name: Checkout
       uses: actions/checkout@v2
     - name: Restore cache

--- a/e2e/framework/maestro/docker-compose.yml
+++ b/e2e/framework/maestro/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     command: [start, runtime-watcher]
 
   k3s_server:
-    image: "rancher/k3s:v1.19.11-k3s1"
+    image: "rancher/k3s:v1.22.7-k3s1"
     command: server --bind-address k3s_server
     tmpfs:
     - /run
@@ -105,7 +105,7 @@ services:
     - "6443:6443"  # Kubernetes API Server
 
   k3s_agent:
-    image: "rancher/k3s:v1.19.11-k3s1"
+    image: "rancher/k3s:v1.22.7-k3s1"
     tmpfs:
     - /run
     - /var/run


### PR DESCRIPTION
### Why?
To guarantee we are testing with the right versions being used on Maestro, we need to bump the workflows and e2e tests.