### PR TITLE
New major version: validation room should not be forwarded

### DIFF
--- a/cmd/roomsapi/wire_gen.go
+++ b/cmd/roomsapi/wire_gen.go
@@ -52,7 +52,7 @@ func initializeRoomsMux(ctx context.Context, conf config.Config) (*runtime.Serve
 	if err != nil {
 		return nil, err
 	}
-	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, schedulerCache, eventsForwarderConfig)
+	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, roomStorage, schedulerCache, eventsForwarderConfig)
 	roomManagerConfig, err := service.NewRoomManagerConfig(conf)
 	if err != nil {
 		return nil, err

--- a/cmd/runtimewatcher/wire_gen.go
+++ b/cmd/runtimewatcher/wire_gen.go
@@ -53,7 +53,7 @@ func initializeRuntimeWatcher(c config.Config) (*workers_manager.WorkersManager,
 	if err != nil {
 		return nil, err
 	}
-	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, schedulerCache, eventsForwarderConfig)
+	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, roomStorage, schedulerCache, eventsForwarderConfig)
 	roomManagerConfig, err := service.NewRoomManagerConfig(c)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -70,7 +70,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	if err != nil {
 		return nil, err
 	}
-	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, schedulerCache, eventsForwarderConfig)
+	eventsService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, gameRoomInstanceStorage, roomStorage, schedulerCache, eventsForwarderConfig)
 	roomManagerConfig, err := service.NewRoomManagerConfig(c)
 	if err != nil {
 		return nil, err

--- a/internal/adapters/room_storage/redis/redis.go
+++ b/internal/adapters/room_storage/redis/redis.go
@@ -43,9 +43,10 @@ const (
 	maxRoomStatusEvents = 100
 
 	// Room hash keys.
-	metadataKey   = "metadata"
-	pingStatusKey = "ping_status"
-	versionKey    = "version"
+	metadataKey      = "metadata"
+	pingStatusKey    = "ping_status"
+	versionKey       = "version"
+	isValidationRoom = "is_validation_room"
 )
 
 type redisStateStorage struct {
@@ -56,6 +57,16 @@ var _ ports.RoomStorage = (*redisStateStorage)(nil)
 
 func NewRedisStateStorage(client *redis.Client) *redisStateStorage {
 	return &redisStateStorage{client: client}
+}
+
+func (r redisStateStorage) GetIsValidationRoom(ctx context.Context, room *game_room.GameRoom) (bool, error) {
+	roomHashCmd := r.client.HGetAll(ctx, getRoomRedisKey(room.SchedulerID, room.ID))
+	boolIsValidationRoom, err := strconv.ParseBool(roomHashCmd.Val()[isValidationRoom])
+	if err != nil {
+		return false, errors.NewErrNotFound("error retrieving \"is_validation_room\" value from room %s", room.ID).WithError(err)
+	}
+
+	return boolIsValidationRoom, nil
 }
 
 func (r redisStateStorage) GetRoom(ctx context.Context, scheduler, roomID string) (*game_room.GameRoom, error) {
@@ -101,9 +112,10 @@ func (r *redisStateStorage) CreateRoom(ctx context.Context, room *game_room.Game
 
 	p := r.client.TxPipeline()
 	p.HSet(ctx, getRoomRedisKey(room.SchedulerID, room.ID), map[string]interface{}{
-		versionKey:    room.Version,
-		metadataKey:   metadataJson,
-		pingStatusKey: strconv.Itoa(int(room.PingStatus)),
+		versionKey:       room.Version,
+		metadataKey:      metadataJson,
+		pingStatusKey:    strconv.Itoa(int(room.PingStatus)),
+		isValidationRoom: room.IsValidationRoom,
 	})
 
 	statusCmd := p.ZAddNX(ctx, getRoomStatusSetRedisKey(room.SchedulerID), &redis.Z{

--- a/internal/adapters/room_storage/redis/redis.go
+++ b/internal/adapters/room_storage/redis/redis.go
@@ -59,16 +59,6 @@ func NewRedisStateStorage(client *redis.Client) *redisStateStorage {
 	return &redisStateStorage{client: client}
 }
 
-func (r redisStateStorage) GetIsValidationRoom(ctx context.Context, room *game_room.GameRoom) (bool, error) {
-	roomHashCmd := r.client.HGetAll(ctx, getRoomRedisKey(room.SchedulerID, room.ID))
-	boolIsValidationRoom, err := strconv.ParseBool(roomHashCmd.Val()[isValidationRoom])
-	if err != nil {
-		return false, errors.NewErrNotFound("error retrieving \"is_validation_room\" value from room %s", room.ID).WithError(err)
-	}
-
-	return boolIsValidationRoom, nil
-}
-
 func (r redisStateStorage) GetRoom(ctx context.Context, scheduler, roomID string) (*game_room.GameRoom, error) {
 	room := &game_room.GameRoom{
 		ID:          roomID,
@@ -98,6 +88,9 @@ func (r redisStateStorage) GetRoom(ctx context.Context, scheduler, roomID string
 	if err != nil {
 		return nil, errors.NewErrEncoding("failed to parse operation status").WithError(err)
 	}
+
+	boolIsValidationRoom, _ := strconv.ParseBool(roomHashCmd.Val()[isValidationRoom])
+	room.IsValidationRoom = boolIsValidationRoom
 
 	room.PingStatus = game_room.GameRoomPingStatus(pingStatusInt)
 	room.Version = roomHashCmd.Val()[versionKey]

--- a/internal/adapters/room_storage/redis/redis_test.go
+++ b/internal/adapters/room_storage/redis/redis_test.go
@@ -263,7 +263,7 @@ func TestRedisStateStorage_GetRoom(t *testing.T) {
 		require.Equal(t, expectedRoom, actualRoom)
 	})
 
-	t.Run("game room with metadata", func(t *testing.T) {
+	t.Run("game room with metadata and validation flag true", func(t *testing.T) {
 		expectedRoom := &game_room.GameRoom{
 			ID:          "room-2",
 			SchedulerID: "game",
@@ -273,6 +273,7 @@ func TestRedisStateStorage_GetRoom(t *testing.T) {
 			Metadata: map[string]interface{}{
 				"region": "us",
 			},
+			IsValidationRoom: true,
 		}
 
 		require.NoError(t, storage.CreateRoom(ctx, expectedRoom))
@@ -649,46 +650,4 @@ func TestRedisStateStorage_GetRoomIDsByStatus(t *testing.T) {
 	terminatingRooms, err := storage.GetRoomIDsByStatus(ctx, "game", game_room.GameStatusTerminating)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"room-5"}, terminatingRooms)
-}
-
-func TestRedisStateStorage_GetIsValidationRoom(t *testing.T) {
-	ctx := context.Background()
-	client := test.GetRedisConnection(t, redisAddress)
-	storage := NewRedisStateStorage(client)
-
-	t.Run("should succeed - game room is validation (false) info retrieved correctly", func(t *testing.T) {
-		room := &game_room.GameRoom{
-			ID:          "room-1",
-			SchedulerID: "game",
-		}
-		require.NoError(t, storage.CreateRoom(ctx, room))
-
-		boolIsValidationRoom, err := storage.GetIsValidationRoom(ctx, room)
-		require.NoError(t, err)
-		require.Equal(t, boolIsValidationRoom, false)
-	})
-
-	t.Run("should succeed - game room is validation (true) info retrieved correctly", func(t *testing.T) {
-		room := &game_room.GameRoom{
-			ID:               "room-2",
-			SchedulerID:      "game",
-			IsValidationRoom: true,
-		}
-		require.NoError(t, storage.CreateRoom(ctx, room))
-
-		boolIsValidationRoom, err := storage.GetIsValidationRoom(ctx, room)
-		require.NoError(t, err)
-		require.Equal(t, boolIsValidationRoom, true)
-	})
-
-	t.Run("should fail - room not found", func(t *testing.T) {
-		room := &game_room.GameRoom{
-			ID:          "room-not-found",
-			SchedulerID: "game",
-		}
-		_, err := storage.GetIsValidationRoom(ctx, room)
-		require.Error(t, err)
-		require.IsType(t, err, errors.ErrNotFound)
-	})
-
 }

--- a/internal/adapters/runtime/kubernetes/game_room.go
+++ b/internal/adapters/runtime/kubernetes/game_room.go
@@ -60,7 +60,7 @@ func (k *kubernetes) DeleteGameRoomInstance(ctx context.Context, gameRoomInstanc
 	err := k.clientSet.CoreV1().Pods(gameRoomInstance.SchedulerID).Delete(ctx, gameRoomInstance.ID, metav1.DeleteOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			return errors.NewErrNotFound("game room '%s' already exists", gameRoomInstance.ID)
+			return errors.NewErrNotFound("game room '%s' not found", gameRoomInstance.ID)
 		}
 
 		return errors.NewErrUnexpected("error deleting game room instance: %s", err)

--- a/internal/api/handlers/rooms_handler.go
+++ b/internal/api/handlers/rooms_handler.go
@@ -91,6 +91,7 @@ func (h *RoomsHandler) UpdateRoomWithPing(ctx context.Context, message *api.Upda
 		h.logger.Error("error parsing ping request", zap.String("schedulerName", message.SchedulerName), zap.String("roomName", message.RoomName), zap.Any("ping", message), zap.Error(err))
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	// TODO(caio.rodrigues): receive only scheduler, room and metadata. Fetch room from storage on manager before producing event
 	err = h.roomManager.UpdateRoom(ctx, gameRoom)
 	if err != nil {
 		h.logger.Error("error updating room with ping", zap.String("schedulerName", message.SchedulerName), zap.String("roomName", message.RoomName), zap.Any("ping", message), zap.Error(err))

--- a/internal/core/entities/game_room/game_room.go
+++ b/internal/core/entities/game_room/game_room.go
@@ -127,10 +127,6 @@ type GameRoom struct {
 	IsValidationRoom bool
 }
 
-func (g *GameRoom) SetRoomValidation() {
-	g.IsValidationRoom = true
-}
-
 // validStatusTransitions this map has all possible status changes for a game
 // room.
 var validStatusTransitions = map[GameRoomStatus]map[GameRoomStatus]struct{}{

--- a/internal/core/entities/game_room/game_room.go
+++ b/internal/core/entities/game_room/game_room.go
@@ -117,13 +117,18 @@ func FromStringToGameRoomPingStatus(value string) (GameRoomPingStatus, error) {
 }
 
 type GameRoom struct {
-	ID          string
-	SchedulerID string
-	Version     string
-	Status      GameRoomStatus
-	PingStatus  GameRoomPingStatus
-	Metadata    map[string]interface{}
-	LastPingAt  time.Time
+	ID               string
+	SchedulerID      string
+	Version          string
+	Status           GameRoomStatus
+	PingStatus       GameRoomPingStatus
+	Metadata         map[string]interface{}
+	LastPingAt       time.Time
+	IsValidationRoom bool
+}
+
+func (g *GameRoom) SetRoomValidation() {
+	g.IsValidationRoom = true
 }
 
 // validStatusTransitions this map has all possible status changes for a game

--- a/internal/core/operations/add_rooms/add_rooms_executor.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor.go
@@ -109,7 +109,7 @@ func (ex *AddRoomsExecutor) Name() string {
 }
 
 func (ex *AddRoomsExecutor) createRoom(ctx context.Context, scheduler *entities.Scheduler, logger *zap.Logger) error {
-	gameRoom, _, err := ex.roomManager.CreateRoomAndWaitForReadiness(ctx, *scheduler)
+	gameRoom, _, err := ex.roomManager.CreateRoomAndWaitForReadiness(ctx, *scheduler, false)
 	if err != nil {
 		logger.Error("Error while creating room", zap.Error(err))
 		reportAddRoomOperationExecutionFailed(scheduler.Name, ex.Name())

--- a/internal/core/operations/add_rooms/add_rooms_executor_test.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor_test.go
@@ -93,7 +93,7 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 		roomsManager := mockports.NewMockRoomManager(mockCtrl)
 
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), op.SchedulerName).Return(&scheduler, nil)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(10)
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(10)
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
@@ -109,8 +109,8 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 		gameRoomReady := gameRoom
 		gameRoomReady.Status = game_room.GameStatusReady
 
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("error"))
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, errors.NewErrUnexpected("error"))
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
@@ -184,8 +184,8 @@ func TestAddRoomsExecutor_OnError(t *testing.T) {
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
 
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("error"))
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, errors.NewErrUnexpected("error"))
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
@@ -202,8 +202,8 @@ func TestAddRoomsExecutor_OnError(t *testing.T) {
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
 
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("error"))
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, errors.NewErrUnexpected("error"))
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)

--- a/internal/core/operations/add_rooms/add_rooms_executor_test.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor_test.go
@@ -93,7 +93,7 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 		roomsManager := mockports.NewMockRoomManager(mockCtrl)
 
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), op.SchedulerName).Return(&scheduler, nil)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(10)
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(10)
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
@@ -109,8 +109,8 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 		gameRoomReady := gameRoom
 		gameRoomReady.Status = game_room.GameStatusReady
 
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("error"))
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("error"))
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
@@ -184,8 +184,8 @@ func TestAddRoomsExecutor_OnError(t *testing.T) {
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
 
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("error"))
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("error"))
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
@@ -202,8 +202,8 @@ func TestAddRoomsExecutor_OnError(t *testing.T) {
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
 
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("error"))
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("error"))
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -123,7 +123,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Name() string {
 }
 
 func (ex *CreateNewSchedulerVersionExecutor) validateGameRoomCreation(ctx context.Context, scheduler *entities.Scheduler, logger *zap.Logger) error {
-	gameRoom, _, err := ex.roomManager.CreateRoomAndWaitForReadiness(ctx, *scheduler)
+	gameRoom, _, err := ex.roomManager.CreateRoomAndWaitForReadiness(ctx, *scheduler, true)
 	if err != nil {
 		logger.Error("error creating new game room for validating new version")
 		return fmt.Errorf("error creating new game room for validating new version: %w", err)

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -78,7 +78,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		newSchedulerWithNewVersion.Spec.Version = "v2.0.0"
 		newSchedulerWithNewVersion.RollbackVersion = "v1.0.0"
 
-		mocksForExecutor.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(&game_room.GameRoom{ID: "id-1"}, nil, nil)
+		mocksForExecutor.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), true).Return(&game_room.GameRoom{ID: "id-1"}, nil, nil)
 		mocksForExecutor.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil)
 
 		// mocks for SchedulerManager CreateNewSchedulerVersion method
@@ -110,7 +110,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		newSchedulerWithNewVersion.Spec.Version = "v2.0.0"
 		newSchedulerWithNewVersion.RollbackVersion = "v1.0.0"
 
-		mocksForExecutor.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("some error"))
+		mocksForExecutor.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), true).Return(nil, nil, errors.NewErrUnexpected("some error"))
 
 		// mocks for SchedulerManager GetActiveScheduler method
 		mocksForExecutor.schedulerStorage.EXPECT().GetScheduler(gomock.Any(), newScheduler.Name).Return(currentActiveScheduler, nil)

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -78,7 +78,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		newSchedulerWithNewVersion.Spec.Version = "v2.0.0"
 		newSchedulerWithNewVersion.RollbackVersion = "v1.0.0"
 
-		mocksForExecutor.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(&game_room.GameRoom{ID: "id-1"}, nil, nil)
+		mocksForExecutor.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(&game_room.GameRoom{ID: "id-1"}, nil, nil)
 		mocksForExecutor.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil)
 
 		// mocks for SchedulerManager CreateNewSchedulerVersion method
@@ -110,7 +110,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		newSchedulerWithNewVersion.Spec.Version = "v2.0.0"
 		newSchedulerWithNewVersion.RollbackVersion = "v1.0.0"
 
-		mocksForExecutor.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("some error"))
+		mocksForExecutor.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.NewErrUnexpected("some error"))
 
 		// mocks for SchedulerManager GetActiveScheduler method
 		mocksForExecutor.schedulerStorage.EXPECT().GetScheduler(gomock.Any(), newScheduler.Name).Return(currentActiveScheduler, nil)

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -198,7 +198,7 @@ func (ex *SwitchActiveVersionExecutor) replaceRoom(logger *zap.Logger, roomsChan
 			return nil
 		}
 
-		gameRoom, _, err := roomManager.CreateRoomAndWaitForReadiness(ctx, scheduler)
+		gameRoom, _, err := roomManager.CreateRoomAndWaitForReadiness(ctx, scheduler, false)
 		if err != nil {
 			logger.Error("error creating room", zap.Error(err))
 			ex.roomsBeingReplaced.Delete(room.ID)

--- a/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
@@ -116,7 +116,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 				Status:      game_room.GameStatusReady,
 				LastPingAt:  time.Now(),
 			}
-			mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(gameRoom, nil, nil)
+			mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoom, nil, nil)
 		}
 		mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(len(append(gameRoomListCycle1, gameRoomListCycle2...)))
 
@@ -186,7 +186,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.roomManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoomListCycle1, nil)
 		mocks.roomManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*game_room.GameRoom{}, nil).MaxTimes(1)
 
-		mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("error")).MaxTimes(maxSurge)
+		mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("error")).MaxTimes(maxSurge)
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
 		err = executor.Execute(context.Background(), &operation.Operation{}, definition)
@@ -210,7 +210,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.roomManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoomListCycle1, nil)
 		mocks.roomManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*game_room.GameRoom{}, nil).MaxTimes(1)
 
-		mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(nil, nil, nil).MaxTimes(maxSurge)
+		mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil).MaxTimes(maxSurge)
 		mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(errors.New("error")).MaxTimes(maxSurge)
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
@@ -298,7 +298,7 @@ func TestSwitchActiveVersionOperation_OnError(t *testing.T) {
 				Status:      game_room.GameStatusReady,
 				LastPingAt:  time.Now(),
 			}
-			mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(gameRoom, nil, nil)
+			mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoom, nil, nil)
 			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil)
 		}
 
@@ -360,7 +360,7 @@ func TestSwitchActiveVersionOperation_OnError(t *testing.T) {
 				Status:      game_room.GameStatusReady,
 				LastPingAt:  time.Now(),
 			}
-			mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any()).Return(gameRoom, nil, nil)
+			mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoom, nil, nil)
 			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil)
 		}
 

--- a/internal/core/ports/mock/rooms_ports_mock.go
+++ b/internal/core/ports/mock/rooms_ports_mock.go
@@ -235,6 +235,21 @@ func (mr *MockRoomStorageMockRecorder) GetAllRoomIDs(ctx, scheduler interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllRoomIDs", reflect.TypeOf((*MockRoomStorage)(nil).GetAllRoomIDs), ctx, scheduler)
 }
 
+// GetIsValidationRoom mocks base method.
+func (m *MockRoomStorage) GetIsValidationRoom(ctx context.Context, room *game_room.GameRoom) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIsValidationRoom", ctx, room)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIsValidationRoom indicates an expected call of GetIsValidationRoom.
+func (mr *MockRoomStorageMockRecorder) GetIsValidationRoom(ctx, room interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIsValidationRoom", reflect.TypeOf((*MockRoomStorage)(nil).GetIsValidationRoom), ctx, room)
+}
+
 // GetRoom mocks base method.
 func (m *MockRoomStorage) GetRoom(ctx context.Context, scheduler, roomID string) (*game_room.GameRoom, error) {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/mock/rooms_ports_mock.go
+++ b/internal/core/ports/mock/rooms_ports_mock.go
@@ -83,20 +83,6 @@ func (mr *MockRoomManagerMockRecorder) DeleteRoomAndWaitForRoomTerminated(ctx, g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoomAndWaitForRoomTerminated", reflect.TypeOf((*MockRoomManager)(nil).DeleteRoomAndWaitForRoomTerminated), ctx, gameRoom)
 }
 
-// IsValidationRoom mocks base method.
-func (m *MockRoomManager) IsValidationRoom(ctx context.Context, gameRoom *game_room.GameRoom) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsValidationRoom", ctx, gameRoom)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsValidationRoom indicates an expected call of IsValidationRoom.
-func (mr *MockRoomManagerMockRecorder) IsValidationRoom(ctx, gameRoom interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidationRoom", reflect.TypeOf((*MockRoomManager)(nil).IsValidationRoom), ctx, gameRoom)
-}
-
 // ListRoomsWithDeletionPriority mocks base method.
 func (m *MockRoomManager) ListRoomsWithDeletionPriority(ctx context.Context, schedulerName, ignoredVersion string, amount int, roomsBeingReplaced *sync.Map) ([]*game_room.GameRoom, error) {
 	m.ctrl.T.Helper()
@@ -247,21 +233,6 @@ func (m *MockRoomStorage) GetAllRoomIDs(ctx context.Context, scheduler string) (
 func (mr *MockRoomStorageMockRecorder) GetAllRoomIDs(ctx, scheduler interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllRoomIDs", reflect.TypeOf((*MockRoomStorage)(nil).GetAllRoomIDs), ctx, scheduler)
-}
-
-// GetIsValidationRoom mocks base method.
-func (m *MockRoomStorage) GetIsValidationRoom(ctx context.Context, room *game_room.GameRoom) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIsValidationRoom", ctx, room)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetIsValidationRoom indicates an expected call of GetIsValidationRoom.
-func (mr *MockRoomStorageMockRecorder) GetIsValidationRoom(ctx, room interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIsValidationRoom", reflect.TypeOf((*MockRoomStorage)(nil).GetIsValidationRoom), ctx, room)
 }
 
 // GetRoom mocks base method.

--- a/internal/core/ports/mock/rooms_ports_mock.go
+++ b/internal/core/ports/mock/rooms_ports_mock.go
@@ -54,9 +54,9 @@ func (mr *MockRoomManagerMockRecorder) CleanRoomState(ctx, schedulerName, roomId
 }
 
 // CreateRoomAndWaitForReadiness mocks base method.
-func (m *MockRoomManager) CreateRoomAndWaitForReadiness(ctx context.Context, scheduler entities.Scheduler) (*game_room.GameRoom, *game_room.Instance, error) {
+func (m *MockRoomManager) CreateRoomAndWaitForReadiness(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRoomAndWaitForReadiness", ctx, scheduler)
+	ret := m.ctrl.Call(m, "CreateRoomAndWaitForReadiness", ctx, scheduler, isValidationRoom)
 	ret0, _ := ret[0].(*game_room.GameRoom)
 	ret1, _ := ret[1].(*game_room.Instance)
 	ret2, _ := ret[2].(error)
@@ -64,9 +64,9 @@ func (m *MockRoomManager) CreateRoomAndWaitForReadiness(ctx context.Context, sch
 }
 
 // CreateRoomAndWaitForReadiness indicates an expected call of CreateRoomAndWaitForReadiness.
-func (mr *MockRoomManagerMockRecorder) CreateRoomAndWaitForReadiness(ctx, scheduler interface{}) *gomock.Call {
+func (mr *MockRoomManagerMockRecorder) CreateRoomAndWaitForReadiness(ctx, scheduler, isValidationRoom interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoomAndWaitForReadiness", reflect.TypeOf((*MockRoomManager)(nil).CreateRoomAndWaitForReadiness), ctx, scheduler)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoomAndWaitForReadiness", reflect.TypeOf((*MockRoomManager)(nil).CreateRoomAndWaitForReadiness), ctx, scheduler, isValidationRoom)
 }
 
 // DeleteRoomAndWaitForRoomTerminated mocks base method.
@@ -81,6 +81,20 @@ func (m *MockRoomManager) DeleteRoomAndWaitForRoomTerminated(ctx context.Context
 func (mr *MockRoomManagerMockRecorder) DeleteRoomAndWaitForRoomTerminated(ctx, gameRoom interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoomAndWaitForRoomTerminated", reflect.TypeOf((*MockRoomManager)(nil).DeleteRoomAndWaitForRoomTerminated), ctx, gameRoom)
+}
+
+// IsValidationRoom mocks base method.
+func (m *MockRoomManager) IsValidationRoom(ctx context.Context, gameRoom *game_room.GameRoom) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsValidationRoom", ctx, gameRoom)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsValidationRoom indicates an expected call of IsValidationRoom.
+func (mr *MockRoomManagerMockRecorder) IsValidationRoom(ctx, gameRoom interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidationRoom", reflect.TypeOf((*MockRoomManager)(nil).IsValidationRoom), ctx, gameRoom)
 }
 
 // ListRoomsWithDeletionPriority mocks base method.

--- a/internal/core/ports/room_ports.go
+++ b/internal/core/ports/room_ports.go
@@ -69,13 +69,15 @@ type RoomManager interface {
 	UpdateRoom(ctx context.Context, gameRoom *game_room.GameRoom) error
 	// CreateRoomAndWaitForReadiness creates a room and only returns it when the room is ready (sent a ping to maestro).
 	// If the room is created and don't succeed on sending a ping to maestro, it will try to delete the room, and return
-	// an error.
-	CreateRoomAndWaitForReadiness(ctx context.Context, scheduler entities.Scheduler) (*game_room.GameRoom, *game_room.Instance, error)
+	// an error. The "isValidationRoom" parameter must be passed "true" if we want to create a room that won't be forwarded
+	CreateRoomAndWaitForReadiness(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error)
 	// UpdateGameRoomStatus updates the game based on the ping and runtime status.
 	UpdateGameRoomStatus(ctx context.Context, schedulerId, gameRoomId string) error
 	// WaitRoomStatus blocks the caller until the context is canceled, an error
 	// happens in the process or the game room has the desired status.
 	WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status game_room.GameRoomStatus) error
+	// IsValidationRoom return info about the room being of type validation (room being used to validate new GRU image)
+	IsValidationRoom(ctx context.Context, gameRoom *game_room.GameRoom) bool
 }
 
 // Secondary Ports (output, driven ports)

--- a/internal/core/ports/room_ports.go
+++ b/internal/core/ports/room_ports.go
@@ -76,8 +76,6 @@ type RoomManager interface {
 	// WaitRoomStatus blocks the caller until the context is canceled, an error
 	// happens in the process or the game room has the desired status.
 	WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status game_room.GameRoomStatus) error
-	// IsValidationRoom return info about the room being of type validation (room being used to validate new GRU image)
-	IsValidationRoom(ctx context.Context, gameRoom *game_room.GameRoom) bool
 }
 
 // Secondary Ports (output, driven ports)
@@ -108,8 +106,6 @@ type RoomStorage interface {
 	UpdateRoomStatus(ctx context.Context, scheduler, roomId string, status game_room.GameRoomStatus) error
 	// WatchRoomStatus watch for status changes on the storage.
 	WatchRoomStatus(ctx context.Context, room *game_room.GameRoom) (RoomStorageStatusWatcher, error)
-	// GetIsValidationRoom return info about the room being of type validation (used to guarantee room deploy quality)
-	GetIsValidationRoom(ctx context.Context, room *game_room.GameRoom) (bool, error)
 }
 
 // RoomStorageStatusWatcher defines a process of watcher, it will have a chan

--- a/internal/core/ports/room_ports.go
+++ b/internal/core/ports/room_ports.go
@@ -106,6 +106,8 @@ type RoomStorage interface {
 	UpdateRoomStatus(ctx context.Context, scheduler, roomId string, status game_room.GameRoomStatus) error
 	// WatchRoomStatus watch for status changes on the storage.
 	WatchRoomStatus(ctx context.Context, room *game_room.GameRoom) (RoomStorageStatusWatcher, error)
+	// GetIsValidationRoom return info about the room being of type validation (used to guarantee room deploy quality)
+	GetIsValidationRoom(ctx context.Context, room *game_room.GameRoom) (bool, error)
 }
 
 // RoomStorageStatusWatcher defines a process of watcher, it will have a chan

--- a/internal/core/services/events_forwarder/events_forwarder_service.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service.go
@@ -79,7 +79,7 @@ func (es *EventsForwarderService) ProduceEvent(ctx context.Context, event *event
 	}
 
 	if gameRoom.IsValidationRoom {
-		es.logger.Info(fmt.Sprintf("not producing events for room \"%s\", scheduler \"%s\" since room it's a validation room", gameRoom.ID, gameRoom.SchedulerID))
+		es.logger.Info(fmt.Sprintf("not producing events for room \"%s\", scheduler \"%s\" since it's a validation room", gameRoom.ID, gameRoom.SchedulerID))
 		return nil
 	}
 	if _, ok := event.Attributes["eventType"].(string); !ok {

--- a/internal/core/services/events_forwarder/events_forwarder_service_test.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service_test.go
@@ -50,9 +50,10 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 	instanceStorage := isMock.NewMockGameRoomInstanceStorage(mockCtrl)
 	schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
 	config := events_forwarder.EventsForwarderConfig{SchedulerCacheTtl: time.Minute}
 
-	eventsForwarderService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, instanceStorage, schedulerCache, config)
+	eventsForwarderService := events_forwarder.NewEventsForwarderService(eventsForwarder, schedulerStorage, instanceStorage, roomStorage, schedulerCache, config)
 
 	fwd := &forwarder.Forwarder{
 		Name:        "fwd",
@@ -121,6 +122,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			Forwarders:      nil,
 		}
 
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(scheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil).Times(0)
@@ -141,6 +149,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 				"playerId":  "player",
 			},
 		}
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
@@ -163,7 +178,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 				"pingType":  "ready",
 			},
 		}
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
 
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
@@ -182,6 +203,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			RoomID:      "room",
 			Attributes:  map[string]interface{}{},
 		}
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
 		require.Error(t, err)
@@ -206,7 +234,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 				Ports: nil,
 			},
 		}
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
 
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(instance, nil)
@@ -227,6 +261,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			},
 		}
 
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil).Times(0)
@@ -246,7 +287,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 				"eventType": "resync",
 			},
 		}
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
 
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil)
@@ -267,6 +314,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			},
 		}
 
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, errors.New("scheduler not found"))
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil).Times(0)
@@ -287,6 +341,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			},
 		}
 
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(nil, errors.New("error"))
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
@@ -307,6 +368,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			},
 		}
 
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil)
 		eventsForwarder.EXPECT().ForwardRoomEvent(context.Background(), gomock.Any(), gomock.Any()).Return(errors.New("error"))
@@ -326,6 +394,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			},
 		}
 
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil).Times(0)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
@@ -347,6 +422,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			},
 		}
 
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, nil)
@@ -368,6 +450,13 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 			},
 		}
 
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: false,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
 		schedulerCache.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(nil, errors.New("error"))
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), event.SchedulerID).Return(expectedScheduler, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), event.SchedulerID, event.RoomID).Return(expectedGameRoomInstance, nil)
@@ -376,6 +465,46 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
 		require.NoError(t, err)
+	})
+
+	t.Run("should succeed but not produce event when room type is validation", func(t *testing.T) {
+		event := &events.Event{
+			Name:        events.RoomEvent,
+			SchedulerID: expectedScheduler.Name,
+			RoomID:      "room",
+			Attributes: map[string]interface{}{
+				"eventType": "resync",
+				"pingType":  "ready",
+			},
+		}
+
+		room := &game_room.GameRoom{
+			ID:               event.RoomID,
+			SchedulerID:      event.SchedulerID,
+			IsValidationRoom: true,
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(room, nil)
+
+		err := eventsForwarderService.ProduceEvent(context.Background(), event)
+		require.NoError(t, err)
+	})
+
+	t.Run("should fail if room cannot be found since we would be producing event for non-registered room", func(t *testing.T) {
+		event := &events.Event{
+			Name:        events.RoomEvent,
+			SchedulerID: expectedScheduler.Name,
+			RoomID:      "room",
+			Attributes: map[string]interface{}{
+				"eventType": "resync",
+				"pingType":  "ready",
+			},
+		}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), event.SchedulerID, event.RoomID).Return(nil, errors.New("error"))
+
+		err := eventsForwarderService.ProduceEvent(context.Background(), event)
+		require.Error(t, err)
 	})
 
 }

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -167,11 +167,6 @@ func (m *RoomManager) UpdateRoom(ctx context.Context, gameRoom *game_room.GameRo
 	gameRoom.Metadata["eventType"] = events.FromRoomEventTypeToString(events.Ping)
 	gameRoom.Metadata["pingType"] = gameRoom.PingStatus.String()
 
-	if isValidationRoom := m.IsValidationRoom(ctx, gameRoom); isValidationRoom {
-		m.Logger.Info(fmt.Sprintf("not producing events for room \"%s\", scheduler \"%s\" since room it's a validation room", gameRoom.ID, gameRoom.SchedulerID))
-		return nil
-	}
-
 	err = m.EventsService.ProduceEvent(ctx, events.NewRoomEvent(gameRoom.SchedulerID, gameRoom.ID, gameRoom.Metadata))
 	if err != nil {
 		m.Logger.Error(fmt.Sprintf("Failed to forward ping event, error details: %s", err.Error()), zap.Error(err))
@@ -376,14 +371,6 @@ watchLoop:
 	}
 
 	return nil
-}
-
-func (m *RoomManager) IsValidationRoom(ctx context.Context, gameRoom *game_room.GameRoom) bool {
-	isValidationRoom, err := m.RoomStorage.GetIsValidationRoom(ctx, gameRoom)
-	if err != nil {
-		m.Logger.Warn("Failed to get info about room being type validation", zap.Error(err))
-	}
-	return isValidationRoom
 }
 
 func removeDuplicateValues(slice []string) []string {

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -290,7 +290,6 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(nil)
-		roomStorage.EXPECT().GetIsValidationRoom(context.Background(), newGameRoom).Return(false, nil)
 		eventsService.EXPECT().ProduceEvent(context.Background(), gomock.Any())
 
 		err := roomManager.UpdateRoom(context.Background(), newGameRoom)
@@ -336,7 +335,6 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(nil)
-		roomStorage.EXPECT().GetIsValidationRoom(context.Background(), newGameRoom).Return(false, nil)
 		eventsService.EXPECT().ProduceEvent(context.Background(), gomock.Any())
 
 		err := roomManager.UpdateRoom(context.Background(), newGameRoom)
@@ -638,54 +636,6 @@ func TestRoomManager_CleanRoomState(t *testing.T) {
 
 		err = roomManager.CleanRoomState(context.Background(), schedulerName, roomId)
 		require.Error(t, err)
-	})
-}
-
-func TestRoomManager_IsValidationRoom(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-
-	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-	instanceStorage := ismock.NewMockGameRoomInstanceStorage(mockCtrl)
-	runtime := runtimemock.NewMockRuntime(mockCtrl)
-	eventsService := mockports.NewMockEventsService(mockCtrl)
-	clock := clockmock.NewFakeClock(time.Now())
-	config := RoomManagerConfig{RoomInitializationTimeout: time.Millisecond * 1000, RoomDeletionTimeout: time.Millisecond * 1000}
-	roomManager := New(
-		clock,
-		pamock.NewMockPortAllocator(mockCtrl),
-		roomStorage,
-		instanceStorage,
-		runtime,
-		eventsService,
-		config,
-	)
-	gameRoom := &game_room.GameRoom{
-		ID:          "test-room",
-		SchedulerID: "test-scheduler",
-		Status:      game_room.GameStatusReady,
-		PingStatus:  game_room.GameRoomPingStatusReady,
-		LastPingAt:  clock.Now(),
-	}
-
-	t.Run("should succeed - find \"is validation room\" info - return false", func(t *testing.T) {
-		roomStorage.EXPECT().GetIsValidationRoom(context.Background(), gomock.Any()).Return(false, nil)
-
-		isValidationRoom := roomManager.IsValidationRoom(context.Background(), gameRoom)
-		require.Equal(t, isValidationRoom, false)
-	})
-
-	t.Run("should succeed - find \"is validation room\" info - return true", func(t *testing.T) {
-		roomStorage.EXPECT().GetIsValidationRoom(context.Background(), gomock.Any()).Return(true, nil)
-
-		isValidationRoom := roomManager.IsValidationRoom(context.Background(), gameRoom)
-		require.Equal(t, isValidationRoom, true)
-	})
-
-	t.Run("should fail - don't find \"is validation room\" info - return false", func(t *testing.T) {
-		roomStorage.EXPECT().GetIsValidationRoom(context.Background(), gomock.Any()).Return(false, errors.New("error"))
-
-		isValidationRoom := roomManager.IsValidationRoom(context.Background(), gameRoom)
-		require.Equal(t, isValidationRoom, false)
 	})
 }
 


### PR DESCRIPTION
### What?
Don't forward validation room pings.
### Why?
Because during an update, a match could try to use validation rooms
### How?
Storing a flag with the game room on Redis, and fetching this room before producing event (inside produce event method). If game room have flag true, event is not produced