### PR TITLE
Fix forwarder response in get scheduler and create scheduler

### DIFF
--- a/internal/api/handlers/fixtures/request/scheduler-config.json
+++ b/internal/api/handlers/fixtures/request/scheduler-config.json
@@ -33,5 +33,17 @@
         "hostPort": 54321
       }]
     }]
-  }
+  },
+  "forwarders": [
+    {
+	  "name": "forwarder-1",
+	  "enable": true,
+	  "type": "gRPC",
+	  "address": "127.0.0.1:9090",
+	  "options": {
+	    "timeout": 1000,
+        "metadata": {}
+	  }
+    }
+  ]
 }

--- a/internal/api/handlers/schedulers_handler.go
+++ b/internal/api/handlers/schedulers_handler.go
@@ -25,10 +25,12 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/go-playground/validator/v10"
+	_struct "google.golang.org/protobuf/types/known/structpb"
 
 	"go.uber.org/zap"
 
@@ -102,7 +104,13 @@ func (h *SchedulersHandler) GetScheduler(ctx context.Context, request *api.GetSc
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
 
-	return &api.GetSchedulerResponse{Scheduler: h.fromEntitySchedulerToResponse(scheduler)}, nil
+	returnScheduler, err := h.fromEntitySchedulerToResponse(scheduler)
+	if err != nil {
+		h.logger.Error("error parsing scheduler to response", zap.Any("schedulerName", schedulerName), zap.Error(err))
+		return nil, status.Error(codes.Unknown, err.Error())
+	}
+
+	return &api.GetSchedulerResponse{Scheduler: returnScheduler}, nil
 }
 
 func (h *SchedulersHandler) GetSchedulerVersions(ctx context.Context, request *api.GetSchedulerVersionsRequest) (*api.GetSchedulerVersionsResponse, error) {
@@ -136,7 +144,12 @@ func (h *SchedulersHandler) CreateScheduler(ctx context.Context, request *api.Cr
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
 
-	return &api.CreateSchedulerResponse{Scheduler: h.fromEntitySchedulerToResponse(scheduler)}, nil
+	returnScheduler, err := h.fromEntitySchedulerToResponse(scheduler)
+	if err != nil {
+		h.logger.Error("error parsing scheduler to response", zap.Any("schedulerName", request.GetName()), zap.Error(err))
+		return nil, status.Error(codes.Unknown, err.Error())
+	}
+	return &api.CreateSchedulerResponse{Scheduler: returnScheduler}, nil
 }
 
 func (h *SchedulersHandler) AddRooms(ctx context.Context, request *api.AddRoomsRequest) (*api.AddRoomsResponse, error) {
@@ -266,16 +279,21 @@ func (h *SchedulersHandler) fromApiNewSchedulerVersionRequestToEntity(request *a
 	)
 }
 
-func (h *SchedulersHandler) fromEntitySchedulerToResponse(entity *entities.Scheduler) *api.Scheduler {
-	return &api.Scheduler{
-		Name:      entity.Name,
-		Game:      entity.Game,
-		State:     entity.State,
-		PortRange: getPortRange(entity.PortRange),
-		CreatedAt: timestamppb.New(entity.CreatedAt),
-		MaxSurge:  entity.MaxSurge,
-		Spec:      getSpec(entity.Spec),
+func (h *SchedulersHandler) fromEntitySchedulerToResponse(entity *entities.Scheduler) (*api.Scheduler, error) {
+	forwarders, err := h.fromEntityForwardersToResponse(entity.Forwarders)
+	if err != nil {
+		return nil, err
 	}
+	return &api.Scheduler{
+		Name:       entity.Name,
+		Game:       entity.Game,
+		State:      entity.State,
+		PortRange:  getPortRange(entity.PortRange),
+		CreatedAt:  timestamppb.New(entity.CreatedAt),
+		MaxSurge:   entity.MaxSurge,
+		Spec:       getSpec(entity.Spec),
+		Forwarders: forwarders,
+	}, nil
 }
 
 func (h *SchedulersHandler) fromEntitySchedulerVersionListToResponse(entity []*entities.SchedulerVersion) []*api.SchedulerVersion {
@@ -288,6 +306,37 @@ func (h *SchedulersHandler) fromEntitySchedulerVersionListToResponse(entity []*e
 		}
 	}
 	return versions
+}
+
+func (h *SchedulersHandler) fromEntityForwardersToResponse(entities []*forwarder.Forwarder) ([]*api.Forwarder, error) {
+	forwarders := make([]*api.Forwarder, len(entities))
+	for i, entity := range entities {
+		opts, err := h.fromEntityForwardOptions(entity.Options)
+		if err != nil {
+			return nil, err
+		}
+
+		forwarders[i] = &api.Forwarder{
+			Name:    entity.Name,
+			Enable:  entity.Enabled,
+			Type:    fmt.Sprint(entity.ForwardType),
+			Address: entity.Address,
+			Options: opts,
+		}
+	}
+	return forwarders, nil
+}
+
+func (h *SchedulersHandler) fromEntityForwardOptions(entity *forwarder.ForwardOptions) (*api.ForwarderOptions, error) {
+	protoStruct, err := _struct.NewStruct(entity.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.ForwarderOptions{
+		Timeout:  int64(entity.Timeout),
+		Metadata: protoStruct,
+	}, nil
 }
 
 func (h *SchedulersHandler) fromApiSpec(apiSpec *api.Spec) *game_room.Spec {

--- a/internal/api/handlers/schedulers_handler_test.go
+++ b/internal/api/handlers/schedulers_handler_test.go
@@ -202,7 +202,7 @@ func TestGetScheduler(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
 
-		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(&entities.Scheduler{
+		scheduler := &entities.Scheduler{
 			Name:            "zooba-us",
 			Game:            "zooba",
 			State:           entities.StateInSync,
@@ -243,7 +243,20 @@ func TestGetScheduler(t *testing.T) {
 				Start: 1,
 				End:   2,
 			},
-		}, nil)
+			Forwarders: []*forwarder.Forwarder{
+				{
+					Name:        "forwarder-1",
+					Enabled:     true,
+					ForwardType: "gRPC",
+					Address:     "127.0.0.1:9090",
+					Options: &forwarder.ForwardOptions{
+						Timeout: time.Duration(1000),
+					},
+				},
+			},
+		}
+
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(scheduler, nil)
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterSchedulersServiceHandlerServer(context.Background(), mux, ProvideSchedulersHandler(schedulerManager))
@@ -260,12 +273,97 @@ func TestGetScheduler(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rr.Code)
 
+		var response struct {
+			Scheduler struct {
+				Name     string
+				Game     string
+				State    string
+				MaxSurge string
+				Spec     struct {
+					Version                string
+					TerminationGracePeriod string
+					Containers             []struct {
+						Name            string
+						Image           string
+						ImagePullPolicy string
+						Command         []string
+						Environment     []struct {
+							Name  string
+							Value string
+						}
+						Requests struct {
+							Memory string
+							CPU    string
+						}
+						Limits struct {
+							Memory string
+							CPU    string
+						}
+						Ports []struct {
+							Name     string
+							Protocol string
+							Port     int
+							HostPort int
+						}
+					}
+				}
+				PortRange  *entities.PortRange
+				Forwarders []*struct {
+					Name    string
+					Enable  bool
+					Type    string
+					Address string
+					Options struct {
+						Timeout  string
+						Metadata interface{}
+					}
+				}
+			} `json:"scheduler"`
+		}
+
 		bodyString := rr.Body.String()
-		var response api.GetSchedulerResponse
 		err = json.Unmarshal([]byte(bodyString), &response)
 		require.NoError(t, err)
 
-		require.NotEmpty(t, response.Scheduler)
+		schedulerResponse := response.Scheduler
+
+		assert.Equal(t, scheduler.Name, schedulerResponse.Name)
+		assert.Equal(t, scheduler.Game, schedulerResponse.Game)
+		assert.Equal(t, scheduler.State, schedulerResponse.State)
+		assert.Equal(t, scheduler.MaxSurge, schedulerResponse.MaxSurge)
+
+		specResponse := schedulerResponse.Spec
+		assert.Equal(t, scheduler.Spec.Version, specResponse.Version)
+		assert.Equal(t, fmt.Sprint(int64(scheduler.Spec.TerminationGracePeriod)), specResponse.TerminationGracePeriod)
+		for i, container := range specResponse.Containers {
+			assert.Equal(t, scheduler.Spec.Containers[i].Name, container.Name)
+			assert.Equal(t, scheduler.Spec.Containers[i].Image, container.Image)
+			assert.Equal(t, scheduler.Spec.Containers[i].ImagePullPolicy, container.ImagePullPolicy)
+			assert.Equal(t, scheduler.Spec.Containers[i].Command, container.Command)
+			for j, env := range container.Environment {
+				assert.Equal(t, scheduler.Spec.Containers[i].Environment[j].Name, env.Name)
+				assert.Equal(t, scheduler.Spec.Containers[i].Environment[j].Value, env.Value)
+			}
+			assert.Equal(t, scheduler.Spec.Containers[i].Requests.Memory, container.Requests.Memory)
+			assert.Equal(t, scheduler.Spec.Containers[i].Requests.CPU, container.Requests.CPU)
+			assert.Equal(t, scheduler.Spec.Containers[i].Limits.Memory, container.Limits.Memory)
+			assert.Equal(t, scheduler.Spec.Containers[i].Limits.CPU, container.Limits.CPU)
+			for j, port := range container.Ports {
+				assert.Equal(t, scheduler.Spec.Containers[i].Ports[j].Name, port.Name)
+				assert.Equal(t, scheduler.Spec.Containers[i].Ports[j].Protocol, port.Protocol)
+				assert.Equal(t, scheduler.Spec.Containers[i].Ports[j].Port, port.Port)
+				assert.Equal(t, scheduler.Spec.Containers[i].Ports[j].HostPort, port.HostPort)
+			}
+		}
+
+		assert.Equal(t, scheduler.PortRange, schedulerResponse.PortRange)
+		for i, forwarder := range schedulerResponse.Forwarders {
+			assert.Equal(t, scheduler.Forwarders[i].Name, forwarder.Name)
+			assert.Equal(t, scheduler.Forwarders[i].Enabled, forwarder.Enable)
+			assert.Equal(t, string(scheduler.Forwarders[i].ForwardType), forwarder.Type)
+			assert.Equal(t, scheduler.Forwarders[i].Address, forwarder.Address)
+			assert.Equal(t, fmt.Sprint(int64(scheduler.Forwarders[i].Options.Timeout)), forwarder.Options.Timeout)
+		}
 	})
 
 	t.Run("with valid request and no scheduler found", func(t *testing.T) {
@@ -483,14 +581,40 @@ func TestCreateScheduler(t *testing.T) {
 				Start: 1,
 				End:   1000,
 			},
+			Forwarders: []*forwarder.Forwarder{
+				{
+					Name:        "forwarder-1",
+					Enabled:     true,
+					ForwardType: "gRPC",
+					Address:     "127.0.0.1:9090",
+					Options: &forwarder.ForwardOptions{
+						Timeout: time.Duration(1000),
+					},
+				},
+			},
 		}
 
-		schedulerStorage.EXPECT().CreateScheduler(gomock.Any(), gomock.Eq(scheduler)).Return(nil)
+		schedulerStorage.EXPECT().CreateScheduler(gomock.Any(), gomock.Any()).Do(
+			func(_ interface{}, arg *entities.Scheduler) {
+				assert.Equal(t, scheduler.Name, arg.Name)
+				assert.Equal(t, scheduler.Game, arg.Game)
+				assert.Equal(t, scheduler.State, arg.State)
+				assert.Equal(t, scheduler.MaxSurge, arg.MaxSurge)
+				assert.Equal(t, scheduler.Spec, arg.Spec)
+				assert.Equal(t, scheduler.PortRange, arg.PortRange)
+				for i, forwarder := range arg.Forwarders {
+					assert.Equal(t, scheduler.Forwarders[i].Name, forwarder.Name)
+					assert.Equal(t, scheduler.Forwarders[i].Enabled, forwarder.Enabled)
+					assert.Equal(t, scheduler.Forwarders[i].Address, forwarder.Address)
+					assert.Equal(t, scheduler.Forwarders[i].Options.Timeout, forwarder.Options.Timeout)
+				}
+			},
+		).Return(nil)
 		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, gomock.Any()).Return(&operation.Operation{ID: "id-1"}, nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(scheduler, nil)
 
 		mux := runtime.NewServeMux()
-		err := api.RegisterSchedulersServiceHandlerServer(context.Background(), mux, ProvideSchedulersHandler(schedulerManager))
+		err = api.RegisterSchedulersServiceHandlerServer(context.Background(), mux, ProvideSchedulersHandler(schedulerManager))
 		require.NoError(t, err)
 
 		request, err := ioutil.ReadFile(dirPath + "/fixtures/request/scheduler-config.json")
@@ -503,27 +627,98 @@ func TestCreateScheduler(t *testing.T) {
 		mux.ServeHTTP(rr, req)
 
 		require.Equal(t, http.StatusOK, rr.Code)
+
+		var response struct {
+			Scheduler struct {
+				Name     string
+				Game     string
+				State    string
+				MaxSurge string
+				Spec     struct {
+					Version                string
+					TerminationGracePeriod string
+					Containers             []struct {
+						Name            string
+						Image           string
+						ImagePullPolicy string
+						Command         []string
+						Environment     []struct {
+							Name  string
+							Value string
+						}
+						Requests struct {
+							Memory string
+							CPU    string
+						}
+						Limits struct {
+							Memory string
+							CPU    string
+						}
+						Ports []struct {
+							Name     string
+							Protocol string
+							Port     int
+							HostPort int
+						}
+					}
+				}
+				PortRange  *entities.PortRange
+				Forwarders []*struct {
+					Name    string
+					Enable  bool
+					Type    string
+					Address string
+					Options struct {
+						Timeout  string
+						Metadata interface{}
+					}
+				}
+			} `json:"scheduler"`
+		}
+
 		bodyString := rr.Body.String()
-		var body map[string]interface{}
-		err = json.Unmarshal([]byte(bodyString), &body)
+		err = json.Unmarshal([]byte(bodyString), &response)
 		require.NoError(t, err)
 
-		schedulerContent, ok := body["scheduler"].(map[string]interface{})
-		require.NotNil(t, schedulerContent)
-		require.True(t, ok)
+		schedulerResponse := response.Scheduler
 
-		assert.Equal(t, "game-name", schedulerContent["game"])
-		assert.Equal(t, "scheduler-name-1", schedulerContent["name"])
-		assert.NotNil(t, schedulerContent["portRange"])
-		assert.Equal(t, "creating", schedulerContent["state"])
+		assert.Equal(t, scheduler.Name, schedulerResponse.Name)
+		assert.Equal(t, scheduler.Game, schedulerResponse.Game)
+		assert.Equal(t, scheduler.State, schedulerResponse.State)
+		assert.Equal(t, scheduler.MaxSurge, schedulerResponse.MaxSurge)
 
-		specContent, ok := schedulerContent["spec"].(map[string]interface{})
-		require.NotNil(t, schedulerContent)
-		require.True(t, ok)
+		specResponse := schedulerResponse.Spec
+		assert.Equal(t, scheduler.Spec.Version, specResponse.Version)
+		assert.Equal(t, fmt.Sprint(int64(scheduler.Spec.TerminationGracePeriod)), specResponse.TerminationGracePeriod)
+		for i, container := range specResponse.Containers {
+			assert.Equal(t, scheduler.Spec.Containers[i].Name, container.Name)
+			assert.Equal(t, scheduler.Spec.Containers[i].Image, container.Image)
+			assert.Equal(t, scheduler.Spec.Containers[i].ImagePullPolicy, container.ImagePullPolicy)
+			assert.Equal(t, scheduler.Spec.Containers[i].Command, container.Command)
+			for j, env := range container.Environment {
+				assert.Equal(t, scheduler.Spec.Containers[i].Environment[j].Name, env.Name)
+				assert.Equal(t, scheduler.Spec.Containers[i].Environment[j].Value, env.Value)
+			}
+			assert.Equal(t, scheduler.Spec.Containers[i].Requests.Memory, container.Requests.Memory)
+			assert.Equal(t, scheduler.Spec.Containers[i].Requests.CPU, container.Requests.CPU)
+			assert.Equal(t, scheduler.Spec.Containers[i].Limits.Memory, container.Limits.Memory)
+			assert.Equal(t, scheduler.Spec.Containers[i].Limits.CPU, container.Limits.CPU)
+			for j, port := range container.Ports {
+				assert.Equal(t, scheduler.Spec.Containers[i].Ports[j].Name, port.Name)
+				assert.Equal(t, scheduler.Spec.Containers[i].Ports[j].Protocol, port.Protocol)
+				assert.Equal(t, scheduler.Spec.Containers[i].Ports[j].Port, port.Port)
+				assert.Equal(t, scheduler.Spec.Containers[i].Ports[j].HostPort, port.HostPort)
+			}
+		}
 
-		assert.Equal(t, "v1.0.0", specContent["version"])
-		assert.Equal(t, "10%", schedulerContent["maxSurge"])
-		assert.NotNil(t, schedulerContent["createdAt"])
+		assert.Equal(t, scheduler.PortRange, schedulerResponse.PortRange)
+		for i, forwarder := range schedulerResponse.Forwarders {
+			assert.Equal(t, scheduler.Forwarders[i].Name, forwarder.Name)
+			assert.Equal(t, scheduler.Forwarders[i].Enabled, forwarder.Enable)
+			assert.Equal(t, string(scheduler.Forwarders[i].ForwardType), forwarder.Type)
+			assert.Equal(t, scheduler.Forwarders[i].Address, forwarder.Address)
+			assert.Equal(t, fmt.Sprint(int64(scheduler.Forwarders[i].Options.Timeout)), forwarder.Options.Timeout)
+		}
 	})
 
 	t.Run("with failure", func(t *testing.T) {


### PR DESCRIPTION
### Why
`GetScheduler` and `CreateScheduler` aren't returning the scheduler's forwarders.

### What
The handlers aren't parsing the `Forwarders` members when coming from entities.

### How
Parsing `Forwarders` when coming from entities and adding tests to handle these cases.