### PR TITLE
Fix/maintain scheduler version hierarchy on switch version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ license-check: ## Execute license check.
 
 .PHONY: run/e2e-tests
 run/e2e-tests: build-linux-x86_64 setup/e2e deps/stop ## Execute end-to-end tests.
-	@cd e2e; go test -count=1 $(OPTS) ./suites/...
+	@cd e2e; go test -count=1 -v $(OPTS) ./suites/...
 
 #-------------------------------------------------------------------------------
 #  Build and run

--- a/e2e/suites/management/create_new_scheduler_version_test.go
+++ b/e2e/suites/management/create_new_scheduler_version_test.go
@@ -25,8 +25,6 @@ package management
 import (
 	"context"
 	"fmt"
-	_struct "github.com/golang/protobuf/ptypes/struct"
-	"google.golang.org/protobuf/types/known/structpb"
 	"time"
 
 	"testing"
@@ -47,10 +45,12 @@ import (
 func TestCreateNewSchedulerVersion(t *testing.T) {
 	game := "create-new-scheduler-version-game"
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
-		t.Run("Should Succeed - create minor version, no pods replaces", func(t *testing.T) {
+		t.Run("Should Succeed - create minor version, no pods replaces, create major version, all pods are changed", func(t *testing.T) {
 			t.Parallel()
 
 			scheduler, err := createSchedulerWithRoomsAndWaitForIt(t, maestro, managementApiClient, game, kubeClient)
+
+			// ----------- Create new Minor version v1.1.0 and assert pods are not replace
 
 			podsBeforeUpdate, err := kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
 			require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestCreateNewSchedulerVersion(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, updateResponse.OperationId, scheduler.Name)
 
-			waitForOperationToFinish(t, managementApiClient, scheduler.Name, "create_new_scheduler_version")
+			waitForOperationToFinishByOperationId(t, managementApiClient, scheduler.Name, updateResponse.OperationId)
 			waitForOperationToFinish(t, managementApiClient, scheduler.Name, "switch_active_version")
 
 			podsAfterUpdate, err := kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
@@ -122,17 +122,14 @@ func TestCreateNewSchedulerVersion(t *testing.T) {
 				require.Equal(t, podsAfterUpdate.Items[i].Name, podsBeforeUpdate.Items[i].Name)
 			}
 
-			// Switches to version v1.1.0
 			require.Equal(t, "v1.1.0", getSchedulerResponse.Scheduler.Spec.Version)
-		})
 
-		t.Run("Should Succeed - create major change, all pods are changed", func(t *testing.T) {
-			t.Parallel()
+			//  ----------- Create new Major version v2.0.0 and assert pods are replaced
+			podsBeforeUpdate, err = kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
 
-			schedulerName, roomNameBeforeUpdate := createSchedulerWithForwarderAndRooms(t, maestro, kubeClient, managementApiClient, maestro.ServerMocks.GrpcForwarderAddress)
-
-			updateRequest := &maestroApiV1.NewSchedulerVersionRequest{
-				Name:     schedulerName,
+			updateRequest = &maestroApiV1.NewSchedulerVersionRequest{
+				Name:     scheduler.Name,
 				Game:     "test",
 				MaxSurge: "10%",
 				Spec: &maestrov1.Spec{
@@ -174,94 +171,225 @@ func TestCreateNewSchedulerVersion(t *testing.T) {
 					End:   8000,
 				},
 			}
-			updateResponse := &maestroApiV1.NewSchedulerVersionResponse{}
+			updateResponse = &maestroApiV1.NewSchedulerVersionResponse{}
 
-			err := managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s", schedulerName), updateRequest, updateResponse)
+			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s", scheduler.Name), updateRequest, updateResponse)
 			require.NoError(t, err)
-			require.NotNil(t, updateResponse.OperationId, schedulerName)
+			require.NotNil(t, updateResponse.OperationId, scheduler.Name)
 
-			// Wait till we have 3 pods (the third one is the validation one). Then, try to forward event.
-			// Since we don't forward event from validation room, it should return true even though we're not
-			// mocking the gRPC call.
+			waitForOperationToFinishByOperationId(t, managementApiClient, scheduler.Name, updateResponse.OperationId)
+			waitForOperationToFinish(t, managementApiClient, scheduler.Name, "switch_active_version")
+
 			require.Eventually(t, func() bool {
-				pods, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
-				require.NoError(t, err)
-				require.NotEmpty(t, pods.Items)
-
-				if len(pods.Items) == 2 {
-					var validationRoomName string
-					for _, room := range pods.Items {
-						if room.ObjectMeta.Name != roomNameBeforeUpdate {
-							validationRoomName = room.ObjectMeta.Name
-							break
-						}
-					}
-
-					playerEventRequest := &maestroApiV1.ForwardPlayerEventRequest{
-						RoomName: validationRoomName,
-						Event:     "playerLeft",
-						Timestamp: time.Now().Unix(),
-						Metadata: &_struct.Struct{
-							Fields: map[string]*structpb.Value{
-								"playerId": {
-									Kind: &structpb.Value_StringValue{
-										StringValue: "c50acc91-4d88-46fa-aa56-48d63c5b5311",
-									},
-								},
-								"eventMetadata1": {
-									Kind: &structpb.Value_StringValue{
-										StringValue: "value1",
-									},
-								},
-								"eventMetadata2": {
-									Kind: &structpb.Value_BoolValue{
-										BoolValue: true,
-									},
-								},
-							},
-						},
-					}
-					playerEventResponse := &maestroApiV1.ForwardPlayerEventResponse{}
-					err = roomsApiClient.Do("POST", fmt.Sprintf("/scheduler/%s/rooms/%s/playerevent", schedulerName, validationRoomName), playerEventRequest, playerEventResponse)
-					require.NoError(t, err)
-					require.Equal(t, true, playerEventResponse.Success)
-
+				getSchedulerRequest = &maestroApiV1.GetSchedulerRequest{SchedulerName: scheduler.Name}
+				getSchedulerResponse = &maestroApiV1.GetSchedulerResponse{}
+				err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", scheduler.Name), getSchedulerRequest, getSchedulerResponse)
+				if getSchedulerResponse.Scheduler.Spec.Version == "v2.0.0" {
 					return true
 				}
-
 				return false
-			}, 2*time.Minute, time.Second)
+			}, 1*time.Minute, time.Second)
 
-			waitForOperationToFinish(t, managementApiClient, schedulerName, "create_new_scheduler_version")
-			waitForOperationToFinish(t, managementApiClient, schedulerName, "switch_active_version")
-
-			getSchedulerRequest := &maestroApiV1.GetSchedulerRequest{SchedulerName: schedulerName}
-			getSchedulerResponse := &maestroApiV1.GetSchedulerResponse{}
-
-			err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", schedulerName), getSchedulerRequest, getSchedulerResponse)
 			require.NoError(t, err)
 
-			// Wait till we have only 1 room again
 			require.Eventually(t, func() bool {
-				podsAfterUpdate, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+				podsAfterUpdate, err := kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
 				require.NoError(t, err)
 				require.NotEmpty(t, podsAfterUpdate.Items)
 
-				if len(podsAfterUpdate.Items) == 1 {
+				if len(podsAfterUpdate.Items) == 2 {
 					return true
 				}
 
 				return false
-			}, 2*time.Minute, time.Second)
+			}, 1*time.Minute, time.Second)
 
-			podsAfterUpdate, err := kubeClient.CoreV1().Pods(schedulerName).List(context.Background(), metav1.ListOptions{})
+			podsAfterUpdate, err = kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
 			require.NoError(t, err)
 			require.NotEmpty(t, podsAfterUpdate.Items)
 
+			// Replace pods since is a minor change
+			for i := 0; i < 2; i++ {
+				require.NotEqual(t, podsAfterUpdate.Items[i].Spec, podsBeforeUpdate.Items[i].Spec)
+				require.Equal(t, "example-update", podsAfterUpdate.Items[i].Spec.Containers[0].Name)
+			}
 
-			require.NotEqual(t, podsAfterUpdate.Items[0].ObjectMeta.Name, roomNameBeforeUpdate)
+			// ----------- Switch back to v1.0.0
+			switchActiveVersionRequest := &maestroApiV1.SwitchActiveVersionRequest{
+				SchedulerName: scheduler.Name,
+				Version:       "v1.0.0",
+			}
+			switchActiveVersionResponse := &maestroApiV1.SwitchActiveVersionResponse{}
+			err = managementApiClient.Do("PUT", fmt.Sprintf("/schedulers/%s", scheduler.Name), switchActiveVersionRequest, switchActiveVersionResponse)
+			require.NoError(t, err)
 
-			require.Equal(t, "v2.0.0", getSchedulerResponse.Scheduler.Spec.Version)
+			waitForOperationToFinishByOperationId(t, managementApiClient, scheduler.Name, switchActiveVersionResponse.OperationId)
+
+			// ----------- Create new Minor version v1.2.0 (since v1.1.0 already exists) and assert pods are not replace
+
+			podsBeforeUpdate, err = kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			// Update scheduler
+			updateRequest = &maestroApiV1.NewSchedulerVersionRequest{
+				Name:     scheduler.Name,
+				Game:     "test",
+				MaxSurge: "10%",
+				Spec: &maestrov1.Spec{
+					TerminationGracePeriod: 15,
+					Containers: []*maestroApiV1.Container{
+						{
+							Name:  "example",
+							Image: "alpine:3.15.0",
+							Command: []string{"/bin/sh", "-c", "apk add curl && " + "while true; do curl --request POST " +
+								"$ROOMS_API_ADDRESS/scheduler/$MAESTRO_SCHEDULER_NAME/rooms/$MAESTRO_ROOM_ID/ping " +
+								"--data-raw '{\"status\": \"ready\",\"timestamp\": \"12312312313\"}' && sleep 1; done"},
+							ImagePullPolicy: "Always",
+							Environment: []*maestroApiV1.ContainerEnvironment{
+								{
+									Name:  "ROOMS_API_ADDRESS",
+									Value: maestro.RoomsApiServer.ContainerInternalAddress,
+								},
+							},
+							Requests: &maestroApiV1.ContainerResources{
+								Memory: "20Mi",
+								Cpu:    "10m",
+							},
+							Limits: &maestroApiV1.ContainerResources{
+								Memory: "20Mi",
+								Cpu:    "10m",
+							},
+							Ports: []*maestroApiV1.ContainerPort{
+								{
+									Name:     "default",
+									Protocol: "tcp",
+									Port:     80,
+								},
+							},
+						},
+					},
+				},
+				PortRange: &maestroApiV1.PortRange{
+					Start: 80,
+					End:   8000,
+				},
+			}
+			updateResponse = &maestroApiV1.NewSchedulerVersionResponse{}
+
+			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s", scheduler.Name), updateRequest, updateResponse)
+			require.NoError(t, err)
+			require.NotNil(t, updateResponse.OperationId, scheduler.Name)
+
+			waitForOperationToFinishByOperationId(t, managementApiClient, scheduler.Name, updateResponse.OperationId)
+			waitForOperationToFinish(t, managementApiClient, scheduler.Name, "switch_active_version")
+
+			podsAfterUpdate, err = kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t, podsAfterUpdate.Items)
+
+			require.Eventually(t, func() bool {
+				getSchedulerRequest = &maestroApiV1.GetSchedulerRequest{SchedulerName: scheduler.Name}
+				getSchedulerResponse = &maestroApiV1.GetSchedulerResponse{}
+				err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", scheduler.Name), getSchedulerRequest, getSchedulerResponse)
+				if getSchedulerResponse.Scheduler.Spec.Version == "v1.2.0" {
+					return true
+				}
+				return false
+			}, 1*time.Minute, time.Second)
+
+			// Don't replace pods since is a minor change
+			for i := 0; i < 2; i++ {
+				require.Equal(t, podsAfterUpdate.Items[i].Name, podsBeforeUpdate.Items[i].Name)
+			}
+
+			//  ----------- Create new Major version v3.0.0 (since v2.0.0 already exists) and assert pods are replaced
+			podsBeforeUpdate, err = kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			updateRequest = &maestroApiV1.NewSchedulerVersionRequest{
+				Name:     scheduler.Name,
+				Game:     "test",
+				MaxSurge: "10%",
+				Spec: &maestrov1.Spec{
+					TerminationGracePeriod: 15,
+					Containers: []*maestroApiV1.Container{
+						{
+							Name:  "example-update",
+							Image: "alpine:3.15.0",
+							Command: []string{"/bin/sh", "-c", "apk add curl && " + "while true; do curl --request POST " +
+								"$ROOMS_API_ADDRESS/scheduler/$MAESTRO_SCHEDULER_NAME/rooms/$MAESTRO_ROOM_ID/ping " +
+								"--data-raw '{\"status\": \"ready\",\"timestamp\": \"12312312313\"}' && sleep 1; done"},
+							ImagePullPolicy: "Always",
+							Environment: []*maestroApiV1.ContainerEnvironment{
+								{
+									Name:  "ROOMS_API_ADDRESS",
+									Value: maestro.RoomsApiServer.ContainerInternalAddress,
+								},
+							},
+							Requests: &maestroApiV1.ContainerResources{
+								Memory: "20Mi",
+								Cpu:    "10m",
+							},
+							Limits: &maestroApiV1.ContainerResources{
+								Memory: "20Mi",
+								Cpu:    "10m",
+							},
+							Ports: []*maestroApiV1.ContainerPort{
+								{
+									Name:     "default",
+									Protocol: "tcp",
+									Port:     80,
+								},
+							},
+						},
+					},
+				},
+				PortRange: &maestroApiV1.PortRange{
+					Start: 80,
+					End:   8000,
+				},
+			}
+			updateResponse = &maestroApiV1.NewSchedulerVersionResponse{}
+
+			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s", scheduler.Name), updateRequest, updateResponse)
+			require.NoError(t, err)
+			require.NotNil(t, updateResponse.OperationId, scheduler.Name)
+
+			waitForOperationToFinishByOperationId(t, managementApiClient, scheduler.Name, updateResponse.OperationId)
+			waitForOperationToFinish(t, managementApiClient, scheduler.Name, "switch_active_version")
+
+			require.Eventually(t, func() bool {
+				getSchedulerRequest = &maestroApiV1.GetSchedulerRequest{SchedulerName: scheduler.Name}
+				getSchedulerResponse = &maestroApiV1.GetSchedulerResponse{}
+				err = managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s", scheduler.Name), getSchedulerRequest, getSchedulerResponse)
+				if getSchedulerResponse.Scheduler.Spec.Version == "v3.0.0" {
+					return true
+				}
+				return false
+			}, 1*time.Minute, time.Second)
+
+			require.Eventually(t, func() bool {
+				podsAfterUpdate, err := kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
+				require.NoError(t, err)
+				require.NotEmpty(t, podsAfterUpdate.Items)
+
+				if len(podsAfterUpdate.Items) == 2 {
+					return true
+				}
+
+				return false
+			}, 1*time.Minute, time.Second)
+
+			podsAfterUpdate, err = kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t, podsAfterUpdate.Items)
+
+			// Replace pods since is a minor change
+			for i := 0; i < 2; i++ {
+				require.NotEqual(t, podsAfterUpdate.Items[i].Spec, podsBeforeUpdate.Items[i].Spec)
+				require.Equal(t, "example-update", podsAfterUpdate.Items[i].Spec.Containers[0].Name)
+			}
+
 		})
 
 		t.Run("Should Fail - When scheduler when sending invalid request to update endpoint it fails fast", func(t *testing.T) {

--- a/internal/core/entities/scheduler.go
+++ b/internal/core/entities/scheduler.go
@@ -97,6 +97,7 @@ func (s *Scheduler) IsMajorVersion(newScheduler *Scheduler) bool {
 		cmpopts.IgnoreFields(
 			Scheduler{},
 			"Name",
+			"Spec.Version",
 			"Game",
 			"State",
 			"RollbackVersion",

--- a/internal/core/entities/scheduler_test.go
+++ b/internal/core/entities/scheduler_test.go
@@ -155,6 +155,69 @@ func TestIsMajorVersion(t *testing.T) {
 			newScheduler:     &entities.Scheduler{Spec: game_room.Spec{Version: "v1.2.0"}},
 			expected:         false,
 		},
+		"host port shouldn't be a major": {
+			currentScheduler: &entities.Scheduler{Spec: game_room.Spec{Containers: []game_room.Container{
+				{
+					Name: "Name1",
+					Ports: []game_room.ContainerPort{
+						{
+							Name:     "port1",
+							Protocol: "http",
+							HostPort: 10,
+						},
+						{
+							Name:     "port2",
+							Protocol: "http",
+							HostPort: 20,
+						},
+					}},
+				{
+					Name: "Name2",
+					Ports: []game_room.ContainerPort{
+						{
+							Name:     "port1",
+							Protocol: "http",
+							HostPort: 30,
+						},
+						{
+							Name:     "port2",
+							Protocol: "http",
+							HostPort: 40,
+						},
+					}},
+			}}},
+			newScheduler: &entities.Scheduler{Spec: game_room.Spec{Containers: []game_room.Container{
+				{
+					Name: "Name1",
+					Ports: []game_room.ContainerPort{
+						{
+							Name:     "port1",
+							Protocol: "http",
+							HostPort: 91,
+						},
+						{
+							Name:     "port2",
+							Protocol: "http",
+							HostPort: 92,
+						},
+					}},
+				{
+					Name: "Name2",
+					Ports: []game_room.ContainerPort{
+						{
+							Name:     "port1",
+							Protocol: "http",
+							HostPort: 93,
+						},
+						{
+							Name:     "port2",
+							Protocol: "http",
+							HostPort: 94,
+						},
+					}},
+			}}},
+			expected: false,
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/core/entities/scheduler_test.go
+++ b/internal/core/entities/scheduler_test.go
@@ -150,6 +150,11 @@ func TestIsMajorVersion(t *testing.T) {
 			newScheduler:     &entities.Scheduler{MaxSurge: "100"},
 			expected:         false,
 		},
+		"spec version shouldn't be a major": {
+			currentScheduler: &entities.Scheduler{Spec: game_room.Spec{Version: "v1.1.0"}},
+			newScheduler:     &entities.Scheduler{Spec: game_room.Spec{Version: "v1.2.0"}},
+			expected:         false,
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -79,7 +79,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Execute(ctx context.Context, op *op
 
 	isSchedulerMajorVersion := currentActiveScheduler.IsMajorVersion(newScheduler)
 
-	err = ex.populateSchedulerNewVersion(newScheduler, currentActiveScheduler.Spec.Version, isSchedulerMajorVersion)
+	err = ex.populateSchedulerNewVersion(ctx, newScheduler, currentActiveScheduler.Spec.Version, isSchedulerMajorVersion)
 	if err != nil {
 		return err
 	}
@@ -155,18 +155,67 @@ func (ex *CreateNewSchedulerVersionExecutor) createNewSchedulerVersionAndEnqueue
 	return nil
 }
 
-func (ex *CreateNewSchedulerVersionExecutor) populateSchedulerNewVersion(newScheduler *entities.Scheduler, currentVersion string, isMajorVersion bool) error {
+func (ex *CreateNewSchedulerVersionExecutor) populateSchedulerNewVersion(ctx context.Context, newScheduler *entities.Scheduler, currentVersion string, isMajorVersion bool) error {
 	var newVersion semver.Version
 	currentVersionSemver, err := semver.NewVersion(currentVersion)
 	if err != nil {
 		return fmt.Errorf("failed to parse scheduler current version: %w", err)
 	}
 	if isMajorVersion {
-		newVersion = currentVersionSemver.IncMajor()
+		newVersion, err = ex.calculateNewMajorVersion(ctx, newScheduler.Name, currentVersionSemver)
+		if err != nil {
+			return fmt.Errorf("failed to calculate new major version: %w", err)
+		}
 	} else {
-		newVersion = currentVersionSemver.IncMinor()
+		newVersion, err = ex.calculateNewMinorVersion(ctx, newScheduler.Name, currentVersionSemver)
+		if err != nil {
+			return fmt.Errorf("failed to calculate new minor version: %w", err)
+		}
 	}
 	newScheduler.SetSchedulerVersion(newVersion.Original())
 	newScheduler.SetSchedulerRollbackVersion(currentVersion)
 	return nil
+}
+
+func (ex *CreateNewSchedulerVersionExecutor) calculateNewMajorVersion(ctx context.Context, schedulerName string, currentActiveVersionSemver *semver.Version) (semver.Version, error) {
+	var newVersion semver.Version
+	var greatestMajorVersion = currentActiveVersionSemver
+	schedulerVersions, err := ex.schedulerManager.GetSchedulerVersions(ctx, schedulerName)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("failed to load scheduler versions: %w", err)
+	}
+	for _, schedulerVersion := range schedulerVersions {
+		version, vErr := semver.NewVersion(schedulerVersion.Version)
+		if vErr != nil {
+			return newVersion, fmt.Errorf("failed to parse scheduler version %s: %w", schedulerVersion.Version, vErr)
+		}
+		if version.Major() > greatestMajorVersion.Major() {
+			greatestMajorVersion = version
+		}
+	}
+
+	newVersion = greatestMajorVersion.IncMajor()
+	return newVersion, nil
+}
+
+func (ex *CreateNewSchedulerVersionExecutor) calculateNewMinorVersion(ctx context.Context, schedulerName string, currentActiveVersionSemver *semver.Version) (semver.Version, error) {
+	var newVersion semver.Version
+	var greatestMinorVersion = currentActiveVersionSemver
+	schedulerVersions, err := ex.schedulerManager.GetSchedulerVersions(ctx, schedulerName)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("failed to load scheduler versions: %w", err)
+	}
+
+	for _, schedulerVersion := range schedulerVersions {
+		version, vErr := semver.NewVersion(schedulerVersion.Version)
+		if vErr != nil {
+			return newVersion, fmt.Errorf("failed to parse scheduler version %s: %w", schedulerVersion.Version, vErr)
+		}
+		if version.Major() == currentActiveVersionSemver.Major() && version.Minor() > greatestMinorVersion.Minor() {
+			greatestMinorVersion = version
+		}
+	}
+
+	newVersion = greatestMinorVersion.IncMinor()
+	return newVersion, nil
 }

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -91,13 +91,12 @@ func (ex *CreateNewSchedulerVersionExecutor) Execute(ctx context.Context, op *op
 			return err
 		}
 	}
-
 	err = ex.createNewSchedulerVersionAndEnqueueSwitchVersionOp(ctx, newScheduler, logger, isSchedulerMajorVersion)
 	if err != nil {
 		return err
 	}
-
-	logger.Info(fmt.Sprintf("%s operation succeded, %s operation enqueued to continue scheduler update process", opDef.Name(), switch_active_version.OperationName))
+	logger.Sugar().Infof("new scheduler version created: %s, is major: %t", newScheduler.Spec.Version, isSchedulerMajorVersion)
+	logger.Sugar().Infof("%s operation succeded, %s operation enqueued to continue scheduler update process, switching to version %s", opDef.Name(), switch_active_version.OperationName, newScheduler.Spec.Version)
 	return nil
 }
 

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -148,8 +148,6 @@ func (ex *SwitchActiveVersionExecutor) startReplaceRoomsLoop(ctx context.Context
 	roomsChan := make(chan *game_room.GameRoom)
 	errs, ctx := errgroup.WithContext(ctx)
 
-	logger.Sugar().Debugf("maxSurgeNum %d", maxSurgeNum)
-
 	for i := 0; i < maxSurgeNum; i++ {
 		errs.Go(func() error {
 			return ex.replaceRoom(logger, roomsChan, ex.roomManager, scheduler)
@@ -158,13 +156,10 @@ func (ex *SwitchActiveVersionExecutor) startReplaceRoomsLoop(ctx context.Context
 
 roomsListLoop:
 	for {
-		logger.Sugar().Debug("listing schedulers to replace ", zap.String("version", scheduler.Spec.Version))
 		rooms, err := ex.roomManager.ListRoomsWithDeletionPriority(ctx, scheduler.Name, scheduler.Spec.Version, maxSurgeNum, ex.roomsBeingReplaced)
-		logger.Sugar().Debug("rooms to replace:", zap.Any("rooms", rooms))
 		if err != nil {
 			return fmt.Errorf("failed to list rooms for deletion")
 		}
-
 		for _, room := range rooms {
 			ex.roomsBeingReplaced.Store(room.ID, true)
 			select {

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -148,6 +148,8 @@ func (ex *SwitchActiveVersionExecutor) startReplaceRoomsLoop(ctx context.Context
 	roomsChan := make(chan *game_room.GameRoom)
 	errs, ctx := errgroup.WithContext(ctx)
 
+	logger.Sugar().Debugf("maxSurgeNum %d", maxSurgeNum)
+
 	for i := 0; i < maxSurgeNum; i++ {
 		errs.Go(func() error {
 			return ex.replaceRoom(logger, roomsChan, ex.roomManager, scheduler)
@@ -156,7 +158,9 @@ func (ex *SwitchActiveVersionExecutor) startReplaceRoomsLoop(ctx context.Context
 
 roomsListLoop:
 	for {
+		logger.Sugar().Debug("listing schedulers to replace ", zap.String("version", scheduler.Spec.Version))
 		rooms, err := ex.roomManager.ListRoomsWithDeletionPriority(ctx, scheduler.Name, scheduler.Spec.Version, maxSurgeNum, ex.roomsBeingReplaced)
+		logger.Sugar().Debug("rooms to replace:", zap.Any("rooms", rooms))
 		if err != nil {
 			return fmt.Errorf("failed to list rooms for deletion")
 		}

--- a/internal/core/ports/mock/scheduler_ports_mock.go
+++ b/internal/core/ports/mock/scheduler_ports_mock.go
@@ -111,6 +111,21 @@ func (mr *MockSchedulerManagerMockRecorder) GetActiveScheduler(ctx, schedulerNam
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveScheduler", reflect.TypeOf((*MockSchedulerManager)(nil).GetActiveScheduler), ctx, schedulerName)
 }
 
+// GetSchedulerVersions mocks base method.
+func (m *MockSchedulerManager) GetSchedulerVersions(ctx context.Context, schedulerName string) ([]*entities.SchedulerVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSchedulerVersions", ctx, schedulerName)
+	ret0, _ := ret[0].([]*entities.SchedulerVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSchedulerVersions indicates an expected call of GetSchedulerVersions.
+func (mr *MockSchedulerManagerMockRecorder) GetSchedulerVersions(ctx, schedulerName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedulerVersions", reflect.TypeOf((*MockSchedulerManager)(nil).GetSchedulerVersions), ctx, schedulerName)
+}
+
 // GetSchedulersInfo mocks base method.
 func (m *MockSchedulerManager) GetSchedulersInfo(ctx context.Context, filter *filters.SchedulerFilter) ([]*entities.SchedulerInfo, error) {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/scheduler_ports.go
+++ b/internal/core/ports/scheduler_ports.go
@@ -41,6 +41,7 @@ type SchedulerManager interface {
 	EnqueueSwitchActiveVersionOperation(ctx context.Context, newScheduler *entities.Scheduler, replacePods bool) (*operation.Operation, error)
 	SwitchActiveVersion(ctx context.Context, schedulerName string, targetVersion string) (*operation.Operation, error)
 	GetSchedulersInfo(ctx context.Context, filter *filters.SchedulerFilter) ([]*entities.SchedulerInfo, error)
+	GetSchedulerVersions(ctx context.Context, schedulerName string) ([]*entities.SchedulerVersion, error)
 	DeleteScheduler(ctx context.Context, schedulerName string) error
 }
 


### PR DESCRIPTION
## What ❓
Create methods for calculating new major and minor versions, considering that the versions hierarchy should be maintained even if we are creating new versions from previous versions and not the most recent one. 

## Why 🤔 
If we switch to a previous scheduler version and then create a minor or major version, maestro is overriding higher versions and not dealing with this scenario correctly.

We have to fix the following scenarios:

- We have three versions, v1.0.0(active) and v1.1.0 and v2.0.0. If i create a new minor version:
  - What is happening: maestro overrides v1.1.0
  - What is expected to happen: maestro creates a new version v1.2.0

- We have three versions, v1.0.0(active), v1.1.0 and v2.0.0. If i create a new major version:
  - What is happening: maestro overrides v2.0.0
  - What is expected to happen: maestro create a new major version v3.0.0

## How 👀 
- Create and unify `create_new_scheduler_version` e2e tests, including both new scenarios described above.
- Implement a method for calculating the new major version and new minor version, always considering what is the greatest minor and major version.
- Implement fix for the `IsMajorVersion` method from scheduler, it was not ignoring the spec `version` field (that will be different in some scenarios but should not be considered in the comparison), and the containers HostPort, which is a field populated by maestro and should also not be considered in the comparison. 
- Improve switch active version e2e tests to ensure that a change from minor to minor does not replace pods