### PR TITLE
Review debug logs

### DIFF
--- a/internal/core/operations/add_rooms/add_rooms_executor.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor.go
@@ -104,7 +104,7 @@ func (ex *AddRoomsExecutor) OnError(ctx context.Context, op *operation.Operation
 	if err != nil {
 		return err
 	}
-	executionLogger.Debug("finished OnError routine")
+	executionLogger.Info("finished OnError routine")
 	return nil
 }
 
@@ -125,7 +125,7 @@ func (ex *AddRoomsExecutor) createRoom(ctx context.Context, scheduler *entities.
 }
 
 func (ex *AddRoomsExecutor) deleteNewCreatedRooms(ctx context.Context, logger *zap.Logger, schedulerName string) error {
-	logger.Debug("deleting created rooms since add rooms operation had error - start")
+	logger.Info("deleting created rooms since add rooms operation had error - start")
 	for _, room := range ex.newCreatedRooms[schedulerName] {
 		err := ex.roomManager.DeleteRoomAndWaitForRoomTerminated(ctx, room)
 		if err != nil {
@@ -134,7 +134,7 @@ func (ex *AddRoomsExecutor) deleteNewCreatedRooms(ctx context.Context, logger *z
 		}
 		logger.Sugar().Debugf("deleted room \"%s\" successfully", room.ID)
 	}
-	logger.Debug("deleting created rooms since add rooms operation had error - end successfully")
+	logger.Info("deleting created rooms since add rooms operation had error - end successfully")
 	return nil
 }
 

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -73,7 +73,7 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 		zap.String(logs.LogFieldOperationDefinition, definition.Name()),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
-	logger.Debug("start switching scheduler active version")
+	logger.Info("start switching scheduler active version")
 
 	updateDefinition, ok := definition.(*SwitchActiveVersionDefinition)
 	if !ok {
@@ -103,7 +103,7 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 	}
 
 	ex.clearNewCreatedRooms(op.SchedulerName)
-	logger.Debug("scheduler update finishes with success")
+	logger.Info("scheduler update finishes with success")
 	return nil
 }
 
@@ -121,7 +121,7 @@ func (ex *SwitchActiveVersionExecutor) OnError(ctx context.Context, op *operatio
 		return err
 	}
 
-	logger.Debug("finished OnError routine")
+	logger.Info("finished OnError routine")
 	return nil
 }
 
@@ -130,7 +130,7 @@ func (ex *SwitchActiveVersionExecutor) Name() string {
 }
 
 func (ex *SwitchActiveVersionExecutor) deleteNewCreatedRooms(ctx context.Context, logger *zap.Logger, schedulerName string) error {
-	logger.Debug("deleting created rooms since switching active version had error - start")
+	logger.Info("deleting created rooms since switching active version had error - start")
 	for _, room := range ex.newCreatedRooms[schedulerName] {
 		err := ex.roomManager.DeleteRoomAndWaitForRoomTerminated(ctx, room)
 		if err != nil {
@@ -139,12 +139,12 @@ func (ex *SwitchActiveVersionExecutor) deleteNewCreatedRooms(ctx context.Context
 		}
 		logger.Sugar().Debugf("deleted room \"%s\" successfully", room.ID)
 	}
-	logger.Debug("deleting created rooms since switching active version had error - end successfully")
+	logger.Info("deleting created rooms since switching active version had error - end successfully")
 	return nil
 }
 
 func (ex *SwitchActiveVersionExecutor) startReplaceRoomsLoop(ctx context.Context, logger *zap.Logger, maxSurgeNum int, scheduler entities.Scheduler) error {
-	logger.Debug("replacing rooms loop - start")
+	logger.Info("replacing rooms loop - start")
 	roomsChan := make(chan *game_room.GameRoom)
 	errs, ctx := errgroup.WithContext(ctx)
 
@@ -182,7 +182,7 @@ roomsListLoop:
 	if err := errs.Wait(); err != nil {
 		return err
 	}
-	logger.Debug("replacing rooms loop - finish")
+	logger.Info("replacing rooms loop - finish")
 	return nil
 }
 

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -178,7 +178,7 @@ func (w *OperationExecutionWorker) IsRunning() bool {
 
 // TODO(gabrielcorado): consider handling the finish operation error.
 func (w *OperationExecutionWorker) evictOperation(ctx context.Context, logger *zap.Logger, op *operation.Operation) {
-	logger.Debug("operation evicted")
+	logger.Info("operation evicted")
 	op.Status = operation.StatusEvicted
 	_ = w.operationManager.FinishOperation(ctx, op)
 }


### PR DESCRIPTION
### Why?
Having some logs as "Debug" makes it harder to troubleshoot in production. Because of this, some logs we wrote as "debug" should be reviewed.