### PR TITLE
Review production logs configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,19 +78,19 @@ build-linux-x86_64: ## Build the project and generates a binary for x86_64 archi
 
 .PHONY: run/worker
 run/worker: ## Runs maestro worker.
-	@go run main.go start worker
+	@go run main.go start worker -l development
 
 .PHONY: run/management-api
 run/management-api: build ## Runs maestro management-api.
-	@go run main.go start management-api
+	@go run main.go start management-api -l development
 
 .PHONY: run/rooms-api
 run/rooms-api: build ## Runs maestro rooms-api.
-	@go run main.go start rooms-api
+	@go run main.go start rooms-api -l development
 
 .PHONY: run/runtime-watcher
 run/runtime-watcher: build ## Runs maestro runtime-watcher.
-	@go run main.go start runtime-watcher
+	@go run main.go start runtime-watcher -l development
 
 #-------------------------------------------------------------------------------
 #  Code generation

--- a/cmd/managementapi/management_api.go
+++ b/cmd/managementapi/management_api.go
@@ -59,7 +59,7 @@ var ManagementApiCmd = &cobra.Command{
 }
 
 func init() {
-	ManagementApiCmd.Flags().StringVarP(&logConfig, "log-config", "l", "development", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
+	ManagementApiCmd.Flags().StringVarP(&logConfig, "log-config", "l", "production", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
 	ManagementApiCmd.Flags().StringVarP(&configPath, "config-path", "c", "config/management-api.local.yaml", "path of the configuration YAML file")
 }
 

--- a/cmd/roomsapi/rooms_api.go
+++ b/cmd/roomsapi/rooms_api.go
@@ -57,7 +57,7 @@ var RoomsAPICmd = &cobra.Command{
 }
 
 func init() {
-	RoomsAPICmd.Flags().StringVarP(&logConfig, "log-config", "l", "development", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
+	RoomsAPICmd.Flags().StringVarP(&logConfig, "log-config", "l", "production", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
 	RoomsAPICmd.Flags().StringVarP(&configPath, "config-path", "c", "config/rooms-api.local.yaml", "path of the configuration YAML file")
 }
 

--- a/cmd/runtimewatcher/runtime_watcher.go
+++ b/cmd/runtimewatcher/runtime_watcher.go
@@ -49,7 +49,7 @@ var RuntimeWatcherCmd = &cobra.Command{
 }
 
 func init() {
-	RuntimeWatcherCmd.Flags().StringVarP(&logConfig, "log-config", "l", "development", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
+	RuntimeWatcherCmd.Flags().StringVarP(&logConfig, "log-config", "l", "production", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
 	RuntimeWatcherCmd.Flags().StringVarP(&configPath, "config-path", "c", "config/runtime-watcher.local.yaml", "path of the configuration YAML file")
 }
 

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -49,7 +49,7 @@ var WorkerCmd = &cobra.Command{
 }
 
 func init() {
-	WorkerCmd.Flags().StringVarP(&logConfig, "log-config", "l", "development", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
+	WorkerCmd.Flags().StringVarP(&logConfig, "log-config", "l", "production", "preset of configurations used by the logs. possible values are \"development\" or \"production\".")
 	WorkerCmd.Flags().StringVarP(&configPath, "config-path", "c", "config/worker.local.yaml", "path of the configuration YAML file")
 }
 

--- a/e2e/framework/maestro/docker-compose.yml
+++ b/e2e/framework/maestro/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "8080:8080"
       - "8081:8081"
-    command: [start, management-api, -l development]
+    command: [start, management-api, -l, development]
     depends_on:
       postgres:
         condition: service_healthy
@@ -35,7 +35,7 @@ services:
       - "8071:8071"
     volumes:
       - ../../../kubeconfig:/kubeconfig
-    command: [start, rooms-api, -l development]
+    command: [start, rooms-api, -l, development]
     depends_on:
       postgres:
         condition: service_healthy
@@ -55,7 +55,7 @@ services:
       - "8061:8061"
     volumes:
       - ../../../kubeconfig:/kubeconfig
-    command: [start, runtime-watcher, -l development]
+    command: [start, runtime-watcher, -l, development]
 
   worker:
     build:
@@ -75,7 +75,7 @@ services:
       - "8051:8051"
     volumes:
       - ../../../kubeconfig:/kubeconfig
-    command: [start, worker, -l development]
+    command: [start, worker, -l, development]
     depends_on:
       postgres:
         condition: service_healthy

--- a/e2e/framework/maestro/docker-compose.yml
+++ b/e2e/framework/maestro/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "8080:8080"
       - "8081:8081"
-    command: [start, management-api]
+    command: [start, management-api, -l development]
     depends_on:
       postgres:
         condition: service_healthy
@@ -35,7 +35,7 @@ services:
       - "8071:8071"
     volumes:
       - ../../../kubeconfig:/kubeconfig
-    command: [start, rooms-api]
+    command: [start, rooms-api, -l development]
     depends_on:
       postgres:
         condition: service_healthy
@@ -55,7 +55,7 @@ services:
       - "8061:8061"
     volumes:
       - ../../../kubeconfig:/kubeconfig
-    command: [start, runtime-watcher]
+    command: [start, runtime-watcher, -l development]
 
   worker:
     build:
@@ -75,7 +75,7 @@ services:
       - "8051:8051"
     volumes:
       - ../../../kubeconfig:/kubeconfig
-    command: [start, worker]
+    command: [start, worker, -l development]
     depends_on:
       postgres:
         condition: service_healthy

--- a/internal/service/logging.go
+++ b/internal/service/logging.go
@@ -32,8 +32,10 @@ func ConfigureLogging(configPreset string) error {
 	var cfg zap.Config
 	switch configPreset {
 	case "development":
+		fmt.Println("running in development")
 		cfg = zap.NewDevelopmentConfig()
 	case "production":
+		fmt.Println("running in production")
 		cfg = zap.NewProductionConfig()
 	default:
 		return fmt.Errorf("unexpected log_config: %v", configPreset)

--- a/internal/service/logging.go
+++ b/internal/service/logging.go
@@ -32,10 +32,8 @@ func ConfigureLogging(configPreset string) error {
 	var cfg zap.Config
 	switch configPreset {
 	case "development":
-		fmt.Println("running in development")
 		cfg = zap.NewDevelopmentConfig()
 	case "production":
-		fmt.Println("running in production")
 		cfg = zap.NewProductionConfig()
 	default:
 		return fmt.Errorf("unexpected log_config: %v", configPreset)


### PR DESCRIPTION
### Why?
We must be sure that the logs in production are being executed in production mode. To that purpose, we let it be "production" by default, and configure it locally to execute in development mode.