### PR TITLE
chore - clear cache when update scheduler

### DIFF
--- a/cmd/managementapi/wire.go
+++ b/cmd/managementapi/wire.go
@@ -48,6 +48,7 @@ func initializeManagementMux(ctx context.Context, conf config.Config) (*runtime.
 		service.NewSchedulerStoragePg,
 		service.NewOperationManager,
 		service.NewRoomStorageRedis,
+		service.NewSchedulerCacheRedis,
 
 		// scheduler operations
 		providers.ProvideDefinitionConstructors,

--- a/cmd/managementapi/wire_gen.go
+++ b/cmd/managementapi/wire_gen.go
@@ -24,6 +24,10 @@ func initializeManagementMux(ctx context.Context, conf config.Config) (*runtime.
 	if err != nil {
 		return nil, err
 	}
+	schedulerCache, err := service.NewSchedulerCacheRedis(conf)
+	if err != nil {
+		return nil, err
+	}
 	operationFlow, err := service.NewOperationFlowRedis(conf)
 	if err != nil {
 		return nil, err
@@ -47,7 +51,7 @@ func initializeManagementMux(ctx context.Context, conf config.Config) (*runtime.
 	if err != nil {
 		return nil, err
 	}
-	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 	schedulersHandler := handlers.ProvideSchedulersHandler(schedulerManager)
 	operationsHandler := handlers.ProvideOperationsHandler(operationManager)
 	serveMux := provideManagementMux(ctx, schedulersHandler, operationsHandler)

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -76,7 +76,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 		return nil, err
 	}
 	roomManager := service.NewRoomManager(clock, portAllocator, roomStorage, gameRoomInstanceStorage, runtime, eventsService, roomManagerConfig)
-	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager, schedulerManager)
 	workerOptions := workers.ProvideWorkerOptions(operationManager, v2, roomManager, runtime)
 	workersManager := workers_manager.NewWorkersManager(builder, c, schedulerStorage, workerOptions)

--- a/config/management-api.local.yaml
+++ b/config/management-api.local.yaml
@@ -24,3 +24,6 @@ adapters:
   roomStorage:
     redis:
       url: "redis://localhost:6379/0"
+  schedulerCache:
+    redis:
+      url: "redis://localhost:6379/0"

--- a/e2e/suites/management/switch_active_version_test.go
+++ b/e2e/suites/management/switch_active_version_test.go
@@ -45,8 +45,6 @@ import (
 func TestSwitchActiveVersion(t *testing.T) {
 	game := "switch-active-version-game"
 
-
-
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 		t.Run("Succeed - create minor version, rollback version", func(t *testing.T) {
 			t.Parallel()
@@ -309,7 +307,7 @@ func TestSwitchActiveVersion(t *testing.T) {
 			}
 		})
 
-		t.Run("fail - version does not exist", func(t *testing.T) {
+		t.Run("Fail - version does not exist", func(t *testing.T) {
 			t.Parallel()
 
 			scheduler, err := createSchedulerWithRoomsAndWaitForIt(t, maestro, managementApiClient, game, kubeClient)
@@ -409,7 +407,7 @@ func TestSwitchActiveVersion(t *testing.T) {
 			require.Error(t, err)
 		})
 
-		t.Run("fail - adding forwarders crashes (testing scheduler cache)", func(t *testing.T) {
+		t.Run("Fail - adding forwarders crashes (testing scheduler cache)", func(t *testing.T) {
 			t.Parallel()
 
 			forwarders := []*maestroApiV1.Forwarder{

--- a/e2e/suites/management/switch_active_version_test.go
+++ b/e2e/suites/management/switch_active_version_test.go
@@ -25,6 +25,8 @@ package management
 import (
 	"context"
 	"fmt"
+	_struct "github.com/golang/protobuf/ptypes/struct"
+	"google.golang.org/protobuf/types/known/structpb"
 	"testing"
 	"time"
 
@@ -42,8 +44,11 @@ import (
 
 func TestSwitchActiveVersion(t *testing.T) {
 	game := "switch-active-version-game"
+
+
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
-		t.Run("Should Succeed - create minor version, rollback version", func(t *testing.T) {
+		t.Run("Succeed - create minor version, rollback version", func(t *testing.T) {
 			t.Parallel()
 
 			scheduler, err := createSchedulerWithRoomsAndWaitForIt(t, maestro, managementApiClient, game, kubeClient)
@@ -175,7 +180,7 @@ func TestSwitchActiveVersion(t *testing.T) {
 			}
 		})
 
-		t.Run("Should Succeed - create major change, rollback version", func(t *testing.T) {
+		t.Run("Succeed - create major change, rollback version", func(t *testing.T) {
 			t.Parallel()
 
 			scheduler, err := createSchedulerWithRoomsAndWaitForIt(t, maestro, managementApiClient, game, kubeClient)
@@ -304,7 +309,7 @@ func TestSwitchActiveVersion(t *testing.T) {
 			}
 		})
 
-		t.Run("Should fail - version does not exist", func(t *testing.T) {
+		t.Run("fail - version does not exist", func(t *testing.T) {
 			t.Parallel()
 
 			scheduler, err := createSchedulerWithRoomsAndWaitForIt(t, maestro, managementApiClient, game, kubeClient)
@@ -403,5 +408,139 @@ func TestSwitchActiveVersion(t *testing.T) {
 			err = managementApiClient.Do("PUT", fmt.Sprintf("/schedulers/%s", scheduler.Name), switchActiveVersionRequest, switchActiveVersionResponse)
 			require.Error(t, err)
 		})
+
+		t.Run("fail - adding forwarders crashes (testing scheduler cache)", func(t *testing.T) {
+			t.Parallel()
+
+			forwarders := []*maestroApiV1.Forwarder{
+				{
+					Name:    "matchmaker-grpc",
+					Enable:  true,
+					Type:    "grpc",
+					Address: maestro.ServerMocks.GrpcForwarderAddress,
+					Options: &maestroApiV1.ForwarderOptions{
+						Timeout: 5000,
+						Metadata: &_struct.Struct{
+							Fields: map[string]*structpb.Value{
+								"roomType": {
+									Kind: &structpb.Value_StringValue{
+										StringValue: "green",
+									},
+								},
+								"forwarderMetadata1": {
+									Kind: &structpb.Value_StringValue{
+										StringValue: "value1",
+									},
+								},
+								"forwarderMetadata2": {
+									Kind: &structpb.Value_NumberValue{
+										NumberValue: 245,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			scheduler, err := createSchedulerWithRoomsAndWaitForIt(t, maestro, managementApiClient, game, kubeClient)
+			firstPods, err := kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			firstRoomName := firstPods.Items[0].ObjectMeta.Name
+
+			// Can ping since there is no mock for grpc, and now we have forwarders
+			require.True(t, canPingForwarderWithRoom(roomsApiClient, scheduler.Name, firstRoomName))
+
+			// Update scheduler
+			updateRequest := &maestroApiV1.NewSchedulerVersionRequest{
+				Name:     scheduler.Name,
+				Game:     "test",
+				MaxSurge: "10%",
+				Spec: &maestroApiV1.Spec{
+					TerminationGracePeriod: 15,
+					Containers: []*maestroApiV1.Container{
+						{
+							Name:  "example",
+							Image: "alpine:3.15.0",
+							Command: []string{"/bin/sh", "-c", "apk add curl && " + "while true; do curl --request POST " +
+								"$ROOMS_API_ADDRESS/scheduler/$MAESTRO_SCHEDULER_NAME/rooms/$MAESTRO_ROOM_ID/ping " +
+								"--data-raw '{\"status\": \"ready\",\"timestamp\": \"12312312313\"}' && sleep 1; done"},
+							ImagePullPolicy: "Always",
+							Environment: []*maestroApiV1.ContainerEnvironment{
+								{
+									Name:  "ROOMS_API_ADDRESS",
+									Value: maestro.RoomsApiServer.ContainerInternalAddress,
+								},
+							},
+							Requests: &maestroApiV1.ContainerResources{
+								Memory: "20Mi",
+								Cpu:    "10m",
+							},
+							Limits: &maestroApiV1.ContainerResources{
+								Memory: "20Mi",
+								Cpu:    "10m",
+							},
+							Ports: []*maestroApiV1.ContainerPort{
+								{
+									Name:     "default",
+									Protocol: "tcp",
+									Port:     80,
+								},
+							},
+						},
+					},
+				},
+				PortRange: &maestroApiV1.PortRange{
+					Start: 80,
+					End:   8000,
+				},
+				Forwarders: forwarders,
+			}
+			updateResponse := &maestroApiV1.NewSchedulerVersionResponse{}
+
+			err = managementApiClient.Do("POST", fmt.Sprintf("/schedulers/%s", scheduler.Name), updateRequest, updateResponse)
+			require.NoError(t, err)
+			require.NotNil(t, updateResponse.OperationId, scheduler.Name)
+
+			waitForOperationToFinish(t, managementApiClient, scheduler.Name, "create_new_scheduler_version")
+			waitForOperationToFinish(t, managementApiClient, scheduler.Name, "switch_active_version")
+
+			lastPods, err := kubeClient.CoreV1().Pods(scheduler.Name).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			lastRoomName := lastPods.Items[0].ObjectMeta.Name
+
+			// Cannot ping since there is no mock for grpc, and now we have forwarders
+			require.False(t, canPingForwarderWithRoom(roomsApiClient, scheduler.Name, lastRoomName))
+		})
 	})
+}
+
+func canPingForwarderWithRoom(roomsApiClient *framework.APIClient, schedulerName, roomName string) bool {
+	playerEventRequest := &maestroApiV1.ForwardPlayerEventRequest{
+		RoomName:  roomName,
+		Event:     "playerLeft",
+		Timestamp: time.Now().Unix(),
+		Metadata: &_struct.Struct{
+			Fields: map[string]*structpb.Value{
+				"playerId": {
+					Kind: &structpb.Value_StringValue{
+						StringValue: "c50acc91-4d88-46fa-aa56-48d63c5b5311",
+					},
+				},
+				"eventMetadata1": {
+					Kind: &structpb.Value_StringValue{
+						StringValue: "value1",
+					},
+				},
+				"eventMetadata2": {
+					Kind: &structpb.Value_BoolValue{
+						BoolValue: true,
+					},
+				},
+			},
+		},
+	}
+	playerEventResponse := &maestroApiV1.ForwardPlayerEventResponse{}
+	_ = roomsApiClient.Do("POST", fmt.Sprintf("/scheduler/%s/rooms/%s/playerevent", schedulerName, roomName), playerEventRequest, playerEventResponse)
+	return playerEventResponse.Success
 }

--- a/internal/adapters/scheduler/scheduler_cache_redis.go
+++ b/internal/adapters/scheduler/scheduler_cache_redis.go
@@ -75,6 +75,11 @@ func (r redisSchedulerCache) SetScheduler(ctx context.Context, scheduler *entiti
 	return nil
 }
 
+func (r redisSchedulerCache) DeleteScheduler(ctx context.Context, schedulerName string) error {
+	err := r.client.Del(ctx, r.buildSchedulerKey(schedulerName)).Err()
+	return err
+}
+
 func (r redisSchedulerCache) buildSchedulerKey(schedulerName string) string {
 	return fmt.Sprintf("scheduler:%s", schedulerName)
 }

--- a/internal/api/handlers/schedulers_handler_test.go
+++ b/internal/api/handlers/schedulers_handler_test.go
@@ -66,7 +66,7 @@ func TestListSchedulers(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 
 		schedulerStorage.EXPECT().GetSchedulersWithFilter(gomock.Any(), &filters.SchedulerFilter{Name: schedulerName, Game: game, Version: version}).Return([]*entities.Scheduler{
 			{
@@ -111,7 +111,7 @@ func TestListSchedulers(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 
 		schedulerStorage.EXPECT().GetSchedulersWithFilter(gomock.Any(), gomock.Any()).Return([]*entities.Scheduler{}, nil)
 
@@ -142,7 +142,7 @@ func TestListSchedulers(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 
 		schedulerStorage.EXPECT().GetSchedulersWithFilter(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("GetSchedulersWithFilter error"))
 
@@ -200,7 +200,7 @@ func TestGetScheduler(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 
 		scheduler := &entities.Scheduler{
 			Name:            "zooba-us",
@@ -370,7 +370,7 @@ func TestGetScheduler(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrNotFound("scheduler NonExistentSchedule not found"))
 
@@ -401,7 +401,7 @@ func TestGetScheduler(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrInvalidArgument("Error"))
 
@@ -436,7 +436,7 @@ func TestGetSchedulerVersions(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 
 		createdAtV1, _ := time.Parse(time.RFC3339Nano, "2020-01-01T00:00:00.001Z")
 		createdAtV2, _ := time.Parse(time.RFC3339Nano, "2020-01-01T00:00:00.001Z")
@@ -477,7 +477,7 @@ func TestGetSchedulerVersions(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 
 		schedulerStorage.EXPECT().GetSchedulerVersions(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrNotFound("scheduler NonExistentScheduler not found"))
 
@@ -503,7 +503,7 @@ func TestGetSchedulerVersions(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 
 		schedulerStorage.EXPECT().GetSchedulerVersions(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrInvalidArgument("Error"))
 
@@ -540,7 +540,8 @@ func TestCreateScheduler(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		scheduler := &entities.Scheduler{
 			Name:     "scheduler-name-1",
@@ -722,7 +723,7 @@ func TestCreateScheduler(t *testing.T) {
 	})
 
 	t.Run("with failure", func(t *testing.T) {
-		schedulerManager := scheduler_manager.NewSchedulerManager(nil, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(nil, nil, nil, nil)
 
 		mux := runtime.NewServeMux()
 		err := api.RegisterSchedulersServiceHandlerServer(context.Background(), mux, ProvideSchedulersHandler(schedulerManager))
@@ -767,7 +768,7 @@ func TestCreateScheduler(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 
 		schedulerStorage.EXPECT().CreateScheduler(gomock.Any(), gomock.Any()).Return(errors.NewErrAlreadyExists("error creating scheduler %s: name already exists", "scheduler"))
 
@@ -806,7 +807,8 @@ func TestAddRooms(t *testing.T) {
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
 		operationManager.EXPECT().CreateOperation(gomock.Any(), "scheduler-name-1", gomock.Any()).Return(&operation.Operation{ID: "id-1"}, nil)
 
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, nil)
 
@@ -833,7 +835,7 @@ func TestAddRooms(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, errors.NewErrNotFound("err"))
 
@@ -856,7 +858,8 @@ func TestAddRooms(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, nil)
 		operationManager.EXPECT().CreateOperation(gomock.Any(), "scheduler-name-1", gomock.Any()).Return(nil, errors.NewErrUnexpected("storage offline"))
@@ -884,7 +887,8 @@ func TestRemoveRooms(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, nil)
 		operationManager.EXPECT().CreateOperation(gomock.Any(), "scheduler-name-1", gomock.Any()).Return(&operation.Operation{ID: "id-1"}, nil)
@@ -912,7 +916,7 @@ func TestRemoveRooms(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, errors.NewErrNotFound("err"))
 
@@ -935,7 +939,8 @@ func TestRemoveRooms(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, nil)
 		operationManager.EXPECT().CreateOperation(gomock.Any(), "scheduler-name-1", gomock.Any()).Return(nil, errors.NewErrUnexpected("storage offline"))
@@ -972,7 +977,8 @@ func TestNewSchedulerVersion(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		operationManager.EXPECT().CreateOperation(gomock.Any(), "scheduler-name-1", gomock.Any()).Return(&operation.Operation{ID: "id-1"}, nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(currentScheduler, nil)
@@ -1003,7 +1009,7 @@ func TestNewSchedulerVersion(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(nil, errors.NewErrNotFound("err"))
 
@@ -1035,7 +1041,8 @@ func TestNewSchedulerVersion(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		operationManager.EXPECT().CreateOperation(gomock.Any(), "scheduler-name-1", gomock.Any()).Return(nil, errors.NewErrUnexpected("storage offline"))
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), "scheduler-name-1").Return(currentScheduler, nil)
@@ -1070,7 +1077,8 @@ func TestSwitchActiveVersion(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
@@ -1099,7 +1107,7 @@ func TestSwitchActiveVersion(t *testing.T) {
 		defer mockCtrl.Finish()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrNotFound("err"))
 
@@ -1123,7 +1131,8 @@ func TestSwitchActiveVersion(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
@@ -1150,7 +1159,7 @@ func TestGetSchedulersInfo(t *testing.T) {
 
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 
 		scheduler := newValidScheduler()
 		schedulers := []*entities.Scheduler{scheduler}
@@ -1182,7 +1191,7 @@ func TestGetSchedulersInfo(t *testing.T) {
 	t.Run("with valid request and no scheduler and game rooms found", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 		schedulerStorage.EXPECT().GetSchedulersWithFilter(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrNotFound("err"))
 
 		mux := runtime.NewServeMux()
@@ -1206,7 +1215,7 @@ func TestGetSchedulersInfo(t *testing.T) {
 	t.Run("with unknown error", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, nil, nil, nil)
 		schedulerStorage.EXPECT().GetSchedulersWithFilter(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrUnexpected("exception"))
 
 		mux := runtime.NewServeMux()

--- a/internal/core/ports/mock/scheduler_ports_mock.go
+++ b/internal/core/ports/mock/scheduler_ports_mock.go
@@ -376,6 +376,20 @@ func (m *MockSchedulerCache) EXPECT() *MockSchedulerCacheMockRecorder {
 	return m.recorder
 }
 
+// DeleteScheduler mocks base method.
+func (m *MockSchedulerCache) DeleteScheduler(ctx context.Context, schedulerName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteScheduler", ctx, schedulerName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteScheduler indicates an expected call of DeleteScheduler.
+func (mr *MockSchedulerCacheMockRecorder) DeleteScheduler(ctx, schedulerName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScheduler", reflect.TypeOf((*MockSchedulerCache)(nil).DeleteScheduler), ctx, schedulerName)
+}
+
 // GetScheduler mocks base method.
 func (m *MockSchedulerCache) GetScheduler(ctx context.Context, name string) (*entities.Scheduler, error) {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/scheduler_ports.go
+++ b/internal/core/ports/scheduler_ports.go
@@ -64,6 +64,7 @@ type SchedulerStorage interface {
 type SchedulerCache interface {
 	GetScheduler(ctx context.Context, name string) (*entities.Scheduler, error)
 	SetScheduler(ctx context.Context, scheduler *entities.Scheduler, ttl time.Duration) error
+	DeleteScheduler(ctx context.Context, schedulerName string) error
 }
 
 type TransactionID string

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -59,7 +59,8 @@ func TestCreateScheduler(t *testing.T) {
 	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 	operationManager := mock.NewMockOperationManager(mockCtrl)
 	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-	schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+	schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+	schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 	t.Run("with valid scheduler it returns no error when creating it", func(t *testing.T) {
 		scheduler := newValidScheduler()
@@ -117,7 +118,8 @@ func TestCreateNewSchedulerVersion(t *testing.T) {
 	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 	operationManager := mock.NewMockOperationManager(mockCtrl)
 	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-	schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+	schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+	schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 	t.Run("with valid scheduler it returns no error when creating it", func(t *testing.T) {
 		scheduler := newValidScheduler()
@@ -157,7 +159,8 @@ func TestAddRooms(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		operationManager.EXPECT().CreateOperation(ctx, schedulerName, gomock.Any()).Return(&operation.Operation{}, nil)
 
@@ -172,7 +175,7 @@ func TestAddRooms(t *testing.T) {
 	t.Run("fails when scheduler does not exists", func(t *testing.T) {
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, nil)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, schedulerName).Return(nil, errors.NewErrNotFound("err"))
 
@@ -187,7 +190,8 @@ func TestAddRooms(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, schedulerName).Return(nil, nil)
 		operationManager.EXPECT().CreateOperation(ctx, schedulerName, gomock.Any()).Return(nil, errors.NewErrUnexpected("storage offline"))
@@ -210,7 +214,8 @@ func TestRemoveRooms(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		operationManager.EXPECT().CreateOperation(ctx, schedulerName, gomock.Any()).Return(&operation.Operation{}, nil)
 		schedulerStorage.EXPECT().GetScheduler(ctx, schedulerName).Return(nil, nil)
@@ -225,7 +230,7 @@ func TestRemoveRooms(t *testing.T) {
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, schedulerName).Return(nil, errors.NewErrNotFound("err"))
 
@@ -240,7 +245,8 @@ func TestRemoveRooms(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, schedulerName).Return(nil, nil)
 		operationManager.EXPECT().CreateOperation(ctx, schedulerName, gomock.Any()).Return(nil, errors.NewErrUnexpected("storage offline"))
@@ -268,7 +274,8 @@ func TestEnqueueNewSchedulerVersionOperation(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		operationManager.EXPECT().CreateOperation(ctx, scheduler.Name, gomock.Any()).Return(&operation.Operation{}, nil)
 		schedulerStorage.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -288,7 +295,8 @@ func TestEnqueueNewSchedulerVersionOperation(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 
@@ -305,7 +313,8 @@ func TestEnqueueNewSchedulerVersionOperation(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, scheduler.Name).Return(nil, errors.NewErrUnexpected("some_error"))
 
@@ -321,7 +330,8 @@ func TestEnqueueNewSchedulerVersionOperation(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 		operationManager.EXPECT().CreateOperation(ctx, scheduler.Name, gomock.Any()).Return(nil, errors.NewErrUnexpected("storage offline"))
@@ -352,7 +362,8 @@ func TestEnqueueSwitchActiveVersionOperation(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		operationManager.EXPECT().CreateOperation(ctx, scheduler.Name, gomock.Any()).Return(&operation.Operation{}, nil)
 
@@ -375,7 +386,8 @@ func TestEnqueueSwitchActiveVersionOperation(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		_, err := schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, scheduler, true)
 		require.Error(t, err)
@@ -393,7 +405,8 @@ func TestEnqueueSwitchActiveVersionOperation(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		operationManager.EXPECT().CreateOperation(ctx, scheduler.Name, gomock.Any()).Return(nil, errors.NewErrUnexpected("storage offline"))
 
@@ -416,7 +429,8 @@ func TestGetSchedulerVersions(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulerVersions(ctx, scheduler.Name).Return(schedulerVersionList, nil)
 
@@ -433,7 +447,8 @@ func TestGetSchedulerVersions(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulerVersions(ctx, scheduler.Name).Return(nil, errors.NewErrNotFound("scheduler not found"))
 
@@ -453,7 +468,8 @@ func TestGetScheduler(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerFilter := &filters.SchedulerFilter{
 			Name:    scheduler.Name,
@@ -474,7 +490,8 @@ func TestGetScheduler(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerFilter := &filters.SchedulerFilter{
 			Name:    scheduler.Name,
@@ -500,7 +517,8 @@ func TestGetSchedulersWithFilter(t *testing.T) {
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
 		schedulers := []*entities.Scheduler{scheduler}
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulersWithFilter(ctx, gomock.Any()).Return(schedulers, nil)
 
@@ -516,7 +534,8 @@ func TestGetSchedulersWithFilter(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulersWithFilter(ctx, gomock.Any()).Return(nil, errors.NewErrUnexpected("some error"))
 
@@ -528,6 +547,10 @@ func TestGetSchedulersWithFilter(t *testing.T) {
 
 func TestUpdateScheduler(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
+	err := validations.RegisterValidations()
+	if err != nil {
+		t.Errorf("unexpected error %d'", err)
+	}
 
 	t.Run("with success", func(t *testing.T) {
 		scheduler := newValidScheduler()
@@ -537,9 +560,29 @@ func TestUpdateScheduler(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().UpdateScheduler(ctx, scheduler).Return(nil)
+		schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name).Return(nil)
+
+		err := schedulerManager.UpdateScheduler(ctx, scheduler)
+		require.NoError(t, err)
+	})
+
+	t.Run("with success - deleting cache fails", func(t *testing.T) {
+		scheduler := newValidScheduler()
+
+		ctx := context.Background()
+
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+		operationManager := mock.NewMockOperationManager(mockCtrl)
+		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
+
+		schedulerStorage.EXPECT().UpdateScheduler(ctx, scheduler).Return(nil)
+		schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name).Return(errors.NewErrUnexpected("error"))
 
 		err := schedulerManager.UpdateScheduler(ctx, scheduler)
 		require.NoError(t, err)
@@ -553,7 +596,8 @@ func TestUpdateScheduler(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().UpdateScheduler(ctx, scheduler).Return(errors.NewErrUnexpected("error"))
 
@@ -567,7 +611,8 @@ func TestUpdateScheduler(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		err := schedulerManager.CreateNewSchedulerVersion(ctx, scheduler)
 
@@ -591,7 +636,8 @@ func TestSwitchActiveVersion(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, gomock.Any()).Return(&operation.Operation{}, nil)
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(scheduler, nil)
@@ -611,7 +657,7 @@ func TestSwitchActiveVersion(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrNotFound("err"))
 
@@ -626,7 +672,7 @@ func TestSwitchActiveVersion(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrUnexpected("err"))
@@ -643,7 +689,8 @@ func TestSwitchActiveVersion(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, operationManager, roomStorage)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(scheduler, nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(scheduler, nil)
@@ -662,7 +709,7 @@ func TestGetSchedulersInfo(t *testing.T) {
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 		schedulerFilter := filters.SchedulerFilter{Game: "Tennis-Clash"}
 		scheduler := newValidScheduler()
 		schedulers := []*entities.Scheduler{scheduler}
@@ -687,7 +734,7 @@ func TestGetSchedulersInfo(t *testing.T) {
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 		schedulerFilter := filters.SchedulerFilter{Game: "Tennis-Clash"}
 		schedulerStorage.EXPECT().GetSchedulersWithFilter(gomock.Any(), gomock.Any()).Return(nil, errors.NewErrNotFound("err"))
 
@@ -703,7 +750,7 @@ func TestGetSchedulersInfo(t *testing.T) {
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, roomStorage)
 		schedulerFilter := filters.SchedulerFilter{Game: "Tennis-Clash"}
 		scheduler := newValidScheduler()
 		schedulers := []*entities.Scheduler{scheduler}
@@ -722,7 +769,7 @@ func TestNewSchedulerInfo(t *testing.T) {
 	t.Run("with valid request it returns a scheduler and game rooms information", func(t *testing.T) {
 		ctx := context.Background()
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(nil, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(nil, nil, nil, roomStorage)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(5, nil)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(10, nil)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(15, nil)
@@ -741,7 +788,7 @@ func TestNewSchedulerInfo(t *testing.T) {
 	t.Run("it returns with error when couldn't get game rooms information in ready state", func(t *testing.T) {
 		ctx := context.Background()
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(nil, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(nil, nil, nil, roomStorage)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(0, errors.NewErrUnexpected("err"))
 		scheduler := newValidScheduler()
 
@@ -754,7 +801,7 @@ func TestNewSchedulerInfo(t *testing.T) {
 	t.Run("it returns with error when couldn't get game rooms information in pending state", func(t *testing.T) {
 		ctx := context.Background()
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(nil, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(nil, nil, nil, roomStorage)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(5, nil)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(0, errors.NewErrUnexpected("err"))
 		scheduler := newValidScheduler()
@@ -768,7 +815,7 @@ func TestNewSchedulerInfo(t *testing.T) {
 	t.Run("it returns with error when couldn't get game rooms information in occupied state", func(t *testing.T) {
 		ctx := context.Background()
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(nil, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(nil, nil, nil, roomStorage)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(5, nil)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(5, nil)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(0, errors.NewErrUnexpected("err"))
@@ -783,7 +830,7 @@ func TestNewSchedulerInfo(t *testing.T) {
 	t.Run("it returns with error when couldn't get game rooms information in terminating state", func(t *testing.T) {
 		ctx := context.Background()
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(nil, nil, roomStorage)
+		schedulerManager := NewSchedulerManager(nil, nil, nil, roomStorage)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(5, nil)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(5, nil)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(5, nil)
@@ -804,7 +851,7 @@ func TestDeleteScheduler(t *testing.T) {
 		scheduler := newValidScheduler()
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerName).Return(scheduler, nil)
 		schedulerStorage.EXPECT().DeleteScheduler(gomock.Any(), scheduler).Return(nil)
 
@@ -817,7 +864,7 @@ func TestDeleteScheduler(t *testing.T) {
 		schedulerName := "scheduler-name"
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerName).Return(nil, errors.NewErrNotFound("err"))
 
 		err := schedulerManager.DeleteScheduler(ctx, schedulerName)
@@ -832,7 +879,7 @@ func TestDeleteScheduler(t *testing.T) {
 		scheduler := newValidScheduler()
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil)
+		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerName).Return(scheduler, nil)
 		schedulerStorage.EXPECT().DeleteScheduler(gomock.Any(), scheduler).Return(errors.NewErrUnexpected("err"))
 
@@ -851,9 +898,9 @@ func newValidScheduler() *entities.Scheduler {
 		Game:            "game",
 		State:           entities.StateCreating,
 		MaxSurge:        "10%",
-		RollbackVersion: "",
+		RollbackVersion: "v1.0.0",
 		Spec: game_room.Spec{
-			Version:                "v1",
+			Version:                "v1.1.0",
 			TerminationGracePeriod: 60,
 			Toleration:             "toleration",
 			Affinity:               "affinity",


### PR DESCRIPTION
### What?
Clear scheduler cache when updating scheduler

### Why?
The **EventsForwarderService** uses a cache to have quick access to a scheduler. This is important because, in a real scenario, we could have a scheduler with thousands of rooms sending pings, and to retrieve forwarder info, we would have to access Postgres for each one of them.
However, since we don't clear cache when we create/switch to a new version, it would take a long time to refresh the cache and reflect the update to the forwarder.

### Missing:
Implement validation on e2e that the scheduler updated