### PR TITLE
Fix how execution worker handle errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,11 @@ run/tests: run/unit-tests run/integration-tests ## Execute all unit and integrat
 
 .PHONY: run/unit-tests
 run/unit-tests: ## Execute unit tests.
-	@go test -count=1 -tags=unit -coverprofile=coverage.out -covermode=atomic ./...
+	@go test -count=1 -tags=unit -coverprofile=coverage.out -covermode=atomic $(OPTS) ./...
 
 .PHONY: run/integration-tests
 run/integration-tests: ## Execute integration tests.
-	@go test -tags=integration -count=1 -timeout 20m -coverprofile=coverage.out -covermode=atomic ./...
+	@go test -tags=integration -count=1 -timeout 20m -coverprofile=coverage.out -covermode=atomic $(OPTS) ./...
 
 .PHONY: run/runtime-integration-tests
 run/runtime-integration-tests: ## Execute runtime integration tests.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/bufbuild/buf v0.47.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-pg/pg v6.13.2+incompatible
+	github.com/go-playground/locales v0.14.0
+	github.com/go-playground/universal-translator v0.18.0
 	github.com/go-playground/validator/v10 v10.10.0
 	github.com/go-redis/redis/v8 v8.10.0
 	github.com/golang-migrate/migrate/v4 v4.14.1
@@ -37,6 +39,7 @@ require (
 	google.golang.org/grpc v1.40.0-dev.0.20210708170655-30dfb4b933a5
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.27.1
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0
 	k8s.io/client-go v0.21.0
@@ -88,8 +91,6 @@ require (
 	github.com/fzipp/gocyclo v0.3.1 // indirect
 	github.com/go-critic/go-critic v0.5.6 // indirect
 	github.com/go-logr/logr v0.4.0 // indirect
-	github.com/go-playground/locales v0.14.0 // indirect
-	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-redis/redis/v7 v7.4.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -127,6 +127,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 		err = w.operationManager.StartOperation(operationContext, op, operationCancellationFunction)
 		if err != nil {
 			w.Stop(ctx)
+			operationCancellationFunction()
 
 			op.Status = operation.StatusError
 			err = w.operationManager.FinishOperation(ctx, op)

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -109,21 +109,33 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 		loopLogger.Info("Starting operation")
 
 		operationContext, operationCancellationFunction := context.WithCancel(ctx)
-		err = w.operationManager.StartOperation(operationContext, op, operationCancellationFunction)
-		if err != nil {
-			w.Stop(ctx)
-
-			// NOTE: currently, we're not treating if the operation exists or
-			// not. In this case, when there is error it will be an unexpected
-			// error.
-			reportOperationExecutionWorkerFailed(w.schedulerName, LabelStartOperationFailed)
-			return fmt.Errorf("failed to start operation \"%s\" for the scheduler \"%s\"", op.ID, op.SchedulerName)
-		}
 		err = w.operationManager.GrantLease(operationContext, op)
 		if err != nil {
 			w.Stop(ctx)
 			reportOperationExecutionWorkerFailed(w.schedulerName, LabelStartOperationFailed)
+			operationCancellationFunction()
+
+			op.Status = operation.StatusError
+			err = w.operationManager.FinishOperation(ctx, op)
+			if err != nil {
+				loopLogger.Error("failed to finish operation", zap.Error(err))
+			}
+
 			return fmt.Errorf("failed to grant lease to operation \"%s\" for the scheduler \"%s\"", op.ID, op.SchedulerName)
+		}
+
+		err = w.operationManager.StartOperation(operationContext, op, operationCancellationFunction)
+		if err != nil {
+			w.Stop(ctx)
+
+			op.Status = operation.StatusError
+			err = w.operationManager.FinishOperation(ctx, op)
+			if err != nil {
+				loopLogger.Error("failed to finish operation", zap.Error(err))
+			}
+
+			reportOperationExecutionWorkerFailed(w.schedulerName, LabelStartOperationFailed)
+			return fmt.Errorf("failed to start operation \"%s\" for the scheduler \"%s\"", op.ID, op.SchedulerName)
 		}
 		w.operationManager.StartLeaseRenewGoRoutine(operationContext, op)
 

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/topfreegames/maestro/internal/core/ports/mock"
+	"gotest.tools/assert"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -217,7 +218,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		require.False(t, workerService.IsRunning())
 	})
 
-	t.Run("error granting lease should stop execution of operation", func(t *testing.T) {
+	t.Run("error starting operation should stop execution of operation and set status as error", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
@@ -247,12 +248,58 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
 
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
-		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any())
-		operationManager.EXPECT().GrantLease(gomock.Any(), expectedOperation).Return(errors.New("error"))
+		operationManager.EXPECT().GrantLease(gomock.Any(), expectedOperation).Return(nil)
+		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any()).Return(errors.New("error"))
+		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
 		// Ends the worker by cancelling it
 
 		err := workerService.Start(context.Background())
 		require.Error(t, err)
+
+		assert.Equal(t, expectedOperation.Status, operation.StatusError)
+
+		workerService.Stop(context.Background())
+		require.False(t, workerService.IsRunning())
+	})
+
+	t.Run("error granting lease should stop execution of operation and set status as error", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		operationManager := mock.NewMockOperationManager(mockCtrl)
+
+		operationName := "test_operation"
+		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
+		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
+		operationExecutor.EXPECT().Name().Return(operationName).AnyTimes()
+		operationDefinition.EXPECT().Name().Return(operationName).AnyTimes()
+
+		defFunc := func() operations.Definition { return operationDefinition }
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[operationName] = defFunc
+
+		scheduler := &entities.Scheduler{Name: "random-scheduler"}
+		expectedOperation := &operation.Operation{
+			ID:             "random-operation-id",
+			SchedulerName:  scheduler.Name,
+			Status:         operation.StatusPending,
+			DefinitionName: operationName,
+		}
+
+		executors := map[string]operations.Executor{}
+		executors[operationName] = operationExecutor
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+
+		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
+
+		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
+		operationManager.EXPECT().GrantLease(gomock.Any(), expectedOperation).Return(errors.New("error"))
+		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
+		// Ends the worker by cancelling it
+
+		err := workerService.Start(context.Background())
+		require.Error(t, err)
+
+		assert.Equal(t, expectedOperation.Status, operation.StatusError)
 
 		workerService.Stop(context.Background())
 		require.False(t, workerService.IsRunning())

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -72,8 +72,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
 
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
-		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any())
 		operationManager.EXPECT().GrantLease(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any())
 		operationManager.EXPECT().StartLeaseRenewGoRoutine(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().RevokeLease(gomock.Any(), expectedOperation)
@@ -129,8 +129,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 			}).Return(nil)
 
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
-		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any())
 		operationManager.EXPECT().GrantLease(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any())
 		operationManager.EXPECT().StartLeaseRenewGoRoutine(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().RevokeLease(gomock.Any(), expectedOperation)


### PR DESCRIPTION
### Why
Fix `ExecutionWorker` inconsistent state when starting an operation execution.
### What
`ExecutionWorker` has an inconsistent state when an operation is changed to status `InProgress` but there is no `Lease` associated with it.
### How
First of all create a lease to an operation when starting it, after that, change the state to `InProgress` to execute the operation. In error cases, it should change the operation to status `Error`.
Add tests cases to cover these flows.