### PR TITLE
fix - Unexpected behavior when trying to cancel operation on final state

### DIFF
--- a/e2e/suites/management/create_scheduler_test.go
+++ b/e2e/suites/management/create_scheduler_test.go
@@ -25,10 +25,11 @@ package management
 import (
 	"context"
 	"fmt"
-	"github.com/topfreegames/maestro/internal/core/entities/operation"
-	"github.com/topfreegames/maestro/internal/core/operations/create_scheduler"
 	"testing"
 	"time"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/operations/create_scheduler"
 
 	"github.com/stretchr/testify/assert"
 

--- a/e2e/suites/management/switch_active_version_test.go
+++ b/e2e/suites/management/switch_active_version_test.go
@@ -25,10 +25,11 @@ package management
 import (
 	"context"
 	"fmt"
-	_struct "github.com/golang/protobuf/ptypes/struct"
-	"google.golang.org/protobuf/types/known/structpb"
 	"testing"
 	"time"
+
+	_struct "github.com/golang/protobuf/ptypes/struct"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	maestroApiV1 "github.com/topfreegames/maestro/pkg/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/api/handlers/operations_handler.go
+++ b/internal/api/handlers/operations_handler.go
@@ -26,10 +26,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	portsErrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 	"sort"
 	"strings"
 	"time"
+
+	portsErrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 
 	"go.uber.org/zap"
 

--- a/internal/core/ports/errors/errors.go
+++ b/internal/core/ports/errors/errors.go
@@ -32,6 +32,7 @@ const (
 	errNotFound
 	errEncoding
 	errInvalidArgument
+	errConflict
 )
 
 var (
@@ -40,6 +41,7 @@ var (
 	ErrNotFound        = &portsError{kind: errNotFound}
 	ErrEncoding        = &portsError{kind: errEncoding}
 	ErrInvalidArgument = &portsError{kind: errInvalidArgument}
+	ErrConflict        = &portsError{kind: errConflict}
 )
 
 type portsError struct {
@@ -104,6 +106,13 @@ func NewErrEncoding(format string, args ...interface{}) *portsError {
 func NewErrInvalidArgument(format string, args ...interface{}) *portsError {
 	return &portsError{
 		kind:    errInvalidArgument,
+		message: fmt.Sprintf(format, args...),
+	}
+}
+
+func NewErrConflict(format string, args ...interface{}) *portsError {
+	return &portsError{
+		kind:    errConflict,
 		message: fmt.Sprintf(format, args...),
 	}
 }


### PR DESCRIPTION
### What?
Adds treatment for when management-API receives a request to cancel an operation that cannot be canceled.

### Why?
Right now, when we try to cancel an operation that is already finished, Maestro does not check the actual status of the operation before trying to execute the cancelation. Because of that, the logs produced are related to the operation not having a cancel function, and not to the status.
Also, we don't see logs at the management-API relating to what is going on.