### PR TITLE
events forwarder service - change log type (reduce noise)

### DIFF
--- a/internal/core/services/events_forwarder/events_forwarder_service.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service.go
@@ -116,7 +116,7 @@ func (es *EventsForwarderService) ProduceEvent(ctx context.Context, event *event
 			}
 		}
 	} else {
-		es.logger.Info(fmt.Sprintf("scheduler \"%v\" do not have forwarders configured", event.SchedulerID))
+		es.logger.Debug(fmt.Sprintf("scheduler \"%v\" do not have forwarders configured", event.SchedulerID))
 	}
 
 	return nil


### PR DESCRIPTION
### What?
Change log from INFO to DEBUG produced when ping is not forwarded since scheduler has no forwarders enabled.
### Why?
Today, if a specific scheduler has no forwarders configured, and the room sends a ping to Maestro, we produce an info log message "scheduler "%v" do not have forwarders configured".
This info, however, is almost useless, since having no forwarders is an okay condition.
We also decided to change to DEBUG because although the information is not useful in prod environment, when debugging it's useful to know that the this behavior happened