### PR TITLE
Populate Operation.Input field

### DIFF
--- a/e2e/suites/management/cancel_operation_test.go
+++ b/e2e/suites/management/cancel_operation_test.go
@@ -159,9 +159,10 @@ func createTestOperation(ctx context.Context, t *testing.T, operationStorage por
 		DefinitionName: definition.Name(),
 		SchedulerName:  schedulerName,
 		CreatedAt:      time.Now(),
+		Input:          definition.Marshal(),
 	}
 
-	err := operationStorage.CreateOperation(ctx, op, definition.Marshal())
+	err := operationStorage.CreateOperation(ctx, op)
 	require.NoError(t, err)
 	err = operationFlow.InsertOperationID(ctx, op.SchedulerName, op.ID)
 	require.NoError(t, err)

--- a/internal/adapters/operation/operation_storage_redis_test.go
+++ b/internal/adapters/operation/operation_storage_redis_test.go
@@ -69,7 +69,7 @@ func TestCreateOperation(t *testing.T) {
 		require.Equal(t, op.SchedulerName, operationStored[schedulerNameRedisKey])
 		require.Equal(t, op.DefinitionName, operationStored[definitionNameRedisKey])
 		require.Equal(t, createdAtString, operationStored[createdAtRedisKey])
-		require.Equal(t, op.Input, operationStored[definitionContentsRedisKey])
+		require.EqualValues(t, op.Input, operationStored[definitionContentsRedisKey])
 
 		intStatus, err := strconv.Atoi(operationStored[statusRedisKey])
 		require.NoError(t, err)

--- a/internal/adapters/operation/operation_storage_redis_test.go
+++ b/internal/adapters/operation/operation_storage_redis_test.go
@@ -262,7 +262,7 @@ func TestUpdateOperationExecutionHistory(t *testing.T) {
 			Status:        operation.StatusPending,
 		}
 
-		err := storage.CreateOperation(context.Background(), op, []byte{})
+		err := storage.CreateOperation(context.Background(), op)
 		require.NoError(t, err)
 
 		events := []operation.OperationEvent{

--- a/internal/core/operations/create_scheduler/create_scheduler_definition.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_definition.go
@@ -24,13 +24,19 @@ package create_scheduler
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
+	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"go.uber.org/zap"
 )
 
 const OperationName = "create_scheduler"
 
-type CreateSchedulerDefinition struct{}
+type CreateSchedulerDefinition struct {
+	NewScheduler *entities.Scheduler `json:"scheduler"`
+}
 
 // ShouldExecute we're going to always perform the scheduler creation.
 func (d *CreateSchedulerDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
@@ -42,9 +48,20 @@ func (d *CreateSchedulerDefinition) Name() string {
 }
 
 func (d *CreateSchedulerDefinition) Marshal() []byte {
-	return make([]byte, 0)
+	bytes, err := json.Marshal(d)
+	if err != nil {
+		zap.L().With(zap.Error(err)).Error("error marshalling update scheduler operation definition")
+		return nil
+	}
+
+	return bytes
 }
 
 func (d *CreateSchedulerDefinition) Unmarshal(raw []byte) error {
+	err := json.Unmarshal(raw, d)
+	if err != nil {
+		return fmt.Errorf("error marshalling update scheduler operation definition: %w", err)
+	}
+
 	return nil
 }

--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -345,27 +345,26 @@ func (m *MockOperationStorage) EXPECT() *MockOperationStorageMockRecorder {
 }
 
 // CreateOperation mocks base method.
-func (m *MockOperationStorage) CreateOperation(ctx context.Context, operation *operation.Operation, definitionContent []byte) error {
+func (m *MockOperationStorage) CreateOperation(ctx context.Context, operation *operation.Operation) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOperation", ctx, operation, definitionContent)
+	ret := m.ctrl.Call(m, "CreateOperation", ctx, operation)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateOperation indicates an expected call of CreateOperation.
-func (mr *MockOperationStorageMockRecorder) CreateOperation(ctx, operation, definitionContent interface{}) *gomock.Call {
+func (mr *MockOperationStorageMockRecorder) CreateOperation(ctx, operation interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOperation", reflect.TypeOf((*MockOperationStorage)(nil).CreateOperation), ctx, operation, definitionContent)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOperation", reflect.TypeOf((*MockOperationStorage)(nil).CreateOperation), ctx, operation)
 }
 
 // GetOperation mocks base method.
-func (m *MockOperationStorage) GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, []byte, error) {
+func (m *MockOperationStorage) GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOperation", ctx, schedulerName, operationID)
 	ret0, _ := ret[0].(*operation.Operation)
-	ret1, _ := ret[1].([]byte)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetOperation indicates an expected call of GetOperation.

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -78,9 +78,9 @@ type OperationFlow interface {
 }
 
 type OperationStorage interface {
-	CreateOperation(ctx context.Context, operation *operation.Operation, definitionContent []byte) error
+	CreateOperation(ctx context.Context, operation *operation.Operation) error
 	// GetOperation returns the operation and the definition contents.
-	GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, []byte, error)
+	GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, error)
 	// ListSchedulerActiveOperations list scheduler active operations.
 	ListSchedulerActiveOperations(ctx context.Context, schedulerName string) ([]*operation.Operation, error)
 	// ListSchedulerFinishedOperations list scheduler finished operations.

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -70,9 +70,10 @@ func (om *OperationManager) CreateOperation(ctx context.Context, schedulerName s
 		DefinitionName: definition.Name(),
 		SchedulerName:  schedulerName,
 		CreatedAt:      time.Now(),
+		Input:          definition.Marshal(),
 	}
 
-	err := om.Storage.CreateOperation(ctx, op, definition.Marshal())
+	err := om.Storage.CreateOperation(ctx, op)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create operation: %w", err)
 	}
@@ -87,7 +88,7 @@ func (om *OperationManager) CreateOperation(ctx context.Context, schedulerName s
 }
 
 func (om *OperationManager) GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, operations.Definition, error) {
-	op, definitionContents, err := om.Storage.GetOperation(ctx, schedulerName, operationID)
+	op, err := om.Storage.GetOperation(ctx, schedulerName, operationID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -98,7 +99,7 @@ func (om *OperationManager) GetOperation(ctx context.Context, schedulerName, ope
 	}
 
 	definition := definitionConstructor()
-	err = definition.Unmarshal(definitionContents)
+	err = definition.Unmarshal(op.Input)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to unmarshal definition: %s", err)
 	}
@@ -137,7 +138,7 @@ func (om *OperationManager) ListSchedulerPendingOperations(ctx context.Context, 
 	}
 	pendingOperations := make([]*operation.Operation, len(pendingOperationIDs))
 	for i, operationID := range pendingOperationIDs {
-		op, _, err := om.Storage.GetOperation(ctx, schedulerName, operationID)
+		op, err := om.Storage.GetOperation(ctx, schedulerName, operationID)
 		if err != nil {
 			return nil, err
 		}
@@ -184,7 +185,7 @@ func (om *OperationManager) EnqueueOperationCancellationRequest(ctx context.Cont
 		return fmt.Errorf("failed to fetch scheduler from storage: %w", err)
 	}
 
-	op, _, err := om.Storage.GetOperation(ctx, schedulerName, operationID)
+	op, err := om.Storage.GetOperation(ctx, schedulerName, operationID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch operation from storage: %w", err)
 	}
@@ -319,7 +320,7 @@ func (om *OperationManager) addOperationsLeaseData(ctx context.Context, schedule
 
 func (om OperationManager) cancelOperation(ctx context.Context, schedulerName, operationID string) error {
 
-	op, _, err := om.Storage.GetOperation(ctx, schedulerName, operationID)
+	op, err := om.Storage.GetOperation(ctx, schedulerName, operationID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch operation from storage: %w", err)
 	}

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -78,7 +78,7 @@ func (s *SchedulerManager) CreateScheduler(ctx context.Context, scheduler *entit
 		return nil, err
 	}
 
-	op, err := s.operationManager.CreateOperation(ctx, scheduler.Name, &create_scheduler.CreateSchedulerDefinition{})
+	op, err := s.operationManager.CreateOperation(ctx, scheduler.Name, &create_scheduler.CreateSchedulerDefinition{NewScheduler: scheduler})
 	if err != nil {
 		return nil, fmt.Errorf("failing in creating the operation: %s: %s", create_scheduler.OperationName, err)
 	}

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -63,7 +63,7 @@ func TestOperationStorageRedis(t *testing.T) {
 		opStorage, err := NewOperationStorageRedis(clock, config)
 		require.NoError(t, err)
 
-		_, _, err = opStorage.GetOperation(context.Background(), "", "")
+		_, err = opStorage.GetOperation(context.Background(), "", "")
 		require.ErrorIs(t, err, errors.ErrNotFound)
 	})
 
@@ -77,7 +77,7 @@ func TestOperationStorageRedis(t *testing.T) {
 		opStorage, err := NewOperationStorageRedis(clock, config)
 		require.NoError(t, err)
 
-		_, _, err = opStorage.GetOperation(context.Background(), "", "")
+		_, err = opStorage.GetOperation(context.Background(), "", "")
 		require.ErrorIs(t, err, errors.ErrUnexpected)
 	})
 


### PR DESCRIPTION
### Why
In the PR #343 was added in the Operation entity the field `Input`. But it doesn't bee filled. This PR proposes to fill it.

### What
* Fill `Operation.Input` field
* Fix tests