### PR TITLE
Fix metrics reporter OOM bug

### DIFF
--- a/internal/adapters/instance_storage/redis/redis.go
+++ b/internal/adapters/instance_storage/redis/redis.go
@@ -96,7 +96,8 @@ func (r redisInstanceStorage) GetAllInstances(ctx context.Context, scheduler str
 		var err error
 		var results []string
 
-		results, cursor, err := client.HScan(ctx, redisKey, cursor, "*", r.scanPageSize).Result()
+		results, resultCursor, err := client.HScan(ctx, redisKey, cursor, "*", r.scanPageSize).Result()
+		cursor = resultCursor
 		if err != nil {
 			return nil, errors.NewErrUnexpected("error scanning %s on redis", redisKey).WithError(err)
 		}

--- a/internal/adapters/instance_storage/redis/redis_test.go
+++ b/internal/adapters/instance_storage/redis/redis_test.go
@@ -163,43 +163,7 @@ func TestRedisInstanceStorage_RemoveInstance(t *testing.T) {
 
 func TestRedisInstanceStorage_GetAllInstances(t *testing.T) {
 	storage := NewRedisInstanceStorage(test.GetRedisConnection(t, redisAddress), 0)
-	instances := []*game_room.Instance{
-		{
-			ID:          "1",
-			SchedulerID: "game",
-			Status: game_room.InstanceStatus{
-				Type: game_room.InstanceReady,
-			},
-			Address: &game_room.Address{
-				Host: "host",
-				Ports: []game_room.Port{
-					{
-						Name:     "game",
-						Port:     7000,
-						Protocol: "udp",
-					},
-				},
-			},
-		},
-		{
-			ID:          "2",
-			SchedulerID: "game",
-			Status: game_room.InstanceStatus{
-				Type:        game_room.InstanceError,
-				Description: "error",
-			},
-			Address: &game_room.Address{
-				Host: "host",
-				Ports: []game_room.Port{
-					{
-						Name:     "game",
-						Port:     7000,
-						Protocol: "udp",
-					},
-				},
-			},
-		},
-	}
+	instances := generateInstances()
 
 	for _, instance := range instances {
 		require.NoError(t, storage.UpsertInstance(context.Background(), instance))
@@ -255,4 +219,200 @@ func TestRedisInstanceStorage_GetInstanceCount(t *testing.T) {
 	count, err := storage.GetInstanceCount(context.Background(), "game")
 	require.NoError(t, err)
 	require.Equal(t, 2, count)
+}
+
+func generateInstances() []*game_room.Instance {
+	return []*game_room.Instance{
+		{
+			ID:          "1",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type: game_room.InstanceReady,
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		},
+		{
+			ID:          "2",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type:        game_room.InstanceError,
+				Description: "error",
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		},
+		{
+			ID:          "3",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type: game_room.InstanceReady,
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		},
+		{
+			ID:          "4",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type:        game_room.InstanceError,
+				Description: "error",
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		}, {
+			ID:          "5",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type: game_room.InstanceReady,
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		},
+		{
+			ID:          "6",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type:        game_room.InstanceError,
+				Description: "error",
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		}, {
+			ID:          "7",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type: game_room.InstanceReady,
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		},
+		{
+			ID:          "8",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type:        game_room.InstanceError,
+				Description: "error",
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		}, {
+			ID:          "9",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type: game_room.InstanceReady,
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		},
+		{
+			ID:          "10",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type:        game_room.InstanceError,
+				Description: "error",
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		},
+		{
+			ID:          "11",
+			SchedulerID: "game",
+			Status: game_room.InstanceStatus{
+				Type:        game_room.InstanceError,
+				Description: "error",
+			},
+			Address: &game_room.Address{
+				Host: "host",
+				Ports: []game_room.Port{
+					{
+						Name:     "game",
+						Port:     7000,
+						Protocol: "udp",
+					},
+				},
+			},
+		},
+	}
+
 }


### PR DESCRIPTION
## What ❓ 
Fix shadowed cursor variable that was causing GetAllInstances method to enter in an infinite loop when the number of retrieved pods was higher than 10.

## Why 🤔 
This bug was causing the metrics-reporter component to have OOM errors when reporting metrics for a scheduler with more than 10 pods.
