### PR TITLE
Feat/populate operation execution history

### DIFF
--- a/e2e/suites/management/list_operations_test.go
+++ b/e2e/suites/management/list_operations_test.go
@@ -70,8 +70,8 @@ func TestListOperations(t *testing.T) {
 					return false
 				}
 
-				require.Equal(t, "add_rooms", listOperationsResponse.FinishedOperations[0].DefinitionName)
-				require.Equal(t, "finished", listOperationsResponse.FinishedOperations[0].Status)
+				assert.Equal(t, "add_rooms", listOperationsResponse.FinishedOperations[0].DefinitionName)
+				assert.Equal(t, "finished", listOperationsResponse.FinishedOperations[0].Status)
 				return true
 			}, 240*time.Second, time.Second)
 
@@ -90,6 +90,8 @@ func TestListOperations(t *testing.T) {
 				assert.True(t, operationExists)
 
 				assert.Equal(t, apiOperation.SchedulerName, scheduler.Name)
+				assert.NotEmpty(t, apiOperation.Input)
+				assert.Greater(t, len(apiOperation.ExecutionHistory), 0)
 			}
 
 			statusInProgressString, err := operation.StatusInProgress.String()
@@ -101,6 +103,8 @@ func TestListOperations(t *testing.T) {
 				assert.True(t, operationExists)
 
 				assert.Equal(t, apiOperation.SchedulerName, scheduler.Name)
+				assert.NotEmpty(t, apiOperation.Input)
+				assert.Greater(t, len(apiOperation.ExecutionHistory), 0)
 			}
 
 			statusFinishedString, err := operation.StatusFinished.String()
@@ -112,6 +116,8 @@ func TestListOperations(t *testing.T) {
 				assert.True(t, operationExists)
 
 				assert.Equal(t, apiOperation.SchedulerName, scheduler.Name)
+				assert.NotEmpty(t, apiOperation.Input)
+				assert.Greater(t, len(apiOperation.ExecutionHistory), 0)
 			}
 		})
 	})

--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -39,11 +39,9 @@ func (m *MockOperationManager) EXPECT() *MockOperationManagerMockRecorder {
 }
 
 // AppendOperationEventToExecutionHistory mocks base method.
-func (m *MockOperationManager) AppendOperationEventToExecutionHistory(ctx context.Context, op *operation.Operation, eventMessage string) error {
+func (m *MockOperationManager) AppendOperationEventToExecutionHistory(ctx context.Context, op *operation.Operation, eventMessage string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendOperationEventToExecutionHistory", ctx, op, eventMessage)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "AppendOperationEventToExecutionHistory", ctx, op, eventMessage)
 }
 
 // AppendOperationEventToExecutionHistory indicates an expected call of AppendOperationEventToExecutionHistory.

--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -38,6 +38,20 @@ func (m *MockOperationManager) EXPECT() *MockOperationManagerMockRecorder {
 	return m.recorder
 }
 
+// AppendOperationEventToExecutionHistory mocks base method.
+func (m *MockOperationManager) AppendOperationEventToExecutionHistory(ctx context.Context, op *operation.Operation, eventMessage string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppendOperationEventToExecutionHistory", ctx, op, eventMessage)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AppendOperationEventToExecutionHistory indicates an expected call of AppendOperationEventToExecutionHistory.
+func (mr *MockOperationManagerMockRecorder) AppendOperationEventToExecutionHistory(ctx, op, eventMessage interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendOperationEventToExecutionHistory", reflect.TypeOf((*MockOperationManager)(nil).AppendOperationEventToExecutionHistory), ctx, op, eventMessage)
+}
+
 // CreateOperation mocks base method.
 func (m *MockOperationManager) CreateOperation(ctx context.Context, schedulerName string, definition operations.Definition) (*operation.Operation, error) {
 	m.ctrl.T.Helper()
@@ -187,15 +201,15 @@ func (mr *MockOperationManagerMockRecorder) RevokeLease(ctx, operation interface
 }
 
 // StartLeaseRenewGoRoutine mocks base method.
-func (m *MockOperationManager) StartLeaseRenewGoRoutine(operationCtx context.Context, op *operation.Operation) {
+func (m *MockOperationManager) StartLeaseRenewGoRoutine(ctx context.Context, op *operation.Operation) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartLeaseRenewGoRoutine", operationCtx, op)
+	m.ctrl.Call(m, "StartLeaseRenewGoRoutine", ctx, op)
 }
 
 // StartLeaseRenewGoRoutine indicates an expected call of StartLeaseRenewGoRoutine.
-func (mr *MockOperationManagerMockRecorder) StartLeaseRenewGoRoutine(operationCtx, op interface{}) *gomock.Call {
+func (mr *MockOperationManagerMockRecorder) StartLeaseRenewGoRoutine(ctx, op interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartLeaseRenewGoRoutine", reflect.TypeOf((*MockOperationManager)(nil).StartLeaseRenewGoRoutine), operationCtx, op)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartLeaseRenewGoRoutine", reflect.TypeOf((*MockOperationManager)(nil).StartLeaseRenewGoRoutine), ctx, op)
 }
 
 // StartOperation mocks base method.

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -59,7 +59,9 @@ type OperationManager interface {
 	// RevokeLease revokes the lease of the given operation.
 	RevokeLease(ctx context.Context, operation *operation.Operation) error
 	// StartLeaseRenewGoRoutine starts an async process to keep renewing the lease of the given operation.
-	StartLeaseRenewGoRoutine(operationCtx context.Context, op *operation.Operation)
+	StartLeaseRenewGoRoutine(ctx context.Context, op *operation.Operation)
+	// AppendOperationEventToExecutionHistory add operation event to execution history
+	AppendOperationEventToExecutionHistory(ctx context.Context, op *operation.Operation, eventMessage string) error
 }
 
 // Secondary ports (output, driven ports)

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -61,7 +61,7 @@ type OperationManager interface {
 	// StartLeaseRenewGoRoutine starts an async process to keep renewing the lease of the given operation.
 	StartLeaseRenewGoRoutine(ctx context.Context, op *operation.Operation)
 	// AppendOperationEventToExecutionHistory add operation event to execution history
-	AppendOperationEventToExecutionHistory(ctx context.Context, op *operation.Operation, eventMessage string) error
+	AppendOperationEventToExecutionHistory(ctx context.Context, op *operation.Operation, eventMessage string)
 }
 
 // Secondary ports (output, driven ports)

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -71,6 +71,12 @@ func (om *OperationManager) CreateOperation(ctx context.Context, schedulerName s
 		SchedulerName:  schedulerName,
 		CreatedAt:      time.Now(),
 		Input:          definition.Marshal(),
+		ExecutionHistory: []operation.OperationEvent{
+			{
+				CreatedAt: time.Now().UTC(),
+				Event:     "Created",
+			},
+		},
 	}
 
 	err := om.Storage.CreateOperation(ctx, op)
@@ -296,6 +302,16 @@ func (om *OperationManager) StartLeaseRenewGoRoutine(operationCtx context.Contex
 			}
 		}
 	}()
+}
+
+func (om *OperationManager) AppendOperationEventToExecutionHistory(ctx context.Context, op *operation.Operation, eventMessage string) error {
+	event := operation.OperationEvent{
+		CreatedAt: time.Now().UTC(),
+		Event:     eventMessage,
+	}
+	op.ExecutionHistory = append(op.ExecutionHistory, event)
+
+	return om.Storage.UpdateOperationExecutionHistory(ctx, op)
 }
 
 func (om *OperationManager) addOperationsLeaseData(ctx context.Context, schedulerName string, ops []*operation.Operation) error {

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -304,9 +304,14 @@ func (om *OperationManager) StartLeaseRenewGoRoutine(operationCtx context.Contex
 	}()
 }
 
+// AppendOperationEventToExecutionHistory add a new operation event to Operation.ExecutionHistory.
+// It expects:
+// * ctx execution context
+// * op operation to add and persist the new event; and
+// * eventMessage the message that describe the event.
 func (om *OperationManager) AppendOperationEventToExecutionHistory(ctx context.Context, op *operation.Operation, eventMessage string) {
 	managerLogger := om.Logger.With(zap.String(logs.LogFieldOperationID, op.ID), zap.String(logs.LogFieldSchedulerName, op.SchedulerName))
-	managerLogger.Info("starting operation lease renew go routine")
+	managerLogger.Debug("Appeding operation event to execution history", zap.String("eventMessage", eventMessage))
 
 	event := operation.OperationEvent{
 		CreatedAt: time.Now().UTC(),

--- a/internal/core/services/operation_manager/operation_manager_test.go
+++ b/internal/core/services/operation_manager/operation_manager_test.go
@@ -1041,37 +1041,7 @@ func TestAppendOperationEventToExecutionHistory(t *testing.T) {
 				assert.Fail(t, "ExecutionHistory does not have new event")
 			}
 		}).Return(nil)
-		err := opManager.AppendOperationEventToExecutionHistory(ctx, op, eventMessage)
-		require.NoError(t, err)
-	})
-
-	t.Run("when UpdateOperationExecutionHistory return error should return error", func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-
-		defFunc := func() operations.Definition { return &testOperationDefinition{} }
-
-		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
-		operationStorage := mockports.NewMockOperationStorage(mockCtrl)
-		definitionConstructors := operations.NewDefinitionConstructors()
-		operationLeaseStorage := mockports.NewMockOperationLeaseStorage(mockCtrl)
-		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		definitionConstructors[defFunc().Name()] = defFunc
-		config := OperationManagerConfig{OperationLeaseTtl: time.Millisecond * 1000}
-		opManager := New(operationFlow, operationStorage, definitionConstructors, operationLeaseStorage, config, schedulerStorage)
-
-		ctx := context.Background()
-		schedulerName := "test-scheduler"
-		operationID := uuid.NewString()
-		op := &operation.Operation{
-			ID: operationID, DefinitionName: (&testOperationDefinition{}).Name(),
-			SchedulerName:    schedulerName,
-			ExecutionHistory: []operation.OperationEvent{},
-		}
-
-		operationStorage.EXPECT().UpdateOperationExecutionHistory(ctx, op).Return(fmt.Errorf("failed to update execution history"))
-		err := opManager.AppendOperationEventToExecutionHistory(ctx, op, "some-event-message")
-		require.Error(t, err)
-		require.Equal(t, err.Error(), "failed to update execution history")
+		opManager.AppendOperationEventToExecutionHistory(ctx, op, eventMessage)
 	})
 }
 

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -99,7 +99,6 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 
 			w.evictOperation(ctx, loopLogger, op)
 			reportOperationEvicted(w.schedulerName, op.DefinitionName, LabelNoOperationExecutorFound)
-			w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Operation definition has no executor")
 
 			continue
 		}
@@ -140,12 +139,12 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 			op.Status = operation.StatusError
 			err = w.operationManager.FinishOperation(ctx, op)
 			if err != nil {
-				loopLogger.Error("failed to finish operation", zap.Error(err))
+				loopLogger.Error("failed to start operation", zap.Error(err))
 			}
 
 			reportOperationExecutionWorkerFailed(w.schedulerName, LabelStartOperationFailed)
 
-			w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Failed to finish operation")
+			w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Failed to start operation")
 
 			return fmt.Errorf("failed to start operation \"%s\" for the scheduler \"%s\"", op.ID, op.SchedulerName)
 		}
@@ -189,7 +188,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 		if err != nil {
 			loopLogger.Error("failed to revoke operation lease", zap.Error(err))
 		}
-		w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Starting operation")
+		w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Finishing operation")
 	}
 }
 
@@ -210,5 +209,5 @@ func (w *OperationExecutionWorker) evictOperation(ctx context.Context, logger *z
 	logger.Info("operation evicted")
 	op.Status = operation.StatusEvicted
 	_ = w.operationManager.FinishOperation(ctx, op)
-	w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Operation evicted because there is no executor to them")
+	w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Operation evicted")
 }

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -176,6 +176,11 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 			op.Status = operation.StatusError
 			if errors.Is(executionErr, context.Canceled) {
 				op.Status = operation.StatusCanceled
+
+				err = w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Operation cancelled")
+				if err != nil {
+					return fmt.Errorf("Error appending operation event to execution history: %w", err)
+				}
 			}
 
 			loopLogger.Error("operation execution failed", zap.Error(executionErr))

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -72,6 +72,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
 
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, gomock.Any()).Return(nil).AnyTimes()
 		operationManager.EXPECT().GrantLease(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any())
 		operationManager.EXPECT().StartLeaseRenewGoRoutine(gomock.Any(), expectedOperation)
@@ -129,6 +130,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 			}).Return(nil)
 
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, gomock.Any()).Return(nil).AnyTimes()
 		operationManager.EXPECT().GrantLease(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any())
 		operationManager.EXPECT().StartLeaseRenewGoRoutine(gomock.Any(), expectedOperation)
@@ -169,6 +171,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
 
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, gomock.Any()).Return(nil).AnyTimes()
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
 		// Ends the worker by cancelling it
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(nil, nil, context.Canceled)
@@ -207,6 +210,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(false)
 
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, gomock.Any()).Return(nil).AnyTimes()
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
 		// Ends the worker by cancelling it
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(nil, nil, context.Canceled)
@@ -248,6 +252,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
 
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, gomock.Any()).Return(nil).AnyTimes()
 		operationManager.EXPECT().GrantLease(gomock.Any(), expectedOperation).Return(nil)
 		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any()).Return(errors.New("error"))
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
@@ -292,6 +297,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
 
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, gomock.Any()).Return(nil).AnyTimes()
 		operationManager.EXPECT().GrantLease(gomock.Any(), expectedOperation).Return(errors.New("error"))
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
 		// Ends the worker by cancelling it

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -311,6 +311,45 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		require.False(t, workerService.IsRunning())
 	})
 
+	t.Run("error appending event to exectution history should stop execution of operation", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		operationManager := mock.NewMockOperationManager(mockCtrl)
+
+		operationName := "test_operation"
+		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
+		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
+		operationExecutor.EXPECT().Name().Return(operationName).AnyTimes()
+		operationDefinition.EXPECT().Name().Return(operationName).AnyTimes()
+
+		defFunc := func() operations.Definition { return operationDefinition }
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[operationName] = defFunc
+
+		scheduler := &entities.Scheduler{Name: "random-scheduler"}
+		expectedOperation := &operation.Operation{
+			ID:             "random-operation-id",
+			SchedulerName:  scheduler.Name,
+			Status:         operation.StatusPending,
+			DefinitionName: operationName,
+		}
+
+		executors := map[string]operations.Executor{}
+		executors[operationName] = operationExecutor
+
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+
+		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
+		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, gomock.Any()).Return(fmt.Errorf("append operation to execution history error"))
+
+		err := workerService.Start(context.Background())
+		assert.Error(t, err, "Error appending operation event to execution history: append operation to execution history error")
+
+		workerService.Stop(context.Background())
+		require.False(t, workerService.IsRunning())
+	})
+
 	t.Run("error getting next operation should stop execution of operation", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
@@ -342,7 +381,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(nil, nil, errors.New("error"))
 
 		err := workerService.Start(context.Background())
-		require.Error(t, err)
+		assert.Error(t, err, "failed to get next operation: error")
 
 		workerService.Stop(context.Background())
 		require.False(t, workerService.IsRunning())


### PR DESCRIPTION
### Why
In the Operation entity, there is a field called `ExecutionHistory` that has a list of events and it isn't populated yet. This PR proposes to during operation_execution_worker populate this field.

### What
* Create operation_manager `AppendOperationEventToExecutionHistory` function
* Add events during worker execution