### PR TITLE
adds timestamp info to logs

### DIFF
--- a/internal/service/logging.go
+++ b/internal/service/logging.go
@@ -24,6 +24,7 @@ package service
 
 import (
 	"fmt"
+	"go.uber.org/zap/zapcore"
 
 	"go.uber.org/zap"
 )
@@ -35,6 +36,7 @@ func ConfigureLogging(configPreset string) error {
 		cfg = zap.NewDevelopmentConfig()
 	case "production":
 		cfg = zap.NewProductionConfig()
+		cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	default:
 		return fmt.Errorf("unexpected log_config: %v", configPreset)
 	}

--- a/internal/service/logging.go
+++ b/internal/service/logging.go
@@ -24,6 +24,7 @@ package service
 
 import (
 	"fmt"
+
 	"go.uber.org/zap/zapcore"
 
 	"go.uber.org/zap"


### PR DESCRIPTION
### What?
Format timestamp as readable to production logs

### Why?
Right now, the logs produced by Maestro don't have readable timestamps within (they're unix epoch). This is a problem because we end up depending on external tools to know when the logs were produced, and this information is 100% necessary for troubleshooting.

### Screen capure
![image](https://user-images.githubusercontent.com/25515954/159016008-d02ff190-700c-46ff-9502-f3534a4ac99a.png)

