### PR TITLE
removes version from remove rooms operation definition

### DIFF
--- a/internal/core/operations/remove_rooms/remove_rooms_definition.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_definition.go
@@ -34,8 +34,7 @@ import (
 const OperationName = "remove_rooms"
 
 type RemoveRoomsDefinition struct {
-	Amount  int    `json:"amount"`
-	Version string `json:"version"`
+	Amount int `json:"amount"`
 }
 
 func (d *RemoveRoomsDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {

--- a/internal/core/operations/remove_rooms/remove_rooms_executor.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor.go
@@ -45,7 +45,7 @@ func NewExecutor(roomManager ports.RoomManager) *RemoveRoomsExecutor {
 
 func (e *RemoveRoomsExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
 	removeDefinition := definition.(*RemoveRoomsDefinition)
-	rooms, err := e.roomManager.ListRoomsWithDeletionPriority(ctx, op.SchedulerName, removeDefinition.Version, removeDefinition.Amount, &sync.Map{})
+	rooms, err := e.roomManager.ListRoomsWithDeletionPriority(ctx, op.SchedulerName, "", removeDefinition.Amount, &sync.Map{})
 	if err != nil {
 		return fmt.Errorf("failed to list rooms to delete: %w", err)
 	}


### PR DESCRIPTION
### What?
Removes `version` from remove rooms definition.
### Why?
The `version` property on the remove rooms operation definition is wrong. Should not be there, and makes no sense to the operation.