### PR TITLE
Normalize http metrics cardinality by defining ignoring path parameter

### DIFF
--- a/cmd/commom/commom.go
+++ b/cmd/commom/commom.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"regexp"
 	"syscall"
 
 	"github.com/topfreegames/maestro/internal/config"
@@ -69,4 +70,12 @@ func launchTerminatingListenerGoroutine(cancelFunc context.CancelFunc) {
 
 		cancelFunc()
 	}()
+}
+
+func MatchPath(path, pattern string) bool {
+	match, err := regexp.MatchString(pattern, path)
+	if err != nil {
+		return false
+	}
+	return match
 }


### PR DESCRIPTION
## What ❓ 
Build and normalize metrics handler tag to keep the APIs metrics cardinality to a minimum.

## Why 🤔 
Currently, we are not aggregating APIs routes while producing request metrics, this led us to have a high metrics cardinality that will increase according to the path parameter possible values. We must not consider the path parameter while building this cardinality.

A little look at how these metrics are being produced today:
![image](https://user-images.githubusercontent.com/33766735/159263572-80274cc4-174f-460a-843f-7a5e36f5a0e6.png)


