### PR TITLE
Add metrics to scheduler storage

### DIFF
--- a/internal/adapters/metrics/pg.go
+++ b/internal/adapters/metrics/pg.go
@@ -20,21 +20,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package scheduler
+package metrics
 
 import (
-	"time"
-
-	"github.com/topfreegames/maestro/internal/adapters/metrics"
 	"github.com/topfreegames/maestro/internal/core/monitoring"
 )
 
-func reportSchedulerStorageFailsCounterMetric(storage, operation string, labels ...string) {
-	metrics.PostgresFailsCounterMetric.WithLabelValues(append([]string{storage, operation}, labels...)...).Inc()
-}
+var (
+	PostgresFailsCounterMetric = monitoring.CreateCounterMetric(&monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "postgres_fails_counter_metric",
+		Help:      "Postgres fails counter metric",
+		Labels: []string{
+			monitoring.LabelStorage,
+			monitoring.LabelOperation,
+			monitoring.LabelScheduler,
+		},
+	})
 
-func reportSchedulerStorageLatency(start time.Time, storage, operation string) {
-	monitoring.ReportLatencyMetricInMillis(
-		metrics.PostgresLatencyMetric, start, storage, operation,
-	)
-}
+	PostgresLatencyMetric = monitoring.CreateLatencyMetric(&monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "postgres_latency_metric",
+		Help:      "Postgres latency metric",
+		Labels: []string{
+			monitoring.LabelStorage,
+			monitoring.LabelOperation,
+		},
+	})
+)

--- a/internal/adapters/scheduler/metrics.go
+++ b/internal/adapters/scheduler/metrics.go
@@ -35,7 +35,7 @@ func reportSchedulerStorageFailsCounterMetric(operation string, labels ...string
 	metrics.PostgresFailsCounterMetric.WithLabelValues(append([]string{SchedulerStorageMetricLabel, operation}, labels...)...).Inc()
 }
 
-func reportSchedulerStorageLatency(operation string, executionFunction func()) {
+func runSchedulerStorageFunctionCollectingLatency(operation string, executionFunction func()) {
 	start := time.Now()
 	executionFunction()
 	monitoring.ReportLatencyMetricInMillis(

--- a/internal/adapters/scheduler/metrics.go
+++ b/internal/adapters/scheduler/metrics.go
@@ -1,0 +1,62 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package scheduler
+
+import (
+	"time"
+
+	"github.com/topfreegames/maestro/internal/core/monitoring"
+)
+
+var (
+	schedulerStorageFailsCounterMetric = monitoring.CreateCounterMetric(&monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "scheduler_storage_fails_counter_metric",
+		Help:      "Scheduler Storage fails counter metric",
+		Labels: []string{
+			monitoring.LabelOperation,
+			monitoring.LabelScheduler,
+		},
+	})
+
+	schedulerStorageLatencyMetric = monitoring.CreateLatencyMetric(&monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "scheduler_storage_latency_metric",
+		Help:      "Scheduler Storage latency metric",
+		Labels: []string{
+			monitoring.LabelOperation,
+		},
+	})
+)
+
+func reportSchedulerStorageFailsCounterMetric(labels ...string) {
+	schedulerStorageFailsCounterMetric.WithLabelValues(labels...).Inc()
+}
+
+func reportSchedulerStorageLatency(start time.Time, operation string) {
+	monitoring.ReportLatencyMetricInMillis(
+		schedulerStorageLatencyMetric, start, operation,
+	)
+}

--- a/internal/adapters/scheduler/metrics.go
+++ b/internal/adapters/scheduler/metrics.go
@@ -29,12 +29,14 @@ import (
 	"github.com/topfreegames/maestro/internal/core/monitoring"
 )
 
-func reportSchedulerStorageFailsCounterMetric(storage, operation string, labels ...string) {
-	metrics.PostgresFailsCounterMetric.WithLabelValues(append([]string{storage, operation}, labels...)...).Inc()
+const SchedulerStorageMetricLabel = "scheduler-storage"
+
+func reportSchedulerStorageFailsCounterMetric(operation string, labels ...string) {
+	metrics.PostgresFailsCounterMetric.WithLabelValues(append([]string{SchedulerStorageMetricLabel, operation}, labels...)...).Inc()
 }
 
-func reportSchedulerStorageLatency(start time.Time, storage, operation string) {
+func reportSchedulerStorageLatency(start time.Time, operation string) {
 	monitoring.ReportLatencyMetricInMillis(
-		metrics.PostgresLatencyMetric, start, storage, operation,
+		metrics.PostgresLatencyMetric, start, SchedulerStorageMetricLabel, operation,
 	)
 }

--- a/internal/adapters/scheduler/metrics.go
+++ b/internal/adapters/scheduler/metrics.go
@@ -35,7 +35,9 @@ func reportSchedulerStorageFailsCounterMetric(operation string, labels ...string
 	metrics.PostgresFailsCounterMetric.WithLabelValues(append([]string{SchedulerStorageMetricLabel, operation}, labels...)...).Inc()
 }
 
-func reportSchedulerStorageLatency(start time.Time, operation string) {
+func reportSchedulerStorageLatency(operation string, executionFunction func()) {
+	start := time.Now()
+	executionFunction()
 	monitoring.ReportLatencyMetricInMillis(
 		metrics.PostgresLatencyMetric, start, SchedulerStorageMetricLabel, operation,
 	)

--- a/internal/adapters/scheduler/scheduler_storage_pg.go
+++ b/internal/adapters/scheduler/scheduler_storage_pg.go
@@ -102,7 +102,7 @@ func (s schedulerStorage) GetScheduler(ctx context.Context, name string) (*entit
 	queryString := queryGetActiveScheduler
 
 	var err error
-	reportSchedulerStorageLatency("GetScheduler", func() {
+	runSchedulerStorageFunctionCollectingLatency("GetScheduler", func() {
 		_, err = client.QueryOne(&dbScheduler, queryString, name)
 	})
 	if err == pg.ErrNoRows {
@@ -138,7 +138,7 @@ func (s schedulerStorage) GetSchedulerWithFilter(ctx context.Context, schedulerF
 	queryString = queryString + " order by created_at desc limit 1"
 
 	var err error
-	reportSchedulerStorageLatency("GetSchedulerWithFilter", func() {
+	runSchedulerStorageFunctionCollectingLatency("GetSchedulerWithFilter", func() {
 		_, err = client.QueryOne(&dbScheduler, queryString, queryArr...)
 	})
 	if err == pg.ErrNoRows {
@@ -159,7 +159,7 @@ func (s schedulerStorage) GetSchedulerVersions(ctx context.Context, name string)
 	client := s.db.WithContext(ctx)
 	var dbSchedulerVersions []SchedulerVersion
 	var err error
-	reportSchedulerStorageLatency("GetSchedulerVersions", func() {
+	runSchedulerStorageFunctionCollectingLatency("GetSchedulerVersions", func() {
 		_, err = client.Query(&dbSchedulerVersions, queryGetSchedulerVersions, name)
 	})
 	if len(dbSchedulerVersions) == 0 {
@@ -181,7 +181,7 @@ func (s schedulerStorage) GetSchedulers(ctx context.Context, names []string) ([]
 	client := s.db.WithContext(ctx)
 	var dbSchedulers []Scheduler
 	var err error
-	reportSchedulerStorageLatency("GetSchedulers", func() {
+	runSchedulerStorageFunctionCollectingLatency("GetSchedulers", func() {
 		_, err = client.Query(&dbSchedulers, queryGetSchedulers, pg.In(names))
 	})
 	if err != nil {
@@ -209,7 +209,7 @@ func (s schedulerStorage) GetSchedulersWithFilter(ctx context.Context, scheduler
 	queryString = queryString + whereClauses
 
 	var err error
-	reportSchedulerStorageLatency("GetSchedulersWithFilter", func() {
+	runSchedulerStorageFunctionCollectingLatency("GetSchedulersWithFilter", func() {
 		_, err = client.Query(&dbSchedulers, queryString, arrayValues...)
 	})
 	if err != nil {
@@ -271,7 +271,7 @@ func (s schedulerStorage) GetAllSchedulers(ctx context.Context) ([]*entities.Sch
 	client := s.db.WithContext(ctx)
 	var dbSchedulers []Scheduler
 	var err error
-	reportSchedulerStorageLatency("GetAllSchedulers", func() {
+	runSchedulerStorageFunctionCollectingLatency("GetAllSchedulers", func() {
 		_, err = client.Query(&dbSchedulers, queryGetAllSchedulers)
 	})
 	if err != nil {
@@ -293,7 +293,7 @@ func (s schedulerStorage) CreateScheduler(ctx context.Context, scheduler *entiti
 	client := s.db.WithContext(ctx)
 	dbScheduler := NewDBScheduler(scheduler)
 	var err error
-	reportSchedulerStorageLatency("CreateScheduler", func() {
+	runSchedulerStorageFunctionCollectingLatency("CreateScheduler", func() {
 		_, err = client.Exec(queryInsertScheduler, dbScheduler)
 	})
 	if err != nil {
@@ -314,7 +314,7 @@ func (s schedulerStorage) UpdateScheduler(ctx context.Context, scheduler *entiti
 	client := s.db.WithContext(ctx)
 	dbScheduler := NewDBScheduler(scheduler)
 	var err error
-	reportSchedulerStorageLatency("UpdateScheduler", func() {
+	runSchedulerStorageFunctionCollectingLatency("UpdateScheduler", func() {
 		_, err = client.ExecOne(queryUpdateScheduler, dbScheduler)
 	})
 	if err == pg.ErrNoRows {
@@ -331,7 +331,7 @@ func (s schedulerStorage) UpdateScheduler(ctx context.Context, scheduler *entiti
 func (s schedulerStorage) DeleteScheduler(ctx context.Context, scheduler *entities.Scheduler) error {
 	client := s.db.WithContext(ctx)
 	var err error
-	reportSchedulerStorageLatency("DeleteScheduler", func() {
+	runSchedulerStorageFunctionCollectingLatency("DeleteScheduler", func() {
 		_, err = client.ExecOne(queryDeleteScheduler, scheduler.Name)
 	})
 	if err == pg.ErrNoRows {
@@ -352,13 +352,13 @@ func (s schedulerStorage) CreateSchedulerVersion(ctx context.Context, transactio
 		if !ok {
 			return errors.NewErrNotFound("transaction %s not found", transactionID)
 		}
-		reportSchedulerStorageLatency("CreateSchedulerVersion", func() {
+		runSchedulerStorageFunctionCollectingLatency("CreateSchedulerVersion", func() {
 			_, err = txClient.Exec(queryInsertVersion, dbScheduler.Name, dbScheduler.Version, dbScheduler.Yaml, dbScheduler.RollbackVersion)
 		})
 
 	} else {
 		client := s.db.WithContext(ctx)
-		reportSchedulerStorageLatency("CreateSchedulerVersion", func() {
+		runSchedulerStorageFunctionCollectingLatency("CreateSchedulerVersion", func() {
 			_, err = client.Exec(queryInsertVersion, dbScheduler.Name, dbScheduler.Version, dbScheduler.Yaml, dbScheduler.RollbackVersion)
 		})
 	}

--- a/internal/core/monitoring/constants.go
+++ b/internal/core/monitoring/constants.go
@@ -34,4 +34,5 @@ const (
 	LabelReason    = "reason"
 	LabelScheduler = "scheduler"
 	LabelOperation = "operation"
+	LabelStorage   = "storage"
 )


### PR DESCRIPTION
### Why
Scheduler storage doesn't have any metric related to database connections.

### What
This PR proposes to add metrics to scheduler storage with latency in database connections and errors count.