### PR TITLE
Fix GetOperation when there is no execution history in operation

### DIFF
--- a/internal/adapters/operation/operation_storage_redis.go
+++ b/internal/adapters/operation/operation_storage_redis.go
@@ -95,9 +95,11 @@ func (r *redisOperationStorage) GetOperation(ctx context.Context, schedulerName,
 	}
 
 	var executionHistory []operation.OperationEvent
-	err = json.Unmarshal([]byte(res[executionHistoryRedisKey]), &executionHistory)
-	if err != nil {
-		return nil, errors.NewErrEncoding("failed to parse operation execution history").WithError(err)
+	if history, ok := res[executionHistoryRedisKey]; ok {
+		err = json.Unmarshal([]byte(history), &executionHistory)
+		if err != nil {
+			return nil, errors.NewErrEncoding("failed to parse operation execution history").WithError(err)
+		}
 	}
 
 	statusInt, err := strconv.Atoi(res[statusRedisKey])


### PR DESCRIPTION
### Why
When `GetOperation` on Redis storage tries to parse an executionHistory that is empty it breaks.

### What
This PR implements logic to prevent errors during `GetOperation` when there are an operation without `ExecutionHistory` saved.