### PR TITLE
refactor - switch active version definition

### DIFF
--- a/internal/api/handlers/schedulers_handler.go
+++ b/internal/api/handlers/schedulers_handler.go
@@ -226,7 +226,7 @@ func (h *SchedulersHandler) NewSchedulerVersion(ctx context.Context, request *ap
 func (h *SchedulersHandler) SwitchActiveVersion(ctx context.Context, request *api.SwitchActiveVersionRequest) (*api.SwitchActiveVersionResponse, error) {
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldSchedulerName, request.GetSchedulerName()))
 	handlerLogger.Info("handling switch active version request")
-	operation, err := h.schedulerManager.SwitchActiveVersion(ctx, request.GetSchedulerName(), request.GetVersion())
+	operation, err := h.schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, request.GetSchedulerName(), request.GetVersion())
 
 	if err != nil {
 		handlerLogger.Error(fmt.Sprintf("error switching active version %s", request.GetVersion()), zap.Error(err))

--- a/internal/api/handlers/schedulers_handler_test.go
+++ b/internal/api/handlers/schedulers_handler_test.go
@@ -1084,7 +1084,6 @@ func TestSwitchActiveVersion(t *testing.T) {
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
-		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
 		operationManager.EXPECT().CreateOperation(gomock.Any(), "scheduler-name-1", gomock.Any()).Return(&operation.Operation{ID: "id-1"}, nil)
 
 		mux := runtime.NewServeMux()
@@ -1125,10 +1124,10 @@ func TestSwitchActiveVersion(t *testing.T) {
 		mux.ServeHTTP(rr, req)
 
 		require.Equal(t, 404, rr.Code)
-		require.Contains(t, rr.Body.String(), "no scheduler versions found to switch")
+		require.Contains(t, rr.Body.String(), "not found")
 	})
 
-	t.Run("fails when operation enqueue fails", func(t *testing.T) {
+	t.Run("fails when operation enqueue fails since version does not exist", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
@@ -1138,7 +1137,6 @@ func TestSwitchActiveVersion(t *testing.T) {
 		schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
 		schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
-		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(newValidScheduler(), nil)
 		operationManager.EXPECT().CreateOperation(gomock.Any(), "scheduler-name-1", gomock.Any()).Return(nil, errors.NewErrUnexpected("internal error"))
 
 		mux := runtime.NewServeMux()
@@ -1152,7 +1150,7 @@ func TestSwitchActiveVersion(t *testing.T) {
 		mux.ServeHTTP(rr, req)
 
 		require.Equal(t, 500, rr.Code)
-		require.Contains(t, rr.Body.String(), "failed to schedule operation: failed to schedule switch_active_version operation")
+		require.Contains(t, rr.Body.String(), "internal error")
 	})
 }
 

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -146,7 +146,7 @@ func (ex *CreateNewSchedulerVersionExecutor) RemoveValidationRoomId(schedulerNam
 }
 
 func (ex *CreateNewSchedulerVersionExecutor) createNewSchedulerVersionAndEnqueueSwitchVersionOp(ctx context.Context, newScheduler *entities.Scheduler, logger *zap.Logger, replacePods bool) error {
-	err := ex.schedulerManager.CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx, newScheduler, replacePods)
+	err := ex.schedulerManager.CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx, newScheduler)
 	if err != nil {
 		logger.Error("error creating new scheduler version in db", zap.Error(err))
 		return fmt.Errorf("error creating new scheduler version in db: %w", err)

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -72,9 +72,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		schedulerManager.
 			EXPECT().
-			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any(), true).
+			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any()).
 			DoAndReturn(
-				func(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error {
+				func(ctx context.Context, scheduler *entities.Scheduler) error {
 					require.Equal(t, newSchedulerExpectedVersion, scheduler.Spec.Version)
 					return nil
 				})
@@ -111,9 +111,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		schedulerManager.
 			EXPECT().
-			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any(), true).
+			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any()).
 			DoAndReturn(
-				func(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error {
+				func(ctx context.Context, scheduler *entities.Scheduler) error {
 					require.Equal(t, newSchedulerExpectedVersion, scheduler.Spec.Version)
 					return nil
 				})
@@ -150,9 +150,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		schedulerManager.
 			EXPECT().
-			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any(), true).
+			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any()).
 			DoAndReturn(
-				func(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error {
+				func(ctx context.Context, scheduler *entities.Scheduler) error {
 					require.Equal(t, newSchedulerExpectedVersion, scheduler.Spec.Version)
 					return nil
 				})
@@ -189,9 +189,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		schedulerManager.
 			EXPECT().
-			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any(), true).
+			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any()).
 			DoAndReturn(
-				func(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error {
+				func(ctx context.Context, scheduler *entities.Scheduler) error {
 					require.Equal(t, newSchedulerExpectedVersion, scheduler.Spec.Version)
 					return nil
 				})
@@ -307,9 +307,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		schedulerManager.
 			EXPECT().
-			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any(), false).
+			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any()).
 			DoAndReturn(
-				func(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error {
+				func(ctx context.Context, scheduler *entities.Scheduler) error {
 					require.Equal(t, newSchedulerExpectedVersion, scheduler.Spec.Version)
 					return nil
 				})
@@ -343,9 +343,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		schedulerManager.
 			EXPECT().
-			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any(), false).
+			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any()).
 			DoAndReturn(
-				func(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error {
+				func(ctx context.Context, scheduler *entities.Scheduler) error {
 					require.Equal(t, newSchedulerExpectedVersion, scheduler.Spec.Version)
 					return nil
 				})
@@ -379,9 +379,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		schedulerManager.
 			EXPECT().
-			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any(), false).
+			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any()).
 			DoAndReturn(
-				func(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error {
+				func(ctx context.Context, scheduler *entities.Scheduler) error {
 					require.Equal(t, newSchedulerExpectedVersion, scheduler.Spec.Version)
 					return nil
 				})
@@ -468,7 +468,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		schedulerManager.EXPECT().GetSchedulerVersions(gomock.Any(), newScheduler.Name).Return([]*entities.SchedulerVersion{}, nil)
 		schedulerManager.
 			EXPECT().
-			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any(), false).
+			CreateNewSchedulerVersionAndEnqueueSwitchVersion(gomock.Any(), gomock.Any()).
 			Return(errors.NewErrUnexpected("some_error"))
 
 		result := executor.Execute(context.Background(), op, operationDef)

--- a/internal/core/operations/switch_active_version/switch_active_version_definition.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_definition.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"go.uber.org/zap"
 )
@@ -35,8 +34,7 @@ import (
 const OperationName = "switch_active_version"
 
 type SwitchActiveVersionDefinition struct {
-	NewActiveScheduler entities.Scheduler `json:"scheduler"`
-	ReplacePods        bool               `json:"replacePods"`
+	NewActiveVersion string `json:"newActiveVersion"`
 }
 
 func (d *SwitchActiveVersionDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -79,8 +79,19 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 	if !ok {
 		return fmt.Errorf("the definition is invalid. Should be type SwitchActiveVersionDefinition")
 	}
-	scheduler := &updateDefinition.NewActiveScheduler
-	replacePods := updateDefinition.ReplacePods
+
+	actualActiveScheduler, err := ex.schedulerManager.GetActiveScheduler(ctx, op.SchedulerName)
+	if err != nil {
+		logger.Error("error fetching active scheduler", zap.Error(err))
+		return err
+	}
+	scheduler, err := ex.schedulerManager.GetSchedulerByVersion(ctx, op.SchedulerName, updateDefinition.NewActiveVersion)
+	if err != nil {
+		logger.Error("error fetching scheduler to be switched to", zap.Error(err))
+		return err
+	}
+
+	replacePods := actualActiveScheduler.IsMajorVersion(scheduler)
 
 	if replacePods {
 		maxSurgeNum, err := ex.roomManager.SchedulerMaxSurge(ctx, scheduler)
@@ -96,7 +107,7 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 	}
 
 	logger.Sugar().Debugf("switching version to %v", scheduler.Spec.Version)
-	err := ex.schedulerManager.UpdateScheduler(ctx, scheduler)
+	err = ex.schedulerManager.UpdateScheduler(ctx, scheduler)
 	if err != nil {
 		logger.Error("Error switching active scheduler version on scheduler manager")
 		return err

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -80,18 +80,17 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 		return fmt.Errorf("the definition is invalid. Should be type SwitchActiveVersionDefinition")
 	}
 
-	actualActiveScheduler, err := ex.schedulerManager.GetActiveScheduler(ctx, op.SchedulerName)
-	if err != nil {
-		logger.Error("error fetching active scheduler", zap.Error(err))
-		return err
-	}
 	scheduler, err := ex.schedulerManager.GetSchedulerByVersion(ctx, op.SchedulerName, updateDefinition.NewActiveVersion)
 	if err != nil {
 		logger.Error("error fetching scheduler to be switched to", zap.Error(err))
 		return err
 	}
 
-	replacePods := actualActiveScheduler.IsMajorVersion(scheduler)
+	replacePods, err := ex.shouldReplacePods(ctx, scheduler)
+	if err != nil {
+		logger.Error("error calculating if should replace pods", zap.Error(err))
+		return err
+	}
 
 	if replacePods {
 		maxSurgeNum, err := ex.roomManager.SchedulerMaxSurge(ctx, scheduler)
@@ -237,4 +236,12 @@ func (ex *SwitchActiveVersionExecutor) appendToNewCreatedRooms(schedulerName str
 
 func (ex *SwitchActiveVersionExecutor) clearNewCreatedRooms(schedulerName string) {
 	delete(ex.newCreatedRooms, schedulerName)
+}
+
+func (ex *SwitchActiveVersionExecutor) shouldReplacePods(ctx context.Context, newScheduler *entities.Scheduler) (bool, error) {
+	actualActiveScheduler, err := ex.schedulerManager.GetActiveScheduler(ctx, newScheduler.Name)
+	if err != nil {
+		return false, err
+	}
+	return actualActiveScheduler.IsMajorVersion(newScheduler), nil
 }

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -88,7 +88,7 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 
 	replacePods, err := ex.shouldReplacePods(ctx, scheduler)
 	if err != nil {
-		logger.Error("error calculating if should replace pods", zap.Error(err))
+		logger.Error("error deciding if should replace pods", zap.Error(err))
 		return err
 	}
 

--- a/internal/core/ports/mock/scheduler_ports_mock.go
+++ b/internal/core/ports/mock/scheduler_ports_mock.go
@@ -54,17 +54,17 @@ func (mr *MockSchedulerManagerMockRecorder) CreateNewSchedulerVersion(ctx, sched
 }
 
 // CreateNewSchedulerVersionAndEnqueueSwitchVersion mocks base method.
-func (m *MockSchedulerManager) CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error {
+func (m *MockSchedulerManager) CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx context.Context, scheduler *entities.Scheduler) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNewSchedulerVersionAndEnqueueSwitchVersion", ctx, scheduler, replacePods)
+	ret := m.ctrl.Call(m, "CreateNewSchedulerVersionAndEnqueueSwitchVersion", ctx, scheduler)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateNewSchedulerVersionAndEnqueueSwitchVersion indicates an expected call of CreateNewSchedulerVersionAndEnqueueSwitchVersion.
-func (mr *MockSchedulerManagerMockRecorder) CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx, scheduler, replacePods interface{}) *gomock.Call {
+func (mr *MockSchedulerManagerMockRecorder) CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx, scheduler interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewSchedulerVersionAndEnqueueSwitchVersion", reflect.TypeOf((*MockSchedulerManager)(nil).CreateNewSchedulerVersionAndEnqueueSwitchVersion), ctx, scheduler, replacePods)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNewSchedulerVersionAndEnqueueSwitchVersion", reflect.TypeOf((*MockSchedulerManager)(nil).CreateNewSchedulerVersionAndEnqueueSwitchVersion), ctx, scheduler)
 }
 
 // DeleteScheduler mocks base method.
@@ -82,18 +82,18 @@ func (mr *MockSchedulerManagerMockRecorder) DeleteScheduler(ctx, schedulerName i
 }
 
 // EnqueueSwitchActiveVersionOperation mocks base method.
-func (m *MockSchedulerManager) EnqueueSwitchActiveVersionOperation(ctx context.Context, newScheduler *entities.Scheduler, replacePods bool) (*operation.Operation, error) {
+func (m *MockSchedulerManager) EnqueueSwitchActiveVersionOperation(ctx context.Context, schedulerName, newVersion string) (*operation.Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnqueueSwitchActiveVersionOperation", ctx, newScheduler, replacePods)
+	ret := m.ctrl.Call(m, "EnqueueSwitchActiveVersionOperation", ctx, schedulerName, newVersion)
 	ret0, _ := ret[0].(*operation.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnqueueSwitchActiveVersionOperation indicates an expected call of EnqueueSwitchActiveVersionOperation.
-func (mr *MockSchedulerManagerMockRecorder) EnqueueSwitchActiveVersionOperation(ctx, newScheduler, replacePods interface{}) *gomock.Call {
+func (mr *MockSchedulerManagerMockRecorder) EnqueueSwitchActiveVersionOperation(ctx, schedulerName, newVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueSwitchActiveVersionOperation", reflect.TypeOf((*MockSchedulerManager)(nil).EnqueueSwitchActiveVersionOperation), ctx, newScheduler, replacePods)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueSwitchActiveVersionOperation", reflect.TypeOf((*MockSchedulerManager)(nil).EnqueueSwitchActiveVersionOperation), ctx, schedulerName, newVersion)
 }
 
 // GetActiveScheduler mocks base method.
@@ -109,6 +109,21 @@ func (m *MockSchedulerManager) GetActiveScheduler(ctx context.Context, scheduler
 func (mr *MockSchedulerManagerMockRecorder) GetActiveScheduler(ctx, schedulerName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveScheduler", reflect.TypeOf((*MockSchedulerManager)(nil).GetActiveScheduler), ctx, schedulerName)
+}
+
+// GetSchedulerByVersion mocks base method.
+func (m *MockSchedulerManager) GetSchedulerByVersion(ctx context.Context, schedulerName, schedulerVersion string) (*entities.Scheduler, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSchedulerByVersion", ctx, schedulerName, schedulerVersion)
+	ret0, _ := ret[0].(*entities.Scheduler)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSchedulerByVersion indicates an expected call of GetSchedulerByVersion.
+func (mr *MockSchedulerManagerMockRecorder) GetSchedulerByVersion(ctx, schedulerName, schedulerVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedulerByVersion", reflect.TypeOf((*MockSchedulerManager)(nil).GetSchedulerByVersion), ctx, schedulerName, schedulerVersion)
 }
 
 // GetSchedulerVersions mocks base method.
@@ -139,21 +154,6 @@ func (m *MockSchedulerManager) GetSchedulersInfo(ctx context.Context, filter *fi
 func (mr *MockSchedulerManagerMockRecorder) GetSchedulersInfo(ctx, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedulersInfo", reflect.TypeOf((*MockSchedulerManager)(nil).GetSchedulersInfo), ctx, filter)
-}
-
-// SwitchActiveVersion mocks base method.
-func (m *MockSchedulerManager) SwitchActiveVersion(ctx context.Context, schedulerName, targetVersion string) (*operation.Operation, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SwitchActiveVersion", ctx, schedulerName, targetVersion)
-	ret0, _ := ret[0].(*operation.Operation)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SwitchActiveVersion indicates an expected call of SwitchActiveVersion.
-func (mr *MockSchedulerManagerMockRecorder) SwitchActiveVersion(ctx, schedulerName, targetVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SwitchActiveVersion", reflect.TypeOf((*MockSchedulerManager)(nil).SwitchActiveVersion), ctx, schedulerName, targetVersion)
 }
 
 // UpdateScheduler mocks base method.

--- a/internal/core/ports/scheduler_ports.go
+++ b/internal/core/ports/scheduler_ports.go
@@ -36,10 +36,10 @@ import (
 type SchedulerManager interface {
 	UpdateScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	GetActiveScheduler(ctx context.Context, schedulerName string) (*entities.Scheduler, error)
-	CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error
+	GetSchedulerByVersion(ctx context.Context, schedulerName, schedulerVersion string) (*entities.Scheduler, error)
+	CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx context.Context, scheduler *entities.Scheduler) error
 	CreateNewSchedulerVersion(ctx context.Context, scheduler *entities.Scheduler) error
-	EnqueueSwitchActiveVersionOperation(ctx context.Context, newScheduler *entities.Scheduler, replacePods bool) (*operation.Operation, error)
-	SwitchActiveVersion(ctx context.Context, schedulerName string, targetVersion string) (*operation.Operation, error)
+	EnqueueSwitchActiveVersionOperation(ctx context.Context, schedulerName, newVersion string) (*operation.Operation, error)
 	GetSchedulersInfo(ctx context.Context, filter *filters.SchedulerFilter) ([]*entities.SchedulerInfo, error)
 	GetSchedulerVersions(ctx context.Context, schedulerName string) ([]*entities.SchedulerVersion, error)
 	DeleteScheduler(ctx context.Context, schedulerName string) error

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	portsErrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -24,7 +24,9 @@ package scheduler_manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	portsErrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 	"github.com/topfreegames/maestro/internal/core/logs"
@@ -49,6 +51,8 @@ type SchedulerManager struct {
 	logger           *zap.Logger
 }
 
+var _ ports.SchedulerManager = (*SchedulerManager)(nil)
+
 func NewSchedulerManager(schedulerStorage ports.SchedulerStorage, schedulerCache ports.SchedulerCache, operationManager ports.OperationManager, roomStorage ports.RoomStorage) *SchedulerManager {
 	return &SchedulerManager{
 		schedulerStorage: schedulerStorage,
@@ -62,6 +66,18 @@ func NewSchedulerManager(schedulerStorage ports.SchedulerStorage, schedulerCache
 func (s *SchedulerManager) GetActiveScheduler(ctx context.Context, schedulerName string) (*entities.Scheduler, error) {
 	activeScheduler, err := s.schedulerStorage.GetScheduler(ctx, schedulerName)
 	if err != nil {
+		return nil, err
+	}
+	return activeScheduler, nil
+}
+
+func (s *SchedulerManager) GetSchedulerByVersion(ctx context.Context, schedulerName, schedulerVersion string) (*entities.Scheduler, error) {
+	activeScheduler, err := s.schedulerStorage.GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
+		Name:    schedulerName,
+		Version: schedulerVersion,
+	})
+	if err != nil {
+		s.logger.Error("error fetching scheduler by version", zap.Error(err))
 		return nil, err
 	}
 	return activeScheduler, nil
@@ -101,7 +117,7 @@ func (s *SchedulerManager) CreateNewSchedulerVersion(ctx context.Context, schedu
 	return nil
 }
 
-func (s *SchedulerManager) CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx context.Context, scheduler *entities.Scheduler, replacePods bool) error {
+func (s *SchedulerManager) CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx context.Context, scheduler *entities.Scheduler) error {
 	err := scheduler.Validate()
 	if err != nil {
 		return fmt.Errorf("failing in creating schedule: %w", err)
@@ -113,7 +129,7 @@ func (s *SchedulerManager) CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx 
 			return err
 		}
 
-		_, err = s.EnqueueSwitchActiveVersionOperation(ctx, scheduler, replacePods)
+		_, err = s.EnqueueSwitchActiveVersionOperation(ctx, scheduler.Name, scheduler.Spec.Version)
 		if err != nil {
 			return fmt.Errorf("error enqueuing switch active version operation: %w", err)
 		}
@@ -197,13 +213,18 @@ func (s *SchedulerManager) EnqueueNewSchedulerVersionOperation(ctx context.Conte
 	return op, nil
 }
 
-func (s *SchedulerManager) EnqueueSwitchActiveVersionOperation(ctx context.Context, newScheduler *entities.Scheduler, replacePods bool) (*operation.Operation, error) {
-	err := newScheduler.Validate()
+func (s *SchedulerManager) EnqueueSwitchActiveVersionOperation(ctx context.Context, schedulerName, newVersion string) (*operation.Operation, error) {
+	_, err := s.GetSchedulerByVersion(ctx, schedulerName, newVersion)
 	if err != nil {
+		if errors.Is(err, portsErrors.ErrNotFound) {
+			s.logger.Sugar().Warnf("scheduler \"%s\" version \"%s\" not found", schedulerName, newVersion)
+			return nil, portsErrors.NewErrNotFound("scheduler \"%s\" version \"%s\" not found", schedulerName, newVersion)
+		}
+		s.logger.Sugar().Error("scheduler \"%s\" version \"%s\" could not be fetched", schedulerName, newVersion, zap.Error(err))
 		return nil, err
 	}
-	opDef := &switch_active_version.SwitchActiveVersionDefinition{NewActiveScheduler: *newScheduler, ReplacePods: replacePods}
-	op, err := s.operationManager.CreateOperation(ctx, newScheduler.Name, opDef)
+	opDef := &switch_active_version.SwitchActiveVersionDefinition{NewActiveVersion: newVersion}
+	op, err := s.operationManager.CreateOperation(ctx, schedulerName, opDef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to schedule %s operation: %w", opDef.Name(), err)
 	}
@@ -227,30 +248,6 @@ func (s *SchedulerManager) UpdateScheduler(ctx context.Context, scheduler *entit
 		s.logger.Error("error deleting scheduler from cache", zap.String("scheduler", scheduler.Name), zap.Error(err))
 	}
 	return nil
-}
-
-func (s *SchedulerManager) SwitchActiveVersion(ctx context.Context, schedulerName string, targetVersion string) (*operation.Operation, error) {
-	schedulerTargetVersion, err := s.schedulerStorage.GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
-		Name:    schedulerName,
-		Version: targetVersion,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("no scheduler versions found to switch: %w", err)
-	}
-
-	currentActiveVersion, err := s.GetActiveScheduler(ctx, schedulerName)
-	if err != nil {
-		return nil, fmt.Errorf("error fetching current active version for scheduler. err: %w", err)
-	}
-
-	isMajorChange := currentActiveVersion.IsMajorVersion(schedulerTargetVersion)
-	s.logger.Sugar().Infof("Change between version \"%v\" and \"%v\" is major: %v", currentActiveVersion.Spec.Version, schedulerTargetVersion.Spec.Version, isMajorChange)
-	op, err := s.EnqueueSwitchActiveVersionOperation(ctx, schedulerTargetVersion, isMajorChange)
-	if err != nil {
-		return nil, fmt.Errorf("failed to schedule operation: %w", err)
-	}
-
-	return op, nil
 }
 
 func (s *SchedulerManager) GetSchedulersInfo(ctx context.Context, filter *filters.SchedulerFilter) ([]*entities.SchedulerInfo, error) {

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -497,6 +497,50 @@ func TestGetSchedulerVersions(t *testing.T) {
 	})
 }
 
+func TestGetSchedulerByVersion(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	t.Run("with success", func(t *testing.T) {
+		scheduler := newValidScheduler()
+
+		ctx := context.Background()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+		operationManager := mock.NewMockOperationManager(mockCtrl)
+		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
+
+		schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
+			Name:    scheduler.Name,
+			Version: scheduler.Spec.Version,
+		}).Return(scheduler, nil)
+
+		schedulerReturned, err := schedulerManager.GetSchedulerByVersion(ctx, scheduler.Name, scheduler.Spec.Version)
+		require.NoError(t, err)
+		require.NotNil(t, schedulerReturned)
+	})
+
+	t.Run("fail", func(t *testing.T) {
+		scheduler := newValidScheduler()
+
+		ctx := context.Background()
+		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+		operationManager := mock.NewMockOperationManager(mockCtrl)
+		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
+
+		schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
+			Name:    scheduler.Name,
+			Version: scheduler.Spec.Version,
+		}).Return(nil, errors.NewErrUnexpected("error"))
+
+		schedulerReturned, err := schedulerManager.GetSchedulerByVersion(ctx, scheduler.Name, scheduler.Spec.Version)
+		require.Error(t, err)
+		require.Nil(t, schedulerReturned)
+	})
+}
+
 func TestGetScheduler(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 


### PR DESCRIPTION
### What?
Make `switch_active_version` operation definition have only `"newVersion"`, instead of `"newScheduler"` and `"replacePods"`.

### Why?
Since now we have the "input" property in the Operation entity, and "input" is the representation of what the client gave to Maestro, we want the definition to be exactly this.
That said, the definition of "switch active version" should have only the version being switched to, and not the whole entity (since the user is not giving it to Maestro, is something that Maestro fetches from the database) and "replacePods" (which is a business rule of the operation itself)