### PR TITLE
Fix success metric label value 

### DIFF
--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -152,7 +152,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 
 		executeStartTime := time.Now()
 		executionErr := executor.Execute(operationContext, op, def)
-		reportOperationExecutionLatency(executeStartTime, w.schedulerName, op.DefinitionName, executionErr != nil)
+		reportOperationExecutionLatency(executeStartTime, w.schedulerName, op.DefinitionName, executionErr == nil)
 
 		op.Status = operation.StatusFinished
 		if executionErr != nil {
@@ -167,7 +167,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 
 			onErrorStartTime := time.Now()
 			onErrorErr := executor.OnError(operationContext, op, def, executionErr)
-			reportOperationOnErrorLatency(onErrorStartTime, w.schedulerName, op.DefinitionName, onErrorErr != nil)
+			reportOperationOnErrorLatency(onErrorStartTime, w.schedulerName, op.DefinitionName, onErrorErr == nil)
 
 			if onErrorErr != nil {
 				loopLogger.Error("operation OnError failed", zap.Error(onErrorErr))


### PR DESCRIPTION
## What ❓ 
Fix `success` label value on operation execution metric reporting

## Why 🤔 
The `success` label value was wrong, it should be success true when no error occurs (err == nil) and false otherwise.