### PR TITLE
Include events forwarding latency metrics

### DIFF
--- a/internal/adapters/events/forwarder_client.go
+++ b/internal/adapters/events/forwarder_client.go
@@ -65,7 +65,9 @@ func (f *forwarderClient) SendRoomEvent(ctx context.Context, forwarder forwarder
 	ctx, cancel := context.WithTimeout(ctx, forwarder.Options.Timeout*time.Millisecond)
 	defer cancel()
 
-	return client.SendRoomEvent(ctx, in)
+	return runReportingLatencyMetrics("SendRoomEvent", func() (*pb.Response, error) {
+		return client.SendRoomEvent(ctx, in)
+	})
 }
 
 func (f *forwarderClient) SendRoomReSync(ctx context.Context, forwarder forwarder.Forwarder, in *pb.RoomStatus) (*pb.Response, error) {
@@ -76,8 +78,9 @@ func (f *forwarderClient) SendRoomReSync(ctx context.Context, forwarder forwarde
 
 	ctx, cancel := context.WithTimeout(ctx, forwarder.Options.Timeout*time.Millisecond)
 	defer cancel()
-
-	return client.SendRoomResync(ctx, in)
+	return runReportingLatencyMetrics("SendRoomResync", func() (*pb.Response, error) {
+		return client.SendRoomResync(ctx, in)
+	})
 }
 
 func (f *forwarderClient) SendPlayerEvent(ctx context.Context, forwarder forwarder.Forwarder, in *pb.PlayerEvent) (*pb.Response, error) {
@@ -88,8 +91,9 @@ func (f *forwarderClient) SendPlayerEvent(ctx context.Context, forwarder forward
 
 	ctx, cancel := context.WithTimeout(ctx, forwarder.Options.Timeout*time.Millisecond)
 	defer cancel()
-
-	return client.SendPlayerEvent(ctx, in)
+	return runReportingLatencyMetrics("SendPlayerEvent", func() (*pb.Response, error) {
+		return client.SendPlayerEvent(ctx, in)
+	})
 }
 
 func (f *forwarderClient) CacheFlush() {

--- a/internal/adapters/events/metrics.go
+++ b/internal/adapters/events/metrics.go
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package events
 
 import (

--- a/internal/adapters/events/metrics.go
+++ b/internal/adapters/events/metrics.go
@@ -1,0 +1,23 @@
+package events
+
+import (
+	"time"
+
+	"github.com/topfreegames/maestro/internal/adapters/metrics"
+	"github.com/topfreegames/maestro/internal/core/monitoring"
+	pb "github.com/topfreegames/protos/maestro/grpc/generated"
+	"google.golang.org/grpc/status"
+)
+
+const forwarderServiceMetricLabel = "GRPCForwarder"
+
+func runReportingLatencyMetrics(method string, executionFunction func() (*pb.Response, error)) (*pb.Response, error) {
+	start := time.Now()
+	response, responseErr := executionFunction()
+	statusCode := status.Code(responseErr)
+
+	monitoring.ReportLatencyMetricInMillis(
+		metrics.GrpcLatencyMetric, start, forwarderServiceMetricLabel, method, statusCode.String(),
+	)
+	return response, responseErr
+}

--- a/internal/adapters/metrics/grpc.go
+++ b/internal/adapters/metrics/grpc.go
@@ -20,22 +20,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package monitoring
+package metrics
 
-const (
-	Namespace       = "maestro"
-	SubsystemApi    = "api"
-	SubsystemWorker = "worker"
+import (
+	"github.com/topfreegames/maestro/internal/core/monitoring"
 )
 
-const (
-	LabelService   = "service"
-	LabelMethod    = "method"
-	LabelCode      = "code"
-	LabelPlatform  = "platform"
-	LabelSuccess   = "success"
-	LabelReason    = "reason"
-	LabelScheduler = "scheduler"
-	LabelOperation = "operation"
-	LabelStorage   = "storage"
+var (
+	GrpcLatencyMetric = monitoring.CreateLatencyMetric(&monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "grpc_request",
+		Help:      "Grpc latency metric",
+		Labels: []string{
+			monitoring.LabelService,
+			monitoring.LabelMethod,
+			monitoring.LabelCode,
+		},
+	})
 )

--- a/internal/adapters/metrics/pg.go
+++ b/internal/adapters/metrics/pg.go
@@ -30,7 +30,7 @@ var (
 	PostgresFailsCounterMetric = monitoring.CreateCounterMetric(&monitoring.MetricOpts{
 		Namespace: monitoring.Namespace,
 		Subsystem: monitoring.SubsystemWorker,
-		Name:      "postgres_fails_counter_metric",
+		Name:      "postgres_fails",
 		Help:      "Postgres fails counter metric",
 		Labels: []string{
 			monitoring.LabelStorage,
@@ -42,7 +42,7 @@ var (
 	PostgresLatencyMetric = monitoring.CreateLatencyMetric(&monitoring.MetricOpts{
 		Namespace: monitoring.Namespace,
 		Subsystem: monitoring.SubsystemWorker,
-		Name:      "postgres_latency_metric",
+		Name:      "postgres_operation",
 		Help:      "Postgres latency metric",
 		Labels: []string{
 			monitoring.LabelStorage,


### PR DESCRIPTION
## What ❓ 
Create and produce metrics for events forwarding grpc calls. Rename postgres metrics.

## Why 🤔 
To improve events forwarding observability