### PR TITLE
Fix/cannot create new scheduler version

### DIFF
--- a/e2e/suites/management/switch_active_version_test.go
+++ b/e2e/suites/management/switch_active_version_test.go
@@ -416,7 +416,9 @@ func TestSwitchActiveVersion(t *testing.T) {
 			switchActiveVersionResponse := &maestroApiV1.SwitchActiveVersionResponse{}
 
 			err = managementApiClient.Do("PUT", fmt.Sprintf("/schedulers/%s", scheduler.Name), switchActiveVersionRequest, switchActiveVersionResponse)
-			require.Error(t, err)
+			require.NoError(t, err)
+
+			waitForOperationToFailById(t, managementApiClient, scheduler.Name, switchActiveVersionResponse.OperationId)
 		})
 
 		t.Run("Fail - adding forwarders crashes (testing scheduler cache)", func(t *testing.T) {

--- a/e2e/suites/management/utils.go
+++ b/e2e/suites/management/utils.go
@@ -308,3 +308,22 @@ func waitForOperationToFail(t *testing.T, managementApiClient *framework.APIClie
 		return false
 	}, 4*time.Minute, time.Second)
 }
+
+func waitForOperationToFailById(t *testing.T, managementApiClient *framework.APIClient, schedulerName, operationId string) {
+	require.Eventually(t, func() bool {
+		listOperationsRequest := &maestroApiV1.ListOperationsRequest{}
+		listOperationsResponse := &maestroApiV1.ListOperationsResponse{}
+		err := managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", schedulerName), listOperationsRequest, listOperationsResponse)
+		require.NoError(t, err)
+
+		if len(listOperationsResponse.FinishedOperations) >= 1 {
+			for _, _operation := range listOperationsResponse.FinishedOperations {
+				if _operation.Id == operationId && _operation.Status == "error" {
+					return true
+				}
+			}
+		}
+
+		return false
+	}, 4*time.Minute, time.Second)
+}

--- a/internal/api/handlers/schedulers_handler.go
+++ b/internal/api/handlers/schedulers_handler.go
@@ -230,9 +230,6 @@ func (h *SchedulersHandler) SwitchActiveVersion(ctx context.Context, request *ap
 
 	if err != nil {
 		handlerLogger.Error(fmt.Sprintf("error switching active version %s", request.GetVersion()), zap.Error(err))
-		if errors.Is(err, portsErrors.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, err.Error())
-		}
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
 

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -24,10 +24,7 @@ package scheduler_manager
 
 import (
 	"context"
-	"errors"
 	"fmt"
-
-	portsErrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 	"github.com/topfreegames/maestro/internal/core/logs"
@@ -215,15 +212,15 @@ func (s *SchedulerManager) EnqueueNewSchedulerVersionOperation(ctx context.Conte
 }
 
 func (s *SchedulerManager) EnqueueSwitchActiveVersionOperation(ctx context.Context, schedulerName, newVersion string) (*operation.Operation, error) {
-	_, err := s.GetSchedulerByVersion(ctx, schedulerName, newVersion)
-	if err != nil {
-		if errors.Is(err, portsErrors.ErrNotFound) {
-			s.logger.Sugar().Warnf("scheduler \"%s\" version \"%s\" not found", schedulerName, newVersion)
-			return nil, portsErrors.NewErrNotFound("scheduler \"%s\" version \"%s\" not found", schedulerName, newVersion)
-		}
-		s.logger.Sugar().Error("scheduler \"%s\" version \"%s\" could not be fetched", schedulerName, newVersion, zap.Error(err))
-		return nil, err
-	}
+	//_, err := s.GetSchedulerByVersion(ctx, schedulerName, newVersion)
+	//if err != nil {
+	//	if errors.Is(err, portsErrors.ErrNotFound) {
+	//		s.logger.Sugar().Warnf("scheduler \"%s\" version \"%s\" not found", schedulerName, newVersion)
+	//		return nil, portsErrors.NewErrNotFound("scheduler \"%s\" version \"%s\" not found", schedulerName, newVersion)
+	//	}
+	//	s.logger.Sugar().Error("scheduler \"%s\" version \"%s\" could not be fetched", schedulerName, newVersion, zap.Error(err))
+	//	return nil, err
+	//}
 	opDef := &switch_active_version.SwitchActiveVersionDefinition{NewActiveVersion: newVersion}
 	op, err := s.operationManager.CreateOperation(ctx, schedulerName, opDef)
 	if err != nil {

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -212,15 +212,6 @@ func (s *SchedulerManager) EnqueueNewSchedulerVersionOperation(ctx context.Conte
 }
 
 func (s *SchedulerManager) EnqueueSwitchActiveVersionOperation(ctx context.Context, schedulerName, newVersion string) (*operation.Operation, error) {
-	//_, err := s.GetSchedulerByVersion(ctx, schedulerName, newVersion)
-	//if err != nil {
-	//	if errors.Is(err, portsErrors.ErrNotFound) {
-	//		s.logger.Sugar().Warnf("scheduler \"%s\" version \"%s\" not found", schedulerName, newVersion)
-	//		return nil, portsErrors.NewErrNotFound("scheduler \"%s\" version \"%s\" not found", schedulerName, newVersion)
-	//	}
-	//	s.logger.Sugar().Error("scheduler \"%s\" version \"%s\" could not be fetched", schedulerName, newVersion, zap.Error(err))
-	//	return nil, err
-	//}
 	opDef := &switch_active_version.SwitchActiveVersionDefinition{NewActiveVersion: newVersion}
 	op, err := s.operationManager.CreateOperation(ctx, schedulerName, opDef)
 	if err != nil {

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -365,10 +365,6 @@ func TestEnqueueSwitchActiveVersionOperation(t *testing.T) {
 		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
 		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
-		//schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
-		//	Name:    scheduler.Name,
-		//	Version: scheduler.Spec.Version,
-		//}).Return(scheduler, nil)
 		operationManager.EXPECT().CreateOperation(ctx, scheduler.Name, gomock.Any()).Return(&operation.Operation{}, nil)
 
 		op, err := schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, scheduler.Name, scheduler.Spec.Version)
@@ -392,11 +388,6 @@ func TestEnqueueSwitchActiveVersionOperation(t *testing.T) {
 		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
 		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
-		//schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
-		//	Name:    scheduler.Name,
-		//	Version: scheduler.Spec.Version,
-		//}).Return(scheduler, nil)
-
 		operationManager.EXPECT().CreateOperation(ctx, scheduler.Name, gomock.Any()).Return(nil, errors.NewErrUnexpected("storage offline"))
 
 		op, err := schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, scheduler.Name, scheduler.Spec.Version)
@@ -404,56 +395,6 @@ func TestEnqueueSwitchActiveVersionOperation(t *testing.T) {
 		require.ErrorIs(t, err, errors.ErrUnexpected)
 		require.Contains(t, err.Error(), "failed to schedule switch_active_version operation:")
 	})
-
-	//t.Run("return error when error not found fetching scheduler version to switch", func(t *testing.T) {
-	//	currentScheduler := newValidScheduler()
-	//	currentScheduler.PortRange = &entities.PortRange{Start: 1, End: 2}
-	//
-	//	scheduler := newValidScheduler()
-	//	scheduler.PortRange = &entities.PortRange{Start: 0, End: 1}
-	//
-	//	ctx := context.Background()
-	//	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-	//	operationManager := mock.NewMockOperationManager(mockCtrl)
-	//	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-	//	schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
-	//	schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
-	//
-	//	schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
-	//		Name:    scheduler.Name,
-	//		Version: scheduler.Spec.Version,
-	//	}).Return(scheduler, errors.NewErrNotFound("error"))
-	//
-	//	op, err := schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, scheduler.Name, scheduler.Spec.Version)
-	//	require.Nil(t, op)
-	//	require.ErrorIs(t, err, errors.ErrNotFound)
-	//	require.Contains(t, err.Error(), "not found")
-	//})
-
-	//t.Run("return error when error unexpected fetching scheduler version to switch", func(t *testing.T) {
-	//	currentScheduler := newValidScheduler()
-	//	currentScheduler.PortRange = &entities.PortRange{Start: 1, End: 2}
-	//
-	//	scheduler := newValidScheduler()
-	//	scheduler.PortRange = &entities.PortRange{Start: 0, End: 1}
-	//
-	//	ctx := context.Background()
-	//	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-	//	operationManager := mock.NewMockOperationManager(mockCtrl)
-	//	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-	//	schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
-	//	schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
-	//
-	//	schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
-	//		Name:    scheduler.Name,
-	//		Version: scheduler.Spec.Version,
-	//	}).Return(scheduler, errors.NewErrUnexpected("error"))
-	//
-	//	op, err := schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, scheduler.Name, scheduler.Spec.Version)
-	//	require.Nil(t, op)
-	//	require.ErrorIs(t, err, errors.ErrUnexpected)
-	//	require.Contains(t, err.Error(), "error")
-	//})
 }
 
 func TestGetSchedulerVersions(t *testing.T) {

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -365,10 +365,10 @@ func TestEnqueueSwitchActiveVersionOperation(t *testing.T) {
 		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
 		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
-		schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
-			Name:    scheduler.Name,
-			Version: scheduler.Spec.Version,
-		}).Return(scheduler, nil)
+		//schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
+		//	Name:    scheduler.Name,
+		//	Version: scheduler.Spec.Version,
+		//}).Return(scheduler, nil)
 		operationManager.EXPECT().CreateOperation(ctx, scheduler.Name, gomock.Any()).Return(&operation.Operation{}, nil)
 
 		op, err := schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, scheduler.Name, scheduler.Spec.Version)
@@ -392,10 +392,10 @@ func TestEnqueueSwitchActiveVersionOperation(t *testing.T) {
 		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
 		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 
-		schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
-			Name:    scheduler.Name,
-			Version: scheduler.Spec.Version,
-		}).Return(scheduler, nil)
+		//schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
+		//	Name:    scheduler.Name,
+		//	Version: scheduler.Spec.Version,
+		//}).Return(scheduler, nil)
 
 		operationManager.EXPECT().CreateOperation(ctx, scheduler.Name, gomock.Any()).Return(nil, errors.NewErrUnexpected("storage offline"))
 
@@ -405,55 +405,55 @@ func TestEnqueueSwitchActiveVersionOperation(t *testing.T) {
 		require.Contains(t, err.Error(), "failed to schedule switch_active_version operation:")
 	})
 
-	t.Run("return error when error not found fetching scheduler version to switch", func(t *testing.T) {
-		currentScheduler := newValidScheduler()
-		currentScheduler.PortRange = &entities.PortRange{Start: 1, End: 2}
+	//t.Run("return error when error not found fetching scheduler version to switch", func(t *testing.T) {
+	//	currentScheduler := newValidScheduler()
+	//	currentScheduler.PortRange = &entities.PortRange{Start: 1, End: 2}
+	//
+	//	scheduler := newValidScheduler()
+	//	scheduler.PortRange = &entities.PortRange{Start: 0, End: 1}
+	//
+	//	ctx := context.Background()
+	//	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+	//	operationManager := mock.NewMockOperationManager(mockCtrl)
+	//	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+	//	schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+	//	schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
+	//
+	//	schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
+	//		Name:    scheduler.Name,
+	//		Version: scheduler.Spec.Version,
+	//	}).Return(scheduler, errors.NewErrNotFound("error"))
+	//
+	//	op, err := schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, scheduler.Name, scheduler.Spec.Version)
+	//	require.Nil(t, op)
+	//	require.ErrorIs(t, err, errors.ErrNotFound)
+	//	require.Contains(t, err.Error(), "not found")
+	//})
 
-		scheduler := newValidScheduler()
-		scheduler.PortRange = &entities.PortRange{Start: 0, End: 1}
-
-		ctx := context.Background()
-		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		operationManager := mock.NewMockOperationManager(mockCtrl)
-		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
-
-		schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
-			Name:    scheduler.Name,
-			Version: scheduler.Spec.Version,
-		}).Return(scheduler, errors.NewErrNotFound("error"))
-
-		op, err := schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, scheduler.Name, scheduler.Spec.Version)
-		require.Nil(t, op)
-		require.ErrorIs(t, err, errors.ErrNotFound)
-		require.Contains(t, err.Error(), "not found")
-	})
-
-	t.Run("return error when error unexpected fetching scheduler version to switch", func(t *testing.T) {
-		currentScheduler := newValidScheduler()
-		currentScheduler.PortRange = &entities.PortRange{Start: 1, End: 2}
-
-		scheduler := newValidScheduler()
-		scheduler.PortRange = &entities.PortRange{Start: 0, End: 1}
-
-		ctx := context.Background()
-		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
-		operationManager := mock.NewMockOperationManager(mockCtrl)
-		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
-		schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
-
-		schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
-			Name:    scheduler.Name,
-			Version: scheduler.Spec.Version,
-		}).Return(scheduler, errors.NewErrUnexpected("error"))
-
-		op, err := schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, scheduler.Name, scheduler.Spec.Version)
-		require.Nil(t, op)
-		require.ErrorIs(t, err, errors.ErrUnexpected)
-		require.Contains(t, err.Error(), "error")
-	})
+	//t.Run("return error when error unexpected fetching scheduler version to switch", func(t *testing.T) {
+	//	currentScheduler := newValidScheduler()
+	//	currentScheduler.PortRange = &entities.PortRange{Start: 1, End: 2}
+	//
+	//	scheduler := newValidScheduler()
+	//	scheduler.PortRange = &entities.PortRange{Start: 0, End: 1}
+	//
+	//	ctx := context.Background()
+	//	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+	//	operationManager := mock.NewMockOperationManager(mockCtrl)
+	//	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+	//	schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+	//	schedulerManager := NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
+	//
+	//	schedulerStorage.EXPECT().GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
+	//		Name:    scheduler.Name,
+	//		Version: scheduler.Spec.Version,
+	//	}).Return(scheduler, errors.NewErrUnexpected("error"))
+	//
+	//	op, err := schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, scheduler.Name, scheduler.Spec.Version)
+	//	require.Nil(t, op)
+	//	require.ErrorIs(t, err, errors.ErrUnexpected)
+	//	require.Contains(t, err.Error(), "error")
+	//})
 }
 
 func TestGetSchedulerVersions(t *testing.T) {


### PR DESCRIPTION
### What?
Remove validation for already existing scheduler version before enqueue `switch active version operation.

### Why?
After refactoring the input for switch active version operation, we inserted a new bug that we cannot create a new scheduler version since the method called to enqueue the switch active version operation tries to enqueue it inside a transaction where we create a new scheduler version. Since the transaction is not finished yet when we call the method, there's a validation that we can only enqueue the switch active version operation for already existent schedulers, and this validation fails.