### PR TITLE
Improvement/add game label to metrics

### DIFF
--- a/internal/core/monitoring/constants.go
+++ b/internal/core/monitoring/constants.go
@@ -36,6 +36,7 @@ const (
 	LabelSuccess   = "success"
 	LabelReason    = "reason"
 	LabelScheduler = "scheduler"
+	LabelGame      = "game"
 	LabelOperation = "operation"
 	LabelStorage   = "storage"
 )

--- a/internal/core/services/events_forwarder/metrics.go
+++ b/internal/core/services/events_forwarder/metrics.go
@@ -33,6 +33,7 @@ var (
 		Name:      "success_room_event_forwarding",
 		Help:      "Current number of room events forwarding with success",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -45,6 +46,7 @@ var (
 		Name:      "success_player_event_forwarding",
 		Help:      "Current number of player events forwarding with success",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -57,6 +59,7 @@ var (
 		Name:      "failed_room_event_forwarding",
 		Help:      "Current number of failed room events forwarding",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -69,23 +72,24 @@ var (
 		Name:      "failed_player_event_forwarding",
 		Help:      "Current number of failed player events forwarding",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
 )
 
 func reportRoomEventForwardingSuccess(game, schedulerName string) {
-	successRoomEventForwardingMetric.WithLabelValues(schedulerName).Inc()
+	successRoomEventForwardingMetric.WithLabelValues(game, schedulerName).Inc()
 }
 
 func reportPlayerEventForwardingSuccess(game, schedulerName string) {
-	successPlayerEventForwardingMetric.WithLabelValues(schedulerName).Inc()
+	successPlayerEventForwardingMetric.WithLabelValues(game, schedulerName).Inc()
 }
 
 func reportRoomEventForwardingFailed(game, schedulerName string) {
-	failedRoomEventForwardingMetric.WithLabelValues(schedulerName).Inc()
+	failedRoomEventForwardingMetric.WithLabelValues(game, schedulerName).Inc()
 }
 
 func reportPlayerEventForwardingFailed(game, schedulerName string) {
-	failedPlayerEventForwardingMetric.WithLabelValues(schedulerName).Inc()
+	failedPlayerEventForwardingMetric.WithLabelValues(game, schedulerName).Inc()
 }

--- a/internal/core/services/events_forwarder/metrics.go
+++ b/internal/core/services/events_forwarder/metrics.go
@@ -74,18 +74,18 @@ var (
 	})
 )
 
-func reportRoomEventForwardingSuccess(schedulerName string) {
+func reportRoomEventForwardingSuccess(game, schedulerName string) {
 	successRoomEventForwardingMetric.WithLabelValues(schedulerName).Inc()
 }
 
-func reportPlayerEventForwardingSuccess(schedulerName string) {
+func reportPlayerEventForwardingSuccess(game, schedulerName string) {
 	successPlayerEventForwardingMetric.WithLabelValues(schedulerName).Inc()
 }
 
-func reportRoomEventForwardingFailed(schedulerName string) {
+func reportRoomEventForwardingFailed(game, schedulerName string) {
 	failedRoomEventForwardingMetric.WithLabelValues(schedulerName).Inc()
 }
 
-func reportPlayerEventForwardingFailed(schedulerName string) {
+func reportPlayerEventForwardingFailed(game, schedulerName string) {
 	failedPlayerEventForwardingMetric.WithLabelValues(schedulerName).Inc()
 }

--- a/internal/core/workers/metricsreporter/metrics.go
+++ b/internal/core/workers/metricsreporter/metrics.go
@@ -33,6 +33,7 @@ var (
 		Name:      "gru_ready",
 		Help:      "The number of game rooms with status ready",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -43,6 +44,7 @@ var (
 		Name:      "gru_pending",
 		Help:      "The number of game rooms with status pending",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -53,6 +55,7 @@ var (
 		Name:      "gru_unready",
 		Help:      "The number of game rooms with status unready",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -63,6 +66,7 @@ var (
 		Name:      "gru_terminating",
 		Help:      "The number of game rooms with status terminating",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -72,6 +76,7 @@ var (
 		Name:      "gru_error",
 		Help:      "The number of game rooms with status error",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -81,6 +86,7 @@ var (
 		Name:      "gru_occupied",
 		Help:      "The number of game rooms with status occupied",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -91,6 +97,7 @@ var (
 		Name:      "instance_ready",
 		Help:      "The number of instances with status ready",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -101,6 +108,7 @@ var (
 		Name:      "instance_pending",
 		Help:      "The number of instances with status pending",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -111,6 +119,7 @@ var (
 		Name:      "instance_unknown",
 		Help:      "The number of instances with status unknown",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -121,6 +130,7 @@ var (
 		Name:      "instance_terminating",
 		Help:      "The number of instances with status terminating",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
@@ -130,45 +140,46 @@ var (
 		Name:      "instance_error",
 		Help:      "The number of instances with status error",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 		},
 	})
 )
 
-func reportGameRoomReadyNumber(schedulerName string, numberOfGameRooms int) {
-	gameRoomReadyGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfGameRooms))
+func reportGameRoomReadyNumber(game, schedulerName string, numberOfGameRooms int) {
+	gameRoomReadyGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfGameRooms))
 }
-func reportGameRoomPendingNumber(schedulerName string, numberOfGameRooms int) {
-	gameRoomPendingGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfGameRooms))
+func reportGameRoomPendingNumber(game, schedulerName string, numberOfGameRooms int) {
+	gameRoomPendingGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfGameRooms))
 }
-func reportGameRoomUnreadyNumber(schedulerName string, numberOfGameRooms int) {
-	gameRoomUnreadyGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfGameRooms))
+func reportGameRoomUnreadyNumber(game, schedulerName string, numberOfGameRooms int) {
+	gameRoomUnreadyGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfGameRooms))
 }
-func reportGameRoomTerminatingNumber(schedulerName string, numberOfGameRooms int) {
-	gameRoomTerminatingGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfGameRooms))
+func reportGameRoomTerminatingNumber(game, schedulerName string, numberOfGameRooms int) {
+	gameRoomTerminatingGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfGameRooms))
 }
-func reportGameRoomErrorNumber(schedulerName string, numberOfGameRooms int) {
-	gameRoomErrorGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfGameRooms))
+func reportGameRoomErrorNumber(game, schedulerName string, numberOfGameRooms int) {
+	gameRoomErrorGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfGameRooms))
 }
-func reportGameRoomOccupiedNumber(schedulerName string, numberOfGameRooms int) {
-	gameRoomOccupiedGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfGameRooms))
-}
-
-func reportInstanceReadyNumber(schedulerName string, numberOfInstances int) {
-	instanceReadyGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfInstances))
+func reportGameRoomOccupiedNumber(game, schedulerName string, numberOfGameRooms int) {
+	gameRoomOccupiedGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfGameRooms))
 }
 
-func reportInstancePendingNumber(schedulerName string, numberOfInstances int) {
-	instancePendingGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfInstances))
+func reportInstanceReadyNumber(game, schedulerName string, numberOfInstances int) {
+	instanceReadyGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfInstances))
 }
 
-func reportInstanceUnknownNumber(schedulerName string, numberOfInstances int) {
-	instanceUnknownGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfInstances))
+func reportInstancePendingNumber(game, schedulerName string, numberOfInstances int) {
+	instancePendingGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfInstances))
 }
 
-func reportInstanceTerminatingNumber(schedulerName string, numberOfInstances int) {
-	instanceTerminatingGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfInstances))
+func reportInstanceUnknownNumber(game, schedulerName string, numberOfInstances int) {
+	instanceUnknownGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfInstances))
 }
-func reportInstanceErrorNumber(schedulerName string, numberOfInstances int) {
-	instanceErrorGaugeMetric.WithLabelValues(schedulerName).Set(float64(numberOfInstances))
+
+func reportInstanceTerminatingNumber(game, schedulerName string, numberOfInstances int) {
+	instanceTerminatingGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfInstances))
+}
+func reportInstanceErrorNumber(game, schedulerName string, numberOfInstances int) {
+	instanceErrorGaugeMetric.WithLabelValues(game, schedulerName).Set(float64(numberOfInstances))
 }

--- a/internal/core/workers/metricsreporter/metrics_reporter_worker.go
+++ b/internal/core/workers/metricsreporter/metrics_reporter_worker.go
@@ -43,6 +43,7 @@ var _ workers.Worker = (*MetricsReporterWorker)(nil)
 // MetricsReporterWorker is the service responsible producing periodic metrics.
 type MetricsReporterWorker struct {
 	schedulerName       string
+	game                string
 	config              *config.MetricsReporterConfig
 	roomStorage         ports.RoomStorage
 	instanceStorage     ports.GameRoomInstanceStorage
@@ -54,6 +55,7 @@ type MetricsReporterWorker struct {
 func NewMetricsReporterWorker(scheduler *entities.Scheduler, opts *workers.WorkerOptions) workers.Worker {
 	return &MetricsReporterWorker{
 		schedulerName:   scheduler.Name,
+		game:            scheduler.Game,
 		config:          opts.MetricsReporterConfig,
 		roomStorage:     opts.RoomStorage,
 		instanceStorage: opts.InstanceStorage,
@@ -115,11 +117,11 @@ func (w *MetricsReporterWorker) reportInstanceMetrics() {
 			terminatingInstances++
 		}
 	}
-	reportInstanceReadyNumber(w.schedulerName, readyInstances)
-	reportInstancePendingNumber(w.schedulerName, pendingInstances)
-	reportInstanceErrorNumber(w.schedulerName, errorInstances)
-	reportInstanceUnknownNumber(w.schedulerName, unknownInstances)
-	reportInstanceTerminatingNumber(w.schedulerName, terminatingInstances)
+	reportInstanceReadyNumber(w.game, w.schedulerName, readyInstances)
+	reportInstancePendingNumber(w.game, w.schedulerName, pendingInstances)
+	reportInstanceErrorNumber(w.game, w.schedulerName, errorInstances)
+	reportInstanceUnknownNumber(w.game, w.schedulerName, unknownInstances)
+	reportInstanceTerminatingNumber(w.game, w.schedulerName, terminatingInstances)
 
 }
 
@@ -139,7 +141,7 @@ func (w *MetricsReporterWorker) reportPendingRooms() {
 		w.logger.Error("Error getting pending pods", zap.Error(err))
 		return
 	}
-	reportGameRoomPendingNumber(w.schedulerName, pendingRooms)
+	reportGameRoomPendingNumber(w.game, w.schedulerName, pendingRooms)
 }
 
 func (w *MetricsReporterWorker) reportReadyRooms() {
@@ -148,7 +150,7 @@ func (w *MetricsReporterWorker) reportReadyRooms() {
 		w.logger.Error("Error getting ready pods", zap.Error(err))
 		return
 	}
-	reportGameRoomReadyNumber(w.schedulerName, readyRooms)
+	reportGameRoomReadyNumber(w.game, w.schedulerName, readyRooms)
 }
 
 func (w *MetricsReporterWorker) reportOccupiedRooms() {
@@ -157,7 +159,7 @@ func (w *MetricsReporterWorker) reportOccupiedRooms() {
 		w.logger.Error("Error getting occupied pods", zap.Error(err))
 		return
 	}
-	reportGameRoomOccupiedNumber(w.schedulerName, occupiedRooms)
+	reportGameRoomOccupiedNumber(w.game, w.schedulerName, occupiedRooms)
 }
 
 func (w *MetricsReporterWorker) reportTerminatingRooms() {
@@ -166,7 +168,7 @@ func (w *MetricsReporterWorker) reportTerminatingRooms() {
 		w.logger.Error("Error getting terminating pods", zap.Error(err))
 		return
 	}
-	reportGameRoomTerminatingNumber(w.schedulerName, terminatingRooms)
+	reportGameRoomTerminatingNumber(w.game, w.schedulerName, terminatingRooms)
 }
 
 func (w *MetricsReporterWorker) reportErrorRooms() {
@@ -175,7 +177,7 @@ func (w *MetricsReporterWorker) reportErrorRooms() {
 		w.logger.Error("Error getting error pods", zap.Error(err))
 		return
 	}
-	reportGameRoomErrorNumber(w.schedulerName, errorRooms)
+	reportGameRoomErrorNumber(w.game, w.schedulerName, errorRooms)
 }
 
 func (w *MetricsReporterWorker) reportUnreadyRooms() {
@@ -184,5 +186,5 @@ func (w *MetricsReporterWorker) reportUnreadyRooms() {
 		w.logger.Error("Error getting unready pods", zap.Error(err))
 		return
 	}
-	reportGameRoomUnreadyNumber(w.schedulerName, unreadyRooms)
+	reportGameRoomUnreadyNumber(w.game, w.schedulerName, unreadyRooms)
 }

--- a/internal/core/workers/metricsreporter/metrics_reporter_worker.go
+++ b/internal/core/workers/metricsreporter/metrics_reporter_worker.go
@@ -42,8 +42,7 @@ var _ workers.Worker = (*MetricsReporterWorker)(nil)
 
 // MetricsReporterWorker is the service responsible producing periodic metrics.
 type MetricsReporterWorker struct {
-	schedulerName       string
-	game                string
+	scheduler           *entities.Scheduler
 	config              *config.MetricsReporterConfig
 	roomStorage         ports.RoomStorage
 	instanceStorage     ports.GameRoomInstanceStorage
@@ -54,8 +53,7 @@ type MetricsReporterWorker struct {
 
 func NewMetricsReporterWorker(scheduler *entities.Scheduler, opts *workers.WorkerOptions) workers.Worker {
 	return &MetricsReporterWorker{
-		schedulerName:   scheduler.Name,
-		game:            scheduler.Game,
+		scheduler:       scheduler,
 		config:          opts.MetricsReporterConfig,
 		roomStorage:     opts.RoomStorage,
 		instanceStorage: opts.InstanceStorage,
@@ -97,7 +95,7 @@ func (w *MetricsReporterWorker) IsRunning() bool {
 func (w *MetricsReporterWorker) reportInstanceMetrics() {
 	w.logger.Info("Reporting instance metrics")
 
-	instances, err := w.instanceStorage.GetAllInstances(w.workerContext, w.schedulerName)
+	instances, err := w.instanceStorage.GetAllInstances(w.workerContext, w.scheduler.Name)
 	if err != nil {
 		w.logger.Error("Error getting pods", zap.Error(err))
 		return
@@ -117,11 +115,11 @@ func (w *MetricsReporterWorker) reportInstanceMetrics() {
 			terminatingInstances++
 		}
 	}
-	reportInstanceReadyNumber(w.game, w.schedulerName, readyInstances)
-	reportInstancePendingNumber(w.game, w.schedulerName, pendingInstances)
-	reportInstanceErrorNumber(w.game, w.schedulerName, errorInstances)
-	reportInstanceUnknownNumber(w.game, w.schedulerName, unknownInstances)
-	reportInstanceTerminatingNumber(w.game, w.schedulerName, terminatingInstances)
+	reportInstanceReadyNumber(w.scheduler.Game, w.scheduler.Name, readyInstances)
+	reportInstancePendingNumber(w.scheduler.Game, w.scheduler.Name, pendingInstances)
+	reportInstanceErrorNumber(w.scheduler.Game, w.scheduler.Name, errorInstances)
+	reportInstanceUnknownNumber(w.scheduler.Game, w.scheduler.Name, unknownInstances)
+	reportInstanceTerminatingNumber(w.scheduler.Game, w.scheduler.Name, terminatingInstances)
 
 }
 
@@ -136,55 +134,55 @@ func (w *MetricsReporterWorker) reportGameRoomMetrics() {
 }
 
 func (w *MetricsReporterWorker) reportPendingRooms() {
-	pendingRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.schedulerName, game_room.GameStatusPending)
+	pendingRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.scheduler.Name, game_room.GameStatusPending)
 	if err != nil {
 		w.logger.Error("Error getting pending pods", zap.Error(err))
 		return
 	}
-	reportGameRoomPendingNumber(w.game, w.schedulerName, pendingRooms)
+	reportGameRoomPendingNumber(w.scheduler.Game, w.scheduler.Name, pendingRooms)
 }
 
 func (w *MetricsReporterWorker) reportReadyRooms() {
-	readyRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.schedulerName, game_room.GameStatusReady)
+	readyRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.scheduler.Name, game_room.GameStatusReady)
 	if err != nil {
 		w.logger.Error("Error getting ready pods", zap.Error(err))
 		return
 	}
-	reportGameRoomReadyNumber(w.game, w.schedulerName, readyRooms)
+	reportGameRoomReadyNumber(w.scheduler.Game, w.scheduler.Name, readyRooms)
 }
 
 func (w *MetricsReporterWorker) reportOccupiedRooms() {
-	occupiedRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.schedulerName, game_room.GameStatusOccupied)
+	occupiedRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.scheduler.Name, game_room.GameStatusOccupied)
 	if err != nil {
 		w.logger.Error("Error getting occupied pods", zap.Error(err))
 		return
 	}
-	reportGameRoomOccupiedNumber(w.game, w.schedulerName, occupiedRooms)
+	reportGameRoomOccupiedNumber(w.scheduler.Game, w.scheduler.Name, occupiedRooms)
 }
 
 func (w *MetricsReporterWorker) reportTerminatingRooms() {
-	terminatingRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.schedulerName, game_room.GameStatusTerminating)
+	terminatingRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.scheduler.Name, game_room.GameStatusTerminating)
 	if err != nil {
 		w.logger.Error("Error getting terminating pods", zap.Error(err))
 		return
 	}
-	reportGameRoomTerminatingNumber(w.game, w.schedulerName, terminatingRooms)
+	reportGameRoomTerminatingNumber(w.scheduler.Game, w.scheduler.Name, terminatingRooms)
 }
 
 func (w *MetricsReporterWorker) reportErrorRooms() {
-	errorRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.schedulerName, game_room.GameStatusError)
+	errorRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.scheduler.Name, game_room.GameStatusError)
 	if err != nil {
 		w.logger.Error("Error getting error pods", zap.Error(err))
 		return
 	}
-	reportGameRoomErrorNumber(w.game, w.schedulerName, errorRooms)
+	reportGameRoomErrorNumber(w.scheduler.Game, w.scheduler.Name, errorRooms)
 }
 
 func (w *MetricsReporterWorker) reportUnreadyRooms() {
-	unreadyRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.schedulerName, game_room.GameStatusUnready)
+	unreadyRooms, err := w.roomStorage.GetRoomCountByStatus(w.workerContext, w.scheduler.Name, game_room.GameStatusUnready)
 	if err != nil {
 		w.logger.Error("Error getting unready pods", zap.Error(err))
 		return
 	}
-	reportGameRoomUnreadyNumber(w.game, w.schedulerName, unreadyRooms)
+	reportGameRoomUnreadyNumber(w.scheduler.Game, w.scheduler.Name, unreadyRooms)
 }

--- a/internal/core/workers/operation_execution_worker/metrics.go
+++ b/internal/core/workers/operation_execution_worker/metrics.go
@@ -43,6 +43,7 @@ var (
 		Name:      "operation_execution",
 		Help:      "An scheduler operation was executed",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 			monitoring.LabelOperation,
 			monitoring.LabelSuccess,
@@ -55,6 +56,7 @@ var (
 		Name:      "operation_on_error",
 		Help:      "An scheduler operation on error fallback was executed",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 			monitoring.LabelOperation,
 			monitoring.LabelSuccess,
@@ -67,6 +69,7 @@ var (
 		Name:      "operation_evicted",
 		Help:      "An scheduler operation was evicted",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 			monitoring.LabelOperation,
 			monitoring.LabelReason,
@@ -79,30 +82,31 @@ var (
 		Name:      "operation_execution_worker_failed",
 		Help:      "An scheduler operation execution worker failed and is no longer running",
 		Labels: []string{
+			monitoring.LabelGame,
 			monitoring.LabelScheduler,
 			monitoring.LabelReason,
 		},
 	})
 )
 
-func reportOperationExecutionLatency(start time.Time, schedulerName, operationName string, success bool) {
+func reportOperationExecutionLatency(start time.Time, game, schedulerName, operationName string, success bool) {
 	successLabelValue := fmt.Sprint(success)
 	monitoring.ReportLatencyMetricInMillis(
-		operationExecutionLatencyMetric, start, schedulerName, operationName, successLabelValue,
+		operationExecutionLatencyMetric, start, game, schedulerName, operationName, successLabelValue,
 	)
 }
 
-func reportOperationOnErrorLatency(start time.Time, schedulerName, operationName string, success bool) {
+func reportOperationOnErrorLatency(start time.Time, game, schedulerName, operationName string, success bool) {
 	successLabelValue := fmt.Sprint(success)
 	monitoring.ReportLatencyMetricInMillis(
-		operationOnErrorLatencyMetric, start, schedulerName, operationName, successLabelValue,
+		operationOnErrorLatencyMetric, start, game, schedulerName, operationName, successLabelValue,
 	)
 }
 
-func reportOperationEvicted(schedulerName, operationName, reason string) {
-	operationEvictedCountMetric.WithLabelValues(schedulerName, operationName, reason).Inc()
+func reportOperationEvicted(game, schedulerName, operationName, reason string) {
+	operationEvictedCountMetric.WithLabelValues(game, schedulerName, operationName, reason).Inc()
 }
 
-func reportOperationExecutionWorkerFailed(schedulerName, reason string) {
-	operationExecutionWorkerFailedCountMetric.WithLabelValues(schedulerName, reason).Inc()
+func reportOperationExecutionWorkerFailed(game, schedulerName, reason string) {
+	operationExecutionWorkerFailedCountMetric.WithLabelValues(game, schedulerName, reason).Inc()
 }

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -45,6 +45,7 @@ var _ workers.Worker = (*OperationExecutionWorker)(nil)
 // responsibilities.
 type OperationExecutionWorker struct {
 	schedulerName    string
+	game             string
 	operationManager ports.OperationManager
 	// TODO(gabrielcorado): check if we this is the right place to have all
 	// executors.
@@ -59,6 +60,7 @@ func NewOperationExecutionWorker(scheduler *entities.Scheduler, opts *workers.Wo
 	return &OperationExecutionWorker{
 		operationManager: opts.OperationManager,
 		executorsByName:  opts.OperationExecutors,
+		game:             scheduler.Game,
 		schedulerName:    scheduler.Name,
 		logger:           zap.L().With(zap.String(logs.LogFieldServiceName, "worker"), zap.String(logs.LogFieldSchedulerName, scheduler.Name)),
 	}
@@ -78,7 +80,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 			}
 
 			w.Stop(ctx)
-			reportOperationExecutionWorkerFailed(w.schedulerName, LabelNextOperationFailed)
+			reportOperationExecutionWorkerFailed(w.game, w.schedulerName, LabelNextOperationFailed)
 			return fmt.Errorf("failed to get next operation: %w", err)
 		}
 
@@ -98,14 +100,14 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 			loopLogger.Warn("operation definition has no executor")
 
 			w.evictOperation(ctx, loopLogger, op)
-			reportOperationEvicted(w.schedulerName, op.DefinitionName, LabelNoOperationExecutorFound)
+			reportOperationEvicted(w.game, w.schedulerName, op.DefinitionName, LabelNoOperationExecutorFound)
 
 			continue
 		}
 
 		if !def.ShouldExecute(ctx, []*operation.Operation{}) {
 			w.evictOperation(ctx, loopLogger, op)
-			reportOperationEvicted(w.schedulerName, op.DefinitionName, LabelShouldNotExecute)
+			reportOperationEvicted(w.game, w.schedulerName, op.DefinitionName, LabelShouldNotExecute)
 			continue
 		}
 
@@ -117,7 +119,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 		err = w.operationManager.GrantLease(operationContext, op)
 		if err != nil {
 			w.Stop(ctx)
-			reportOperationExecutionWorkerFailed(w.schedulerName, LabelStartOperationFailed)
+			reportOperationExecutionWorkerFailed(w.game, w.schedulerName, LabelStartOperationFailed)
 			operationCancellationFunction()
 
 			op.Status = operation.StatusError
@@ -142,7 +144,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 				loopLogger.Error("failed to start operation", zap.Error(err))
 			}
 
-			reportOperationExecutionWorkerFailed(w.schedulerName, LabelStartOperationFailed)
+			reportOperationExecutionWorkerFailed(w.game, w.schedulerName, LabelStartOperationFailed)
 
 			w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Failed to start operation")
 
@@ -150,7 +152,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 		}
 		w.operationManager.StartLeaseRenewGoRoutine(operationContext, op)
 
-		executionErr := executeCollectingLatencyMetrics(w.schedulerName, op.DefinitionName, func() error {
+		executionErr := w.executeCollectingLatencyMetrics(op.DefinitionName, func() error {
 			return executor.Execute(operationContext, op, def)
 		})
 
@@ -165,7 +167,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 
 			loopLogger.Error("operation execution failed", zap.Error(executionErr))
 
-			onErrorErr := executeOnErrorCollectingLatencyMetrics(w.schedulerName, op.DefinitionName, func() error {
+			onErrorErr := w.executeOnErrorCollectingLatencyMetrics(op.DefinitionName, func() error {
 				return executor.OnError(operationContext, op, def, executionErr)
 			})
 
@@ -212,16 +214,16 @@ func (w *OperationExecutionWorker) evictOperation(ctx context.Context, logger *z
 	w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Operation evicted")
 }
 
-func executeCollectingLatencyMetrics(schedulerName, definitionName string, f func() error) (err error) {
+func (w *OperationExecutionWorker) executeCollectingLatencyMetrics(definitionName string, f func() error) (err error) {
 	executeStartTime := time.Now()
 	err = f()
-	reportOperationExecutionLatency(executeStartTime, schedulerName, definitionName, err == nil)
+	reportOperationExecutionLatency(executeStartTime, w.game, w.schedulerName, definitionName, err == nil)
 	return err
 }
 
-func executeOnErrorCollectingLatencyMetrics(schedulerName, definitionName string, f func() error) (err error) {
+func (w *OperationExecutionWorker) executeOnErrorCollectingLatencyMetrics(definitionName string, f func() error) (err error) {
 	onErrorStartTime := time.Now()
 	err = f()
-	reportOperationOnErrorLatency(onErrorStartTime, schedulerName, definitionName, err == nil)
+	reportOperationOnErrorLatency(onErrorStartTime, w.game, w.schedulerName, definitionName, err == nil)
 	return err
 }


### PR DESCRIPTION
## What ❓ 
Add `game` label to operations, event forwarding, rooms, and instances metrics 

## Why 🤔 
The `game` information is a good value to have as a label so we can index those metrics by the game once each maestro deployment can have an arbitrary number of games/schedulers

