### PR TITLE
Clear all named and anonymous volumes from e2e tests

### DIFF
--- a/e2e/framework/maestro/components/management_api.go
+++ b/e2e/framework/maestro/components/management_api.go
@@ -43,7 +43,7 @@ func ProvideManagementApi(maestroPath string) (*ManagementApiServer, error) {
 	client := &http.Client{}
 
 	composeFilePaths := []string{fmt.Sprintf("%s/e2e/framework/maestro/docker-compose.yml", maestroPath)}
-	identifier := strings.ToLower("test-something")
+	identifier := strings.ToLower("e2e-test")
 
 	compose := tc.NewLocalDockerCompose(composeFilePaths, identifier)
 	composeErr := compose.WithCommand([]string{"up", "-d", "--build", "management-api"}).Invoke()
@@ -76,5 +76,5 @@ func ProvideManagementApi(maestroPath string) (*ManagementApiServer, error) {
 }
 
 func (ms *ManagementApiServer) Teardown() {
-	ms.compose.Down()
+	ms.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
 }

--- a/e2e/framework/maestro/components/management_api.go
+++ b/e2e/framework/maestro/components/management_api.go
@@ -76,5 +76,5 @@ func ProvideManagementApi(maestroPath string) (*ManagementApiServer, error) {
 }
 
 func (ms *ManagementApiServer) Teardown() {
-	ms.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
+	ms.compose.WithCommand([]string{"rm", "-s", "-v", "-f", "management-api"}).Invoke()
 }

--- a/e2e/framework/maestro/components/rooms_api.go
+++ b/e2e/framework/maestro/components/rooms_api.go
@@ -95,5 +95,5 @@ func ProvideRoomsApi(maestroPath string) (*RoomsApiServer, error) {
 }
 
 func (ms *RoomsApiServer) Teardown() {
-	ms.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
+	ms.compose.WithCommand([]string{"rm", "-s", "-v", "-f", "rooms-api"}).Invoke()
 }

--- a/e2e/framework/maestro/components/rooms_api.go
+++ b/e2e/framework/maestro/components/rooms_api.go
@@ -46,7 +46,7 @@ func ProvideRoomsApi(maestroPath string) (*RoomsApiServer, error) {
 	client := &http.Client{}
 
 	composeFilePaths := []string{fmt.Sprintf("%s/e2e/framework/maestro/docker-compose.yml", maestroPath)}
-	identifier := strings.ToLower("test-something")
+	identifier := strings.ToLower("e2e-test")
 
 	compose := tc.NewLocalDockerCompose(composeFilePaths, identifier)
 	composeErr := compose.WithCommand([]string{"up", "-d", "--build", "rooms-api"}).Invoke()
@@ -75,7 +75,7 @@ func ProvideRoomsApi(maestroPath string) (*RoomsApiServer, error) {
 	cmd, err := exec.ExecSysCmd(
 		maestroPath,
 		"docker",
-		"inspect", "-f", "'{{range.NetworkSettings.Networks}}{{.Gateway}}{{end}}'", "test-something_rooms-api_1",
+		"inspect", "-f", "'{{range.NetworkSettings.Networks}}{{.Gateway}}{{end}}'", "e2e-test_rooms-api_1",
 	)
 
 	if err != nil {
@@ -95,5 +95,5 @@ func ProvideRoomsApi(maestroPath string) (*RoomsApiServer, error) {
 }
 
 func (ms *RoomsApiServer) Teardown() {
-	ms.compose.Down()
+	ms.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
 }

--- a/e2e/framework/maestro/components/runtime_watcher.go
+++ b/e2e/framework/maestro/components/runtime_watcher.go
@@ -41,7 +41,7 @@ func ProvideRuntimeWatcher(maestroPath string) (*RuntimeWatcherServer, error) {
 	client := &http.Client{}
 
 	composeFilePaths := []string{fmt.Sprintf("%s/e2e/framework/maestro/docker-compose.yml", maestroPath)}
-	identifier := strings.ToLower("test-something")
+	identifier := strings.ToLower("e2e-test")
 
 	compose := tc.NewLocalDockerCompose(composeFilePaths, identifier)
 	composeErr := compose.WithCommand([]string{"up", "-d", "--build", "runtime-watcher"}).Invoke()
@@ -71,5 +71,5 @@ func ProvideRuntimeWatcher(maestroPath string) (*RuntimeWatcherServer, error) {
 }
 
 func (ws *RuntimeWatcherServer) Teardown() {
-	ws.compose.Down()
+	ws.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
 }

--- a/e2e/framework/maestro/components/runtime_watcher.go
+++ b/e2e/framework/maestro/components/runtime_watcher.go
@@ -71,5 +71,5 @@ func ProvideRuntimeWatcher(maestroPath string) (*RuntimeWatcherServer, error) {
 }
 
 func (ws *RuntimeWatcherServer) Teardown() {
-	ws.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
+	ws.compose.WithCommand([]string{"rm", "-s", "-v", "-f", "runtime-watcher"}).Invoke()
 }

--- a/e2e/framework/maestro/components/worker.go
+++ b/e2e/framework/maestro/components/worker.go
@@ -41,7 +41,7 @@ func ProvideWorker(maestroPath string) (*WorkerServer, error) {
 	client := &http.Client{}
 
 	composeFilePaths := []string{fmt.Sprintf("%s/e2e/framework/maestro/docker-compose.yml", maestroPath)}
-	identifier := strings.ToLower("test-something")
+	identifier := strings.ToLower("e2e-test")
 
 	compose := tc.NewLocalDockerCompose(composeFilePaths, identifier)
 	composeErr := compose.WithCommand([]string{"up", "-d", "--build", "worker"}).Invoke()
@@ -71,5 +71,5 @@ func ProvideWorker(maestroPath string) (*WorkerServer, error) {
 }
 
 func (ws *WorkerServer) Teardown() {
-	ws.compose.Down()
+	ws.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
 }

--- a/e2e/framework/maestro/components/worker.go
+++ b/e2e/framework/maestro/components/worker.go
@@ -71,5 +71,5 @@ func ProvideWorker(maestroPath string) (*WorkerServer, error) {
 }
 
 func (ws *WorkerServer) Teardown() {
-	ws.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
+	ws.compose.WithCommand([]string{"rm", "-s", "-v", "-f", "runtime-watcher"}).Invoke()
 }

--- a/e2e/framework/maestro/dependencies.go
+++ b/e2e/framework/maestro/dependencies.go
@@ -90,5 +90,10 @@ func provideDependencies(maestroPath string) (*dependencies, error) {
 }
 
 func (d *dependencies) Teardown() {
-	d.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
+	d.compose.WithCommand([]string{"rm", "-s", "-v", "-f", "postgres", "redis", "k3s_agent", "k3s_server"}).Invoke()
+	exec.ExecSysCmd(
+		maestroPath,
+		"docker",
+		"volume ", "rm", "e2e-test_eventsproto", "e2e-test_kubeconfig",
+	)
 }

--- a/e2e/framework/maestro/maestro.go
+++ b/e2e/framework/maestro/maestro.go
@@ -94,6 +94,7 @@ func (mi *MaestroInstance) Teardown() {
 	mi.WorkerServer.Teardown()
 	mi.RoomsApiServer.Teardown()
 	mi.RuntimeWatcherServer.Teardown()
+	mi.ServerMocks.Teardown()
 
 	// TODO(gabrielcorado): add a flag to not stop dependencies during
 	// development (this will make the e2e run way faster).

--- a/e2e/framework/maestro/servermocks/servermocks.go
+++ b/e2e/framework/maestro/servermocks/servermocks.go
@@ -52,5 +52,6 @@ func ProvideServerMocks(maestroPath string) (*ServerMocks, error) {
 }
 
 func (s *ServerMocks) Teardown() {
-	s.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
+	s.compose.WithCommand([]string{"rm", "-s", "-v", "-f", "grpc-mock"}).Invoke()
+
 }

--- a/e2e/framework/maestro/servermocks/servermocks.go
+++ b/e2e/framework/maestro/servermocks/servermocks.go
@@ -36,7 +36,7 @@ type ServerMocks struct {
 
 func ProvideServerMocks(maestroPath string) (*ServerMocks, error) {
 	composeFilePaths := []string{fmt.Sprintf("%s/e2e/framework/maestro/docker-compose.yml", maestroPath)}
-	identifier := strings.ToLower("test-something")
+	identifier := strings.ToLower("e2e-test")
 
 	compose := tc.NewLocalDockerCompose(composeFilePaths, identifier)
 	composeErr := compose.WithCommand([]string{"up", "-d", "grpc-mock"}).Invoke()
@@ -52,5 +52,5 @@ func ProvideServerMocks(maestroPath string) (*ServerMocks, error) {
 }
 
 func (s *ServerMocks) Teardown() {
-	s.compose.Down()
+	s.compose.WithCommand([]string{"down", "--remove-orphans", "--volumes"}).Invoke()
 }


### PR DESCRIPTION
## What ❓ 
Make sure to stop and remove containers created by e2e tests, also deletes every named and anonymous container volume created by the execution. 

## Why 🤔 
By not cleaning anonymous volumes, the execution of our e2e test was creating too much trash on the host machine.