### PR TITLE
In operation rollback use valid context

### DIFF
--- a/cmd/roomsapi/rooms_api.go
+++ b/cmd/roomsapi/rooms_api.go
@@ -25,10 +25,7 @@ package roomsapi
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
-
-	_ "net/http/pprof"
 
 	"github.com/topfreegames/maestro/cmd/commom"
 
@@ -65,10 +62,6 @@ func init() {
 }
 
 func runRoomsAPI() {
-	go func() {
-		log.Println(http.ListenAndServe("0.0.0.0:6060", nil))
-	}()
-
 	ctx, cancelFn := context.WithCancel(context.Background())
 
 	err, config, shutdownInternalServerFn := commom.ServiceSetup(ctx, cancelFn, logConfig, configPath)

--- a/cmd/roomsapi/rooms_api.go
+++ b/cmd/roomsapi/rooms_api.go
@@ -25,7 +25,10 @@ package roomsapi
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
+
+	_ "net/http/pprof"
 
 	"github.com/topfreegames/maestro/cmd/commom"
 
@@ -62,6 +65,10 @@ func init() {
 }
 
 func runRoomsAPI() {
+	go func() {
+		log.Println(http.ListenAndServe("0.0.0.0:6060", nil))
+	}()
+
 	ctx, cancelFn := context.WithCancel(context.Background())
 
 	err, config, shutdownInternalServerFn := commom.ServiceSetup(ctx, cancelFn, logConfig, configPath)

--- a/internal/core/operations/add_rooms/add_rooms_executor.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor.go
@@ -91,20 +91,20 @@ func (ex *AddRoomsExecutor) Execute(ctx context.Context, op *operation.Operation
 	return nil
 }
 
-func (ex *AddRoomsExecutor) OnError(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (ex *AddRoomsExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
 	executionLogger := ex.logger.With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, definition.Name()),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
-	executionLogger.Info("starting OnError routine")
+	executionLogger.Info("starting rollback routine")
 
 	err := ex.deleteNewCreatedRooms(ctx, executionLogger, op.SchedulerName)
 	ex.clearNewCreatedRooms(op.SchedulerName)
 	if err != nil {
 		return err
 	}
-	executionLogger.Info("finished OnError routine")
+	executionLogger.Info("finished rollback routine")
 	return nil
 }
 

--- a/internal/core/operations/add_rooms/add_rooms_executor_test.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor_test.go
@@ -128,7 +128,7 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 	})
 }
 
-func TestAddRoomsExecutor_OnError(t *testing.T) {
+func TestAddRoomsExecutor_Rollback(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
 	clockMock := clock_mock.NewFakeClock(time.Now())
@@ -193,7 +193,7 @@ func TestAddRoomsExecutor_OnError(t *testing.T) {
 		require.Error(t, err)
 
 		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil).Times(9)
-		err = executor.OnError(context.Background(), &op, &definition, nil)
+		err = executor.Rollback(context.Background(), &op, &definition, nil)
 		require.NoError(t, err)
 	})
 
@@ -212,7 +212,7 @@ func TestAddRoomsExecutor_OnError(t *testing.T) {
 
 		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("error")).Times(1)
 
-		err = executor.OnError(context.Background(), &op, &definition, nil)
+		err = executor.Rollback(context.Background(), &op, &definition, nil)
 		require.Error(t, err)
 	})
 

--- a/internal/core/operations/create_scheduler/create_scheduler_executor.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor.go
@@ -64,18 +64,18 @@ func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op *operation.Ope
 	return nil
 }
 
-func (e *CreateSchedulerExecutor) OnError(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (e *CreateSchedulerExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "OnError"),
+		zap.String("operation_phase", "Rollback"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 
 	err := e.schedulerManager.DeleteScheduler(ctx, op.SchedulerName)
 	if err != nil {
 		logger.Error(fmt.Sprintf("error deleting scheduler %s", op.SchedulerName), zap.Error(err))
-		return fmt.Errorf("error in OnError function execution: %w", err)
+		return fmt.Errorf("error in Rollback function execution: %w", err)
 	}
 	return nil
 }

--- a/internal/core/operations/create_scheduler/create_scheduler_executor_test.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor_test.go
@@ -85,7 +85,7 @@ func TestExecute(t *testing.T) {
 	})
 }
 
-func TestOnError(t *testing.T) {
+func TestRollback(t *testing.T) {
 	t.Run("it returns nil when delete scheduler on execution error", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		runtime := runtimeMock.NewMockRuntime(mockCtrl)
@@ -99,7 +99,7 @@ func TestOnError(t *testing.T) {
 		}
 		schedulerManager.EXPECT().DeleteScheduler(gomock.Any(), op.SchedulerName).Return(nil)
 
-		err := NewExecutor(runtime, schedulerManager).OnError(context.Background(), &op, definition, errors.ErrUnexpected)
+		err := NewExecutor(runtime, schedulerManager).Rollback(context.Background(), &op, definition, errors.ErrUnexpected)
 
 		assert.NoError(t, err)
 	})
@@ -117,10 +117,10 @@ func TestOnError(t *testing.T) {
 		}
 		schedulerManager.EXPECT().DeleteScheduler(gomock.Any(), op.SchedulerName).Return(errors.NewErrUnexpected("err"))
 
-		err := NewExecutor(runtime, schedulerManager).OnError(context.Background(), &op, definition, errors.ErrUnexpected)
+		err := NewExecutor(runtime, schedulerManager).Rollback(context.Background(), &op, definition, errors.ErrUnexpected)
 
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, errors.ErrUnexpected)
-		assert.Contains(t, err.Error(), "error in OnError function execution")
+		assert.Contains(t, err.Error(), "error in Rollback function execution")
 	})
 }

--- a/internal/core/operations/executor.go
+++ b/internal/core/operations/executor.go
@@ -35,9 +35,9 @@ type Executor interface {
 	// that will be used for deadline and cancellation. This function has only
 	// one return which is the operation error (if any);
 	Execute(ctx context.Context, op *operation.Operation, definition Definition) error
-	// OnError is called if Execute returns an error. This will be used
+	// Rollback is called if Execute returns an error. This will be used
 	// for operations that need to do some cleanup or any process if it fails.
-	OnError(ctx context.Context, op *operation.Operation, definition Definition, executeErr error) error
+	Rollback(ctx context.Context, op *operation.Operation, definition Definition, executeErr error) error
 	// Name returns the executor name. This is used to identify a executor for a
 	// definition.
 	Name() string

--- a/internal/core/operations/mock/executor.go
+++ b/internal/core/operations/mock/executor.go
@@ -64,16 +64,16 @@ func (mr *MockExecutorMockRecorder) Name() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockExecutor)(nil).Name))
 }
 
-// OnError mocks base method.
-func (m *MockExecutor) OnError(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+// Rollback mocks base method.
+func (m *MockExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OnError", ctx, op, definition, executeErr)
+	ret := m.ctrl.Call(m, "Rollback", ctx, op, definition, executeErr)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// OnError indicates an expected call of OnError.
-func (mr *MockExecutorMockRecorder) OnError(ctx, op, definition, executeErr interface{}) *gomock.Call {
+// Rollback indicates an expected call of Rollback.
+func (mr *MockExecutorMockRecorder) Rollback(ctx, op, definition, executeErr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnError", reflect.TypeOf((*MockExecutor)(nil).OnError), ctx, op, definition, executeErr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockExecutor)(nil).Rollback), ctx, op, definition, executeErr)
 }

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -100,18 +100,18 @@ func (ex *CreateNewSchedulerVersionExecutor) Execute(ctx context.Context, op *op
 	return nil
 }
 
-func (ex *CreateNewSchedulerVersionExecutor) OnError(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (ex *CreateNewSchedulerVersionExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "OnError"),
+		zap.String("operation_phase", "Rollback"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 	if gameRoom, ok := ex.validationRoomIdsMap[op.SchedulerName]; ok {
 		err := ex.roomManager.DeleteRoomAndWaitForRoomTerminated(ctx, gameRoom)
 		if err != nil {
 			logger.Error("error deleting new game room created for validation", zap.Error(err))
-			return fmt.Errorf("error in OnError function execution: %w", err)
+			return fmt.Errorf("error in Rollback function execution: %w", err)
 		}
 		ex.RemoveValidationRoomId(op.SchedulerName)
 	}

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -554,7 +554,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 }
 
-func TestCreateNewSchedulerVersionExecutor_OnError(t *testing.T) {
+func TestCreateNewSchedulerVersionExecutor_Rollback(t *testing.T) {
 	err := validations.RegisterValidations()
 	if err != nil {
 		t.Errorf("unexpected error %d'", err)
@@ -577,7 +577,7 @@ func TestCreateNewSchedulerVersionExecutor_OnError(t *testing.T) {
 		executor := newschedulerversion.NewExecutor(roomManager, schedulerManager)
 		executor.AddValidationRoomId(newScheduler.Name, &game_room.GameRoom{ID: "room1"})
 		roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil)
-		result := executor.OnError(context.Background(), op, operationDef, nil)
+		result := executor.Rollback(context.Background(), op, operationDef, nil)
 
 		require.NoError(t, result)
 	})
@@ -599,9 +599,9 @@ func TestCreateNewSchedulerVersionExecutor_OnError(t *testing.T) {
 		executor := newschedulerversion.NewExecutor(roomManager, schedulerManager)
 		executor.AddValidationRoomId(newScheduler.Name, &game_room.GameRoom{ID: "room1"})
 		roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("some error"))
-		result := executor.OnError(context.Background(), op, operationDef, nil)
+		result := executor.Rollback(context.Background(), op, operationDef, nil)
 
-		require.EqualError(t, result, "error in OnError function execution: some error")
+		require.EqualError(t, result, "error in Rollback function execution: some error")
 	})
 
 	t.Run("when no game room were created during execution, it does nothing", func(t *testing.T) {
@@ -619,7 +619,7 @@ func TestCreateNewSchedulerVersionExecutor_OnError(t *testing.T) {
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 
 		executor := newschedulerversion.NewExecutor(roomManager, schedulerManager)
-		result := executor.OnError(context.Background(), op, operationDef, nil)
+		result := executor.Rollback(context.Background(), op, operationDef, nil)
 
 		require.NoError(t, result)
 	})

--- a/internal/core/operations/remove_rooms/remove_rooms_executor.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor.go
@@ -71,7 +71,7 @@ func (e *RemoveRoomsExecutor) Execute(ctx context.Context, op *operation.Operati
 	return nil
 }
 
-func (e *RemoveRoomsExecutor) OnError(_ context.Context, _ *operation.Operation, _ operations.Definition, _ error) error {
+func (e *RemoveRoomsExecutor) Rollback(_ context.Context, _ *operation.Operation, _ operations.Definition, _ error) error {
 	return nil
 }
 

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -117,13 +117,13 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 	return nil
 }
 
-func (ex *SwitchActiveVersionExecutor) OnError(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (ex *SwitchActiveVersionExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, definition.Name()),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
-	logger.Info("starting OnError routine")
+	logger.Info("starting Rollback routine")
 
 	err := ex.deleteNewCreatedRooms(ctx, logger, op.SchedulerName)
 	ex.clearNewCreatedRooms(op.SchedulerName)
@@ -131,7 +131,7 @@ func (ex *SwitchActiveVersionExecutor) OnError(ctx context.Context, op *operatio
 		return err
 	}
 
-	logger.Info("finished OnError routine")
+	logger.Info("finished Rollback routine")
 	return nil
 }
 

--- a/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
@@ -288,7 +288,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 }
 
-func TestSwitchActiveVersionOperation_OnError(t *testing.T) {
+func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mocks := newMockRoomAndSchedulerManager(mockCtrl)
 
@@ -313,7 +313,7 @@ func TestSwitchActiveVersionOperation_OnError(t *testing.T) {
 
 	t.Run("should succeed - Execute on error if operation finishes (no created rooms)", func(t *testing.T) {
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.OnError(context.Background(), &operation.Operation{}, definition, nil)
+		err = executor.Rollback(context.Background(), &operation.Operation{}, definition, nil)
 		require.NoError(t, err)
 	})
 
@@ -376,7 +376,7 @@ func TestSwitchActiveVersionOperation_OnError(t *testing.T) {
 			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil)
 		}
 
-		err = executor.OnError(context.Background(), op, definition, nil)
+		err = executor.Rollback(context.Background(), op, definition, nil)
 		require.NoError(t, err)
 	})
 
@@ -436,7 +436,7 @@ func TestSwitchActiveVersionOperation_OnError(t *testing.T) {
 
 		mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 
-		err = executor.OnError(context.Background(), op, definition, nil)
+		err = executor.Rollback(context.Background(), op, definition, nil)
 		require.Error(t, err)
 	})
 }

--- a/internal/core/operations/test_operation/test_operation_executor.go
+++ b/internal/core/operations/test_operation/test_operation_executor.go
@@ -55,8 +55,8 @@ func (e *TestOperationExecutor) Execute(ctx context.Context, _op *operation.Oper
 	return nil
 }
 
-// OnError will do nothing.
-func (e *TestOperationExecutor) OnError(_ context.Context, _ *operation.Operation, _ operations.Definition, _ error) error {
+// Rollback will do nothing.
+func (e *TestOperationExecutor) Rollback(_ context.Context, _ *operation.Operation, _ operations.Definition, _ error) error {
 	return nil
 }
 

--- a/internal/core/workers/operation_execution_worker/metrics.go
+++ b/internal/core/workers/operation_execution_worker/metrics.go
@@ -50,11 +50,11 @@ var (
 		},
 	})
 
-	operationOnErrorLatencyMetric = monitoring.CreateLatencyMetric(&monitoring.MetricOpts{
+	operationRollbackLatencyMetric = monitoring.CreateLatencyMetric(&monitoring.MetricOpts{
 		Namespace: monitoring.Namespace,
 		Subsystem: monitoring.SubsystemWorker,
-		Name:      "operation_on_error",
-		Help:      "An scheduler operation on error fallback was executed",
+		Name:      "operation_rollback",
+		Help:      "An scheduler operation rollback was executed",
 		Labels: []string{
 			monitoring.LabelGame,
 			monitoring.LabelScheduler,
@@ -96,10 +96,10 @@ func reportOperationExecutionLatency(start time.Time, game, schedulerName, opera
 	)
 }
 
-func reportOperationOnErrorLatency(start time.Time, game, schedulerName, operationName string, success bool) {
+func reportOperationRollbackLatency(start time.Time, game, schedulerName, operationName string, success bool) {
 	successLabelValue := fmt.Sprint(success)
 	monitoring.ReportLatencyMetricInMillis(
-		operationOnErrorLatencyMetric, start, game, schedulerName, operationName, successLabelValue,
+		operationRollbackLatencyMetric, start, game, schedulerName, operationName, successLabelValue,
 	)
 }
 

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -160,7 +160,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 			if errors.Is(executionErr, context.Canceled) {
 				op.Status = operation.StatusCanceled
 
-				w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Operation cancelled")
+				w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Canceling operation")
 			}
 
 			loopLogger.Error("operation execution failed", zap.Error(executionErr))
@@ -170,13 +170,12 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 				return executor.OnError(operationContext, op, def, executionErr)
 			})
 
-			if onErrorErr != nil {
-				loopLogger.Error("operation OnError failed", zap.Error(onErrorErr))
-				w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, fmt.Sprintf("Operation OnError flow execution failed, reason: %s", onErrorErr.Error()))
+			if rollbackErr != nil {
+				loopLogger.Error("operation rollback failed", zap.Error(rollbackErr))
+				w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, fmt.Sprintf("Operation rollback flow execution failed, reason: %s", rollbackErr.Error()))
 			} else {
-				w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Operation OnError flow execution finished with success")
+				w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Operation rollback flow execution finished with success")
 			}
-
 		}
 
 		loopLogger.Info("Finishing operation")
@@ -191,7 +190,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 		if err != nil {
 			loopLogger.Error("failed to revoke operation lease", zap.Error(err))
 		}
-		w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Finishing operation")
+		w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Operation finished")
 	}
 }
 
@@ -222,9 +221,9 @@ func (w *OperationExecutionWorker) executeCollectingLatencyMetrics(definitionNam
 	return err
 }
 
-func (w *OperationExecutionWorker) executeOnErrorCollectingLatencyMetrics(definitionName string, f func() error) (err error) {
-	onErrorStartTime := time.Now()
+func (w *OperationExecutionWorker) executeRollbackCollectingLatencyMetrics(definitionName string, f func() error) (err error) {
+	rollbackStartTime := time.Now()
 	err = f()
-	reportOperationOnErrorLatency(onErrorStartTime, w.scheduler.Game, w.scheduler.Name, definitionName, err == nil)
+	reportOperationRollbackLatency(rollbackStartTime, w.scheduler.Game, w.scheduler.Name, definitionName, err == nil)
 	return err
 }

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -166,8 +166,8 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 			loopLogger.Error("operation execution failed", zap.Error(executionErr))
 			w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, fmt.Sprintf("Operation execution failed, reason: %s", executionErr.Error()))
 
-			onErrorErr := w.executeOnErrorCollectingLatencyMetrics(op.DefinitionName, func() error {
-				return executor.OnError(operationContext, op, def, executionErr)
+			rollbackErr := w.executeRollbackCollectingLatencyMetrics(op.DefinitionName, func() error {
+				return executor.Rollback(w.workerContext, op, def, executionErr)
 			})
 
 			if rollbackErr != nil {

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -79,7 +79,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationManager.EXPECT().StartLeaseRenewGoRoutine(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().RevokeLease(gomock.Any(), expectedOperation)
-		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Finishing operation")
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation finished")
 		// Ends the worker by cancelling it
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(nil, nil, context.Canceled)
 
@@ -137,11 +137,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 			},
 		).Return(nil)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation execution failed, reason: some execution error")
-		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation Rollback flow execution finished with success")
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation rollback flow execution finished with success")
 
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().RevokeLease(gomock.Any(), expectedOperation)
-		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Finishing operation")
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation finished")
 		// Ends the worker by cancelling it
 		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(nil, nil, context.Canceled)
 

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -96,7 +96,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		require.False(t, workerService.IsRunning())
 	})
 
-	t.Run("execute OnError when a Execute fails", func(t *testing.T) {
+	t.Run("execute Rollback when a Execute fails", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		operationName := "test_operation"
@@ -131,13 +131,13 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executionErr := fmt.Errorf("some execution error")
 		operationExecutor.EXPECT().Execute(gomock.Any(), expectedOperation, operationDefinition).Return(executionErr)
-		operationExecutor.EXPECT().OnError(gomock.Any(), expectedOperation, operationDefinition, executionErr).Do(
+		operationExecutor.EXPECT().Rollback(gomock.Any(), expectedOperation, operationDefinition, executionErr).Do(
 			func(ctx, operation, definition, executeErr interface{}) {
 				time.Sleep(time.Second * 1)
 			},
 		).Return(nil)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation execution failed, reason: some execution error")
-		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation OnError flow execution finished with success")
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation Rollback flow execution finished with success")
 
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().RevokeLease(gomock.Any(), expectedOperation)


### PR DESCRIPTION
### WHY
- `OnError` is a name that was causing confusion when it is showing to the clients, a better name, for now, is `Rollback`.
- The `Rollback` method was receiving a canceled context when cancel was called.
- The `ExecutionHistory` is receiving histories of `Operation canceled` and `Finishing operation` that does not reflect what is happening.
### WHAT
- Refactor `OnError` to `Rollback`
- Give to `Rollback` a valid context when it is rolling back.
- Change `ExecutionHistory` messages from `Operation canceled` to `Cancelling operation and `Finishing operation` to `Operation finished`.