### PR TITLE
Improvement/normalize operation execution errors

### DIFF
--- a/internal/adapters/metrics/pg.go
+++ b/internal/adapters/metrics/pg.go
@@ -35,7 +35,6 @@ var (
 		Labels: []string{
 			monitoring.LabelStorage,
 			monitoring.LabelOperation,
-			monitoring.LabelScheduler,
 		},
 	})
 

--- a/internal/core/operations/add_rooms/add_rooms_executor.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor.go
@@ -89,9 +89,8 @@ func (ex *AddRoomsExecutor) Execute(ctx context.Context, op *operation.Operation
 		executionLogger.Error("Error creating rooms", zap.Error(executionErr))
 		if errors.Is(executionErr, serviceerrors.ErrGameRoomStatusWaitingTimeout) {
 			return operations.NewErrReadyPingTimeout(executionErr)
-		} else {
-			return operations.NewErrUnexpected(executionErr)
 		}
+		return operations.NewErrUnexpected(executionErr)
 	}
 	ex.clearNewCreatedRooms(op.SchedulerName)
 

--- a/internal/core/operations/add_rooms/add_rooms_executor.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor.go
@@ -99,7 +99,7 @@ func (ex *AddRoomsExecutor) Execute(ctx context.Context, op *operation.Operation
 	return nil
 }
 
-func (ex *AddRoomsExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (ex *AddRoomsExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr operations.ExecutionError) error {
 	executionLogger := ex.logger.With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, definition.Name()),

--- a/internal/core/operations/add_rooms/add_rooms_executor.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor.go
@@ -24,6 +24,7 @@ package add_rooms
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -39,6 +40,7 @@ import (
 
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/operations"
+	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
 )
 
 type AddRoomsExecutor struct {
@@ -48,6 +50,8 @@ type AddRoomsExecutor struct {
 	newCreatedRooms     map[string][]*game_room.GameRoom
 	newCreatedRoomsLock sync.Mutex
 }
+
+var _ operations.Executor = (*AddRoomsExecutor)(nil)
 
 func NewExecutor(roomManager ports.RoomManager, storage ports.SchedulerStorage) *AddRoomsExecutor {
 	return &AddRoomsExecutor{
@@ -59,7 +63,7 @@ func NewExecutor(roomManager ports.RoomManager, storage ports.SchedulerStorage) 
 	}
 }
 
-func (ex *AddRoomsExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
+func (ex *AddRoomsExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) operations.ExecutionError {
 	executionLogger := ex.logger.With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, definition.Name()),
@@ -69,7 +73,7 @@ func (ex *AddRoomsExecutor) Execute(ctx context.Context, op *operation.Operation
 	scheduler, err := ex.storage.GetScheduler(ctx, op.SchedulerName)
 	if err != nil {
 		executionLogger.Error(fmt.Sprintf("Could not find scheduler with name %s, can not create rooms", op.SchedulerName), zap.Error(err))
-		return err
+		return operations.NewErrUnexpected(err)
 	}
 
 	errGroup, errContext := errgroup.WithContext(ctx)
@@ -83,7 +87,11 @@ func (ex *AddRoomsExecutor) Execute(ctx context.Context, op *operation.Operation
 
 	if executionErr := errGroup.Wait(); executionErr != nil {
 		executionLogger.Error("Error creating rooms", zap.Error(executionErr))
-		return executionErr
+		if errors.Is(executionErr, serviceerrors.ErrGameRoomStatusWaitingTimeout) {
+			return operations.NewErrReadyPingTimeout(executionErr)
+		} else {
+			return operations.NewErrUnexpected(executionErr)
+		}
 	}
 	ex.clearNewCreatedRooms(op.SchedulerName)
 

--- a/internal/core/operations/add_rooms/add_rooms_executor_test.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor_test.go
@@ -25,6 +25,8 @@ package add_rooms
 import (
 	"time"
 
+	"github.com/topfreegames/maestro/internal/core/operations"
+
 	"context"
 	"testing"
 
@@ -34,7 +36,9 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
-	"github.com/topfreegames/maestro/internal/core/ports/errors"
+	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
+	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
+
 	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
 )
 
@@ -98,10 +102,10 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
 
-		require.NoError(t, err)
+		require.Nil(t, err)
 	})
 
-	t.Run("should fail - some room creation fail, others succeed => returns error", func(t *testing.T) {
+	t.Run("should fail - some room creation fail, others succeed => returns unexpected error", func(t *testing.T) {
 		roomsManager := mockports.NewMockRoomManager(mockCtrl)
 
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
@@ -110,21 +114,41 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 		gameRoomReady.Status = game_room.GameStatusReady
 
 		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, errors.NewErrUnexpected("error"))
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, porterrors.NewErrUnexpected("error"))
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
 
-		require.Error(t, err)
+		require.NotNil(t, err)
+		require.Equal(t, err.Kind(), operations.ErrKindUnexpected)
+	})
+
+	t.Run("should fail - some room creation fail with timeout => returns timeout error", func(t *testing.T) {
+		roomsManager := mockports.NewMockRoomManager(mockCtrl)
+
+		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
+
+		gameRoomReady := gameRoom
+		gameRoomReady.Status = game_room.GameStatusReady
+
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, serviceerrors.NewErrGameRoomStatusWaitingTimeout("context deadline exceeded"))
+
+		executor := NewExecutor(roomsManager, schedulerStorage)
+		err := executor.Execute(context.Background(), &op, &definition)
+
+		require.NotNil(t, err)
+		require.Equal(t, err.Kind(), operations.ErrKindReadyPingTimeout)
 	})
 
 	t.Run("should fail - no scheduler found => returns error", func(t *testing.T) {
 		roomsManager := mockports.NewMockRoomManager(mockCtrl)
 
-		schedulerStorage.EXPECT().GetScheduler(context.Background(), op.SchedulerName).Return(nil, errors.NewErrNotFound("scheduler not found"))
+		schedulerStorage.EXPECT().GetScheduler(context.Background(), op.SchedulerName).Return(nil, porterrors.NewErrNotFound("scheduler not found"))
 
 		err := NewExecutor(roomsManager, schedulerStorage).Execute(context.Background(), &op, &definition)
-		require.Error(t, err)
+		require.NotNil(t, err)
+		require.Equal(t, err.Kind(), operations.ErrKindUnexpected)
 	})
 }
 
@@ -185,16 +209,16 @@ func TestAddRoomsExecutor_Rollback(t *testing.T) {
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
 
 		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, errors.NewErrUnexpected("error"))
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, porterrors.NewErrUnexpected("error"))
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
 
-		require.Error(t, err)
+		require.NotNil(t, err)
 
 		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil).Times(9)
-		err = executor.Rollback(context.Background(), &op, &definition, nil)
-		require.NoError(t, err)
+		rollbackErr := executor.Rollback(context.Background(), &op, &definition, nil)
+		require.NoError(t, rollbackErr)
 	})
 
 	t.Run("when some error occurs while deleting rooms it returns error", func(t *testing.T) {
@@ -203,17 +227,17 @@ func TestAddRoomsExecutor_Rollback(t *testing.T) {
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
 
 		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, errors.NewErrUnexpected("error"))
+		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, porterrors.NewErrUnexpected("error"))
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
 
-		require.Error(t, err)
+		require.NotNil(t, err)
 
-		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("error")).Times(1)
+		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(porterrors.NewErrUnexpected("error")).Times(1)
 
-		err = executor.Rollback(context.Background(), &op, &definition, nil)
-		require.Error(t, err)
+		rollbackErr = executor.Rollback(context.Background(), &op, &definition, nil)
+		require.Error(t, rollbackErr)
 	})
 
 }

--- a/internal/core/operations/add_rooms/add_rooms_executor_test.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor_test.go
@@ -236,7 +236,7 @@ func TestAddRoomsExecutor_Rollback(t *testing.T) {
 
 		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(porterrors.NewErrUnexpected("error")).Times(1)
 
-		rollbackErr = executor.Rollback(context.Background(), &op, &definition, nil)
+		rollbackErr := executor.Rollback(context.Background(), &op, &definition, nil)
 		require.Error(t, rollbackErr)
 	})
 

--- a/internal/core/operations/create_scheduler/create_scheduler_executor.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor.go
@@ -66,7 +66,7 @@ func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op *operation.Ope
 	return nil
 }
 
-func (e *CreateSchedulerExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (e *CreateSchedulerExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr operations.ExecutionError) error {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),

--- a/internal/core/operations/create_scheduler/create_scheduler_executor.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor.go
@@ -39,6 +39,8 @@ type CreateSchedulerExecutor struct {
 	schedulerManager ports.SchedulerManager
 }
 
+var _ operations.Executor = (*CreateSchedulerExecutor)(nil)
+
 func NewExecutor(runtime ports.Runtime, schedulerManager ports.SchedulerManager) *CreateSchedulerExecutor {
 	return &CreateSchedulerExecutor{
 		runtime:          runtime,
@@ -46,7 +48,7 @@ func NewExecutor(runtime ports.Runtime, schedulerManager ports.SchedulerManager)
 	}
 }
 
-func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
+func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) operations.ExecutionError {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
@@ -57,7 +59,7 @@ func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op *operation.Ope
 	err := e.runtime.CreateScheduler(ctx, &entities.Scheduler{Name: op.SchedulerName})
 	if err != nil {
 		logger.Error(fmt.Sprintf("failed to create scheduler %s in runtime", op.SchedulerName), zap.Error(err))
-		return err
+		return operations.NewErrUnexpected(err)
 	}
 
 	logger.Info(fmt.Sprintf("%s operation succeded, %s scheduler was created", definition.Name(), op.SchedulerName))

--- a/internal/core/operations/create_scheduler/create_scheduler_executor_test.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor_test.go
@@ -27,8 +27,9 @@ package create_scheduler
 
 import (
 	"context"
-	"github.com/topfreegames/maestro/internal/core/operations"
 	"testing"
+
+	"github.com/topfreegames/maestro/internal/core/operations"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/internal/core/operations/create_scheduler/create_scheduler_executor_test.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor_test.go
@@ -27,6 +27,7 @@ package create_scheduler
 
 import (
 	"context"
+	"github.com/topfreegames/maestro/internal/core/operations"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -60,7 +61,7 @@ func TestExecute(t *testing.T) {
 		runtime.EXPECT().CreateScheduler(context.Background(), &entities.Scheduler{Name: op.SchedulerName}).Return(nil)
 
 		err := NewExecutor(runtime, schedulerManager).Execute(context.Background(), &op, &definition)
-		require.NoError(t, err)
+		require.Nil(t, err)
 	})
 
 	t.Run("fails with runtime request fails", func(t *testing.T) {
@@ -81,7 +82,8 @@ func TestExecute(t *testing.T) {
 		runtime.EXPECT().CreateScheduler(context.Background(), &entities.Scheduler{Name: op.SchedulerName}).Return(errors.ErrUnexpected)
 
 		err := NewExecutor(runtime, schedulerManager).Execute(context.Background(), &op, &definition)
-		require.ErrorIs(t, err, errors.ErrUnexpected)
+		require.NotNil(t, err)
+		require.Equal(t, err.Kind(), operations.ErrKindUnexpected)
 	})
 }
 
@@ -99,7 +101,7 @@ func TestRollback(t *testing.T) {
 		}
 		schedulerManager.EXPECT().DeleteScheduler(gomock.Any(), op.SchedulerName).Return(nil)
 
-		err := NewExecutor(runtime, schedulerManager).Rollback(context.Background(), &op, definition, errors.ErrUnexpected)
+		err := NewExecutor(runtime, schedulerManager).Rollback(context.Background(), &op, definition, operations.NewErrUnexpected(errors.ErrUnexpected))
 
 		assert.NoError(t, err)
 	})
@@ -117,7 +119,7 @@ func TestRollback(t *testing.T) {
 		}
 		schedulerManager.EXPECT().DeleteScheduler(gomock.Any(), op.SchedulerName).Return(errors.NewErrUnexpected("err"))
 
-		err := NewExecutor(runtime, schedulerManager).Rollback(context.Background(), &op, definition, errors.ErrUnexpected)
+		err := NewExecutor(runtime, schedulerManager).Rollback(context.Background(), &op, definition, operations.NewErrUnexpected(errors.ErrUnexpected))
 
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, errors.ErrUnexpected)

--- a/internal/core/operations/errors.go
+++ b/internal/core/operations/errors.go
@@ -77,10 +77,8 @@ func NewErrUnexpected(err error) *operationExecutionError {
 func NewErrInvalidGru(err error) *operationExecutionError {
 	return &operationExecutionError{
 		kind: ErrKindInvalidGru,
-		formattedMessage: `The GRU could not be validated. Maestro could not wait for game room to be ready,
-		either the room is not sending the "ready" ping correctly or it is taking too long to respond. Please check if
-		the GRU image is stable, or if roomInitializationTimeoutMillis configuration value needs to be increased, 
-		and try again.`,
+		formattedMessage: `The GRU could not be validated. Maestro got timeout waiting the GRU to be ready. You can check if
+		the GRU image is stable, or if roomInitializationTimeoutMillis configuration value needs to be increased.`,
 		err: err,
 	}
 }
@@ -88,7 +86,7 @@ func NewErrInvalidGru(err error) *operationExecutionError {
 func NewErrReadyPingTimeout(err error) *operationExecutionError {
 	return &operationExecutionError{
 		kind: ErrKindReadyPingTimeout,
-		formattedMessage: `Got timeout while waiting room status to be ready. Please check if 
+		formattedMessage: `Got timeout while waiting room status to be ready. You can check if 
 		roomInitializationTimeoutMillis configuration value needs to be increased.`,
 		err: err,
 	}
@@ -97,7 +95,7 @@ func NewErrReadyPingTimeout(err error) *operationExecutionError {
 func NewErrTerminatingPingTimeout(err error) *operationExecutionError {
 	return &operationExecutionError{
 		kind: ErrKindTerminatingPingTimeout,
-		formattedMessage: `Got timeout while waiting room status to be terminating. Please check if 
+		formattedMessage: `Got timeout while waiting room status to be terminating. You can check if 
 		roomDeletionTimeoutMillis configuration value needs to be increased.`,
 		err: err,
 	}

--- a/internal/core/operations/errors.go
+++ b/internal/core/operations/errors.go
@@ -30,12 +30,14 @@ const (
 	ErrKindUnexpected errorKind = iota
 	ErrKindInvalidGru
 	ErrKindReadyPingTimeout
+	ErrKindTerminatingPingTimeout
 )
 
 var (
-	ErrUnexpected  = &operationExecutionError{kind: ErrKindUnexpected}
-	ErrInvalidGru  = &operationExecutionError{kind: ErrKindInvalidGru}
-	ErrPingTimeout = &operationExecutionError{kind: ErrKindReadyPingTimeout}
+	ErrUnexpected             = &operationExecutionError{kind: ErrKindUnexpected}
+	ErrInvalidGru             = &operationExecutionError{kind: ErrKindInvalidGru}
+	ErrReadyPingTimeout       = &operationExecutionError{kind: ErrKindReadyPingTimeout}
+	ErrTerminatingPingTimeout = &operationExecutionError{kind: ErrKindReadyPingTimeout}
 )
 
 type ExecutionError interface {
@@ -88,6 +90,15 @@ func NewErrReadyPingTimeout(err error) *operationExecutionError {
 		kind: ErrKindReadyPingTimeout,
 		formattedMessage: `Got timeout while waiting room status to be ready. Please check if 
 		roomInitializationTimeoutMillis configuration value needs to be increased.`,
+		err: err,
+	}
+}
+
+func NewErrTerminatingPingTimeout(err error) *operationExecutionError {
+	return &operationExecutionError{
+		kind: ErrKindTerminatingPingTimeout,
+		formattedMessage: `Got timeout while waiting room status to be terminating. Please check if 
+		roomDeletionTimeoutMillis configuration value needs to be increased.`,
 		err: err,
 	}
 }

--- a/internal/core/operations/errors.go
+++ b/internal/core/operations/errors.go
@@ -1,0 +1,91 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package operations
+
+import "fmt"
+
+type errorKind int
+
+const (
+	ErrKindUnexpected errorKind = iota
+	ErrKindInvalidGru
+	ErrKindReadyPingTimeout
+)
+
+var (
+	ErrUnexpected  = &operationExecutionError{kind: ErrKindUnexpected}
+	ErrInvalidGru  = &operationExecutionError{kind: ErrKindInvalidGru}
+	ErrPingTimeout = &operationExecutionError{kind: ErrKindReadyPingTimeout}
+)
+
+type ExecutionError interface {
+	Kind() errorKind
+	Message() string
+	FormattedMessage() string
+}
+
+type operationExecutionError struct {
+	kind             errorKind
+	message          string
+	formattedMessage string
+}
+
+func (e *operationExecutionError) Kind() errorKind {
+	return e.kind
+}
+func (e *operationExecutionError) Message() string {
+	return e.message
+}
+func (e *operationExecutionError) FormattedMessage() string {
+	return e.formattedMessage
+}
+
+func NewErrUnexpected(format string, args ...interface{}) *operationExecutionError {
+	message := fmt.Sprintf(format, args...)
+	return &operationExecutionError{
+		kind:    ErrKindUnexpected,
+		message: message,
+		formattedMessage: fmt.Sprintf("Unexpected Error: %s - Contact the Maestro's responsible team for helping "+
+			"troubleshoot.", message),
+	}
+}
+
+func NewErrInvalidGru(format string, args ...interface{}) *operationExecutionError {
+	return &operationExecutionError{
+		kind:    ErrKindInvalidGru,
+		message: fmt.Sprintf(format, args...),
+		formattedMessage: `The GRU could not be validated. Maestro could not wait for game room to be ready,
+		either the room is not sending the "ready" ping correctly or it is taking too long to respond. Please check if
+		the GRU image is stable, or if roomInitializationTimeoutMillis configuration value needs to be increased, 
+		and try again.`,
+	}
+}
+
+func NewErrReadyPingTimeout(format string, args ...interface{}) *operationExecutionError {
+	return &operationExecutionError{
+		kind:    ErrKindReadyPingTimeout,
+		message: fmt.Sprintf(format, args...),
+		formattedMessage: `Got timeout while waiting room status to be ready. Please check if 
+		roomInitializationTimeoutMillis configuration value needs to be increased.`,
+	}
+}

--- a/internal/core/operations/errors.go
+++ b/internal/core/operations/errors.go
@@ -40,52 +40,54 @@ var (
 
 type ExecutionError interface {
 	Kind() errorKind
-	Message() string
 	FormattedMessage() string
+	Error() error
 }
 
 type operationExecutionError struct {
 	kind             errorKind
-	message          string
 	formattedMessage string
+	err              error
+}
+
+func (e *operationExecutionError) Error() error {
+	return e.err
 }
 
 func (e *operationExecutionError) Kind() errorKind {
 	return e.kind
 }
-func (e *operationExecutionError) Message() string {
-	return e.message
-}
+
 func (e *operationExecutionError) FormattedMessage() string {
 	return e.formattedMessage
 }
 
-func NewErrUnexpected(format string, args ...interface{}) *operationExecutionError {
-	message := fmt.Sprintf(format, args...)
+func NewErrUnexpected(err error) *operationExecutionError {
+	message := err.Error()
 	return &operationExecutionError{
-		kind:    ErrKindUnexpected,
-		message: message,
+		kind: ErrKindUnexpected,
 		formattedMessage: fmt.Sprintf("Unexpected Error: %s - Contact the Maestro's responsible team for helping "+
 			"troubleshoot.", message),
+		err: err,
 	}
 }
 
-func NewErrInvalidGru(format string, args ...interface{}) *operationExecutionError {
+func NewErrInvalidGru(err error) *operationExecutionError {
 	return &operationExecutionError{
-		kind:    ErrKindInvalidGru,
-		message: fmt.Sprintf(format, args...),
+		kind: ErrKindInvalidGru,
 		formattedMessage: `The GRU could not be validated. Maestro could not wait for game room to be ready,
 		either the room is not sending the "ready" ping correctly or it is taking too long to respond. Please check if
 		the GRU image is stable, or if roomInitializationTimeoutMillis configuration value needs to be increased, 
 		and try again.`,
+		err: err,
 	}
 }
 
-func NewErrReadyPingTimeout(format string, args ...interface{}) *operationExecutionError {
+func NewErrReadyPingTimeout(err error) *operationExecutionError {
 	return &operationExecutionError{
-		kind:    ErrKindReadyPingTimeout,
-		message: fmt.Sprintf(format, args...),
+		kind: ErrKindReadyPingTimeout,
 		formattedMessage: `Got timeout while waiting room status to be ready. Please check if 
 		roomInitializationTimeoutMillis configuration value needs to be increased.`,
+		err: err,
 	}
 }

--- a/internal/core/operations/executor.go
+++ b/internal/core/operations/executor.go
@@ -34,10 +34,10 @@ type Executor interface {
 	// Execute is where the operation logic will live; it will receive a context
 	// that will be used for deadline and cancellation. This function has only
 	// one return which is the operation error (if any);
-	Execute(ctx context.Context, op *operation.Operation, definition Definition) error
+	Execute(ctx context.Context, op *operation.Operation, definition Definition) ExecutionError
 	// Rollback is called if Execute returns an error. This will be used
 	// for operations that need to do some cleanup or any process if it fails.
-	Rollback(ctx context.Context, op *operation.Operation, definition Definition, executeErr error) error
+	Rollback(ctx context.Context, op *operation.Operation, definition Definition, executeErr ExecutionError) error
 	// Name returns the executor name. This is used to identify a executor for a
 	// definition.
 	Name() string

--- a/internal/core/operations/mock/executor.go
+++ b/internal/core/operations/mock/executor.go
@@ -37,10 +37,10 @@ func (m *MockExecutor) EXPECT() *MockExecutorMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
+func (m *MockExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) operations.ExecutionError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", ctx, op, definition)
-	ret0, _ := ret[0].(error)
+	ret0, _ := ret[0].(operations.ExecutionError)
 	return ret0
 }
 
@@ -65,7 +65,7 @@ func (mr *MockExecutorMockRecorder) Name() *gomock.Call {
 }
 
 // Rollback mocks base method.
-func (m *MockExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (m *MockExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr operations.ExecutionError) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Rollback", ctx, op, definition, executeErr)
 	ret0, _ := ret[0].(error)

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
 
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -109,7 +109,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Execute(ctx context.Context, op *op
 	return nil
 }
 
-func (ex *CreateNewSchedulerVersionExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (ex *CreateNewSchedulerVersionExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr operations.ExecutionError) error {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -95,9 +95,8 @@ func (ex *CreateNewSchedulerVersionExecutor) Execute(ctx context.Context, op *op
 			validationErr := fmt.Errorf("error creating new game room for validating new version: %w", err)
 			if errors.Is(err, serviceerrors.ErrGameRoomStatusWaitingTimeout) {
 				return operations.NewErrInvalidGru(validationErr)
-			} else {
-				return operations.NewErrUnexpected(validationErr)
 			}
+			return operations.NewErrUnexpected(validationErr)
 		}
 	}
 	err = ex.createNewSchedulerVersionAndEnqueueSwitchVersionOp(ctx, newScheduler, logger, isSchedulerMajorVersion)

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -25,6 +25,8 @@ package newschedulerversion_test
 import (
 	"context"
 	"fmt"
+	"github.com/topfreegames/maestro/internal/core/operations"
+	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
 	"testing"
 
 	"github.com/topfreegames/maestro/internal/core/operations/add_rooms"
@@ -83,7 +85,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.NoError(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("should succeed - major version update, game room is valid, greatest major version is v3, returns no error -> enqueue switch active version op", func(t *testing.T) {
@@ -122,7 +124,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.NoError(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("should succeed - major version update, game room is valid, greatest major version is the current one, returns no error -> enqueue switch active version op", func(t *testing.T) {
@@ -161,7 +163,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.NoError(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("should succeed - major version update, game room is valid, fail to delete validation room, returns no error -> enqueue switch active version op", func(t *testing.T) {
@@ -200,7 +202,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.NoError(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("should fail - major version update, game room is valid, fail when loading scheduler versions -> returns error, don't create new version/switch to it", func(t *testing.T) {
@@ -225,7 +227,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.EqualError(t, result, "failed to calculate new major version: failed to load scheduler versions: some_error")
+		require.NotNil(t, result)
+		require.Equal(t, result.Kind(), operations.ErrKindUnexpected)
+		require.EqualError(t, result.Error(), "failed to calculate new major version: failed to load scheduler versions: some_error")
 	})
 
 	t.Run("should fail - major version update, game room is valid, fail parsing scheduler versions -> returns error, don't create new version/switch to it", func(t *testing.T) {
@@ -251,10 +255,12 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.EqualError(t, result, "failed to calculate new major version: failed to parse scheduler version v-----: Invalid Semantic Version")
+		require.NotNil(t, result)
+		require.Equal(t, result.Kind(), operations.ErrKindUnexpected)
+		require.EqualError(t, result.Error(), "failed to calculate new major version: failed to parse scheduler version v-----: Invalid Semantic Version")
 	})
 
-	t.Run("should fail - major version update, game room is invalid -> returns error, don't create new version/switch to it", func(t *testing.T) {
+	t.Run("should fail - major version update, game room is invalid, timeout error -> returns error, don't create new version/switch to it", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		currentActiveScheduler := newValidSchedulerWithImageVersion("image-v1")
@@ -282,7 +288,42 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.EqualError(t, result, "error creating new game room for validating new version: some error")
+		require.NotNil(t, result)
+		require.Equal(t, result.Kind(), operations.ErrKindUnexpected)
+		require.EqualError(t, result.Error(), "error creating new game room for validating new version: some error")
+	})
+
+	t.Run("should fail - major version update, game room is invalid, unexpected error-> returns error, don't create new version/switch to it", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		currentActiveScheduler := newValidSchedulerWithImageVersion("image-v1")
+		newScheduler := *newValidSchedulerWithImageVersion("image-v2")
+		op := &operation.Operation{
+			ID:             "123",
+			Status:         operation.StatusInProgress,
+			DefinitionName: newschedulerversion.OperationName,
+			SchedulerName:  newScheduler.Name,
+		}
+		operationDef := &newschedulerversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		roomManager := mockports.NewMockRoomManager(mockCtrl)
+		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
+		executor := newschedulerversion.NewExecutor(roomManager, schedulerManager)
+		schedulerVersions := []*entities.SchedulerVersion{{Version: "v2.0.0"}, {Version: "v3.1.0"}, {Version: "v1.2.0"}}
+
+		newSchedulerWithNewVersion := newScheduler
+		newSchedulerWithNewVersion.Spec.Version = "v2.0.0"
+		newSchedulerWithNewVersion.RollbackVersion = "v1.0.0"
+
+		roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), true).Return(nil, nil, serviceerrors.NewErrGameRoomStatusWaitingTimeout("some error"))
+
+		schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), newScheduler.Name).Return(currentActiveScheduler, nil)
+		schedulerManager.EXPECT().GetSchedulerVersions(gomock.Any(), newScheduler.Name).Return(schedulerVersions, nil)
+
+		result := executor.Execute(context.Background(), op, operationDef)
+
+		require.NotNil(t, result)
+		require.Equal(t, result.Kind(), operations.ErrKindInvalidGru)
+		require.EqualError(t, result.Error(), "error creating new game room for validating new version: some error")
 	})
 
 	t.Run("should succeed - given a minor version update it, when the greatest minor version is v1.0 returns no error and enqueue switch active version op", func(t *testing.T) {
@@ -318,7 +359,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.NoError(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("should succeed - given a minor version update it, when the greatest minor version is v1.5 returns no error and enqueue switch active version op", func(t *testing.T) {
@@ -354,7 +395,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.NoError(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("should succeed - given a minor version update it, when the greatest minor version is the current one returns no error and enqueue switch active version op", func(t *testing.T) {
@@ -390,7 +431,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.NoError(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("should fail - minor version update, fail when loading scheduler versions -> returns error, don't create new version/switch to it", func(t *testing.T) {
@@ -415,7 +456,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.EqualError(t, result, "failed to calculate new minor version: failed to load scheduler versions: some_error")
+		require.NotNil(t, result)
+		require.Equal(t, result.Kind(), operations.ErrKindUnexpected)
+		require.EqualError(t, result.Error(), "failed to calculate new minor version: failed to load scheduler versions: some_error")
 	})
 
 	t.Run("should fail - minor version update, fail parsing scheduler versions -> returns error, don't create new version/switch to it", func(t *testing.T) {
@@ -441,7 +484,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.EqualError(t, result, "failed to calculate new minor version: failed to parse scheduler version v-----: Invalid Semantic Version")
+		require.NotNil(t, result)
+		require.Equal(t, result.Kind(), operations.ErrKindUnexpected)
+		require.EqualError(t, result.Error(), "failed to calculate new minor version: failed to parse scheduler version v-----: Invalid Semantic Version")
 	})
 
 	t.Run("should fail - valid scheduler, error occurs (creating new version in db or enqueueing switch op) -> returns error, don't create new version/switch to it", func(t *testing.T) {
@@ -473,7 +518,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.EqualError(t, result, "error creating new scheduler version in db: some_error")
+		require.NotNil(t, result)
+		require.Equal(t, result.Kind(), operations.ErrKindUnexpected)
+		require.EqualError(t, result.Error(), "error creating new scheduler version in db: some_error")
 	})
 
 	t.Run("should fail - valid scheduler, some error occurs (retrieving current active scheduler), returns error, don't create new version", func(t *testing.T) {
@@ -499,7 +546,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.EqualError(t, result, "error getting active scheduler: some_error")
+		require.NotNil(t, result)
+		require.Equal(t, result.Kind(), operations.ErrKindUnexpected)
+		require.EqualError(t, result.Error(), "error getting active scheduler: some_error")
 	})
 
 	t.Run("should fail - valid scheduler when provided operation definition != CreateNewSchedulerVersionDefinition, returns error, don't create new version", func(t *testing.T) {
@@ -523,7 +572,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.EqualError(t, result, "invalid operation definition for create_new_scheduler_version operation")
+		require.NotNil(t, result)
+		require.Equal(t, result.Kind(), operations.ErrKindUnexpected)
+		require.EqualError(t, result.Error(), "invalid operation definition for create_new_scheduler_version operation")
 	})
 
 	t.Run("given a invalid scheduler when the version parse fails it returns error and don't create new version", func(t *testing.T) {
@@ -549,7 +600,9 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 		result := executor.Execute(context.Background(), op, operationDef)
 
-		require.EqualError(t, result, "failed to parse scheduler current version: Invalid Semantic Version")
+		require.NotNil(t, result)
+		require.Equal(t, result.Kind(), operations.ErrKindUnexpected)
+		require.EqualError(t, result.Error(), "failed to parse scheduler current version: Invalid Semantic Version")
 	})
 
 }
@@ -579,7 +632,7 @@ func TestCreateNewSchedulerVersionExecutor_Rollback(t *testing.T) {
 		roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil)
 		result := executor.Rollback(context.Background(), op, operationDef, nil)
 
-		require.NoError(t, result)
+		require.Nil(t, result)
 	})
 
 	t.Run("when some game room were created during execution, it returns error if some error occur in deleting the game room", func(t *testing.T) {
@@ -621,7 +674,7 @@ func TestCreateNewSchedulerVersionExecutor_Rollback(t *testing.T) {
 		executor := newschedulerversion.NewExecutor(roomManager, schedulerManager)
 		result := executor.Rollback(context.Background(), op, operationDef, nil)
 
-		require.NoError(t, result)
+		require.Nil(t, result)
 	})
 
 }

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -25,9 +25,10 @@ package newschedulerversion_test
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/topfreegames/maestro/internal/core/operations"
 	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
-	"testing"
 
 	"github.com/topfreegames/maestro/internal/core/operations/add_rooms"
 	"github.com/topfreegames/maestro/internal/core/ports/errors"

--- a/internal/core/operations/remove_rooms/remove_rooms_executor.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor.go
@@ -72,9 +72,8 @@ func (e *RemoveRoomsExecutor) Execute(ctx context.Context, op *operation.Operati
 
 			if errors.Is(err, serviceerrors.ErrGameRoomStatusWaitingTimeout) {
 				return operations.NewErrTerminatingPingTimeout(deleteErr)
-			} else {
-				return operations.NewErrUnexpected(deleteErr)
 			}
+			return operations.NewErrUnexpected(deleteErr)
 		}
 	}
 

--- a/internal/core/operations/remove_rooms/remove_rooms_executor.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor.go
@@ -26,8 +26,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
 	"sync"
+
+	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
 
 	"github.com/topfreegames/maestro/internal/core/logs"
 	"github.com/topfreegames/maestro/internal/core/ports"

--- a/internal/core/operations/remove_rooms/remove_rooms_executor.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor.go
@@ -82,7 +82,7 @@ func (e *RemoveRoomsExecutor) Execute(ctx context.Context, op *operation.Operati
 	return nil
 }
 
-func (e *RemoveRoomsExecutor) Rollback(_ context.Context, _ *operation.Operation, _ operations.Definition, _ error) error {
+func (e *RemoveRoomsExecutor) Rollback(_ context.Context, _ *operation.Operation, _ operations.Definition, _ operations.ExecutionError) error {
 	return nil
 }
 

--- a/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
@@ -28,9 +28,10 @@ package remove_rooms
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/topfreegames/maestro/internal/core/operations"
 	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
-	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -46,6 +46,8 @@ type SwitchActiveVersionExecutor struct {
 	newCreatedRoomsLock sync.Mutex
 }
 
+var _ operations.Executor = (*SwitchActiveVersionExecutor)(nil)
+
 func NewExecutor(roomManager ports.RoomManager, schedulerManager ports.SchedulerManager) *SwitchActiveVersionExecutor {
 	// TODO(caio.rodrigues): change map to store a list of ids (less memory used)
 	newCreatedRoomsMap := make(map[string][]*game_room.GameRoom)
@@ -67,7 +69,7 @@ func NewExecutor(roomManager ports.RoomManager, schedulerManager ports.Scheduler
 // 3. List all game rooms that need to be replaced and produce them into the
 //    replace goroutines channel;
 // 4. Switch the active version
-func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
+func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) operations.ExecutionError {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, definition.Name()),
@@ -77,31 +79,31 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 
 	updateDefinition, ok := definition.(*SwitchActiveVersionDefinition)
 	if !ok {
-		return fmt.Errorf("the definition is invalid. Should be type SwitchActiveVersionDefinition")
+		return operations.NewErrUnexpected(fmt.Errorf("the definition is invalid. Should be type SwitchActiveVersionDefinition"))
 	}
 
 	scheduler, err := ex.schedulerManager.GetSchedulerByVersion(ctx, op.SchedulerName, updateDefinition.NewActiveVersion)
 	if err != nil {
 		logger.Error("error fetching scheduler to be switched to", zap.Error(err))
-		return err
+		return operations.NewErrUnexpected(err)
 	}
 
 	replacePods, err := ex.shouldReplacePods(ctx, scheduler)
 	if err != nil {
 		logger.Error("error deciding if should replace pods", zap.Error(err))
-		return err
+		return operations.NewErrUnexpected(err)
 	}
 
 	if replacePods {
 		maxSurgeNum, err := ex.roomManager.SchedulerMaxSurge(ctx, scheduler)
 		if err != nil {
-			return fmt.Errorf("error fetching scheduler max surge: %w", err)
+			return operations.NewErrUnexpected(fmt.Errorf("error fetching scheduler max surge: %w", err))
 		}
 
 		err = ex.startReplaceRoomsLoop(ctx, logger, maxSurgeNum, *scheduler)
 		if err != nil {
 			logger.Sugar().Errorf("replace rooms failed for scheduler \"%v\" with error \"%v\"", scheduler.Name, zap.Error(err))
-			return err
+			return operations.NewErrUnexpected(err)
 		}
 	}
 
@@ -109,7 +111,7 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 	err = ex.schedulerManager.UpdateScheduler(ctx, scheduler)
 	if err != nil {
 		logger.Error("Error switching active scheduler version on scheduler manager")
-		return err
+		return operations.NewErrUnexpected(err)
 	}
 
 	ex.clearNewCreatedRooms(op.SchedulerName)

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -119,7 +119,7 @@ func (ex *SwitchActiveVersionExecutor) Execute(ctx context.Context, op *operatio
 	return nil
 }
 
-func (ex *SwitchActiveVersionExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (ex *SwitchActiveVersionExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr operations.ExecutionError) error {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, definition.Name()),

--- a/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
@@ -26,9 +26,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/topfreegames/maestro/internal/core/operations"
 	"testing"
 	"time"
+
+	"github.com/topfreegames/maestro/internal/core/operations"
 
 	"github.com/topfreegames/maestro/internal/core/ports"
 

--- a/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/topfreegames/maestro/internal/core/operations"
 	"testing"
 	"time"
 
@@ -128,8 +129,8 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.schedulerManager.EXPECT().UpdateScheduler(gomock.Any(), newMajorScheduler).Return(nil)
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
-		require.NoError(t, err)
+		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
+		require.Nil(t, execErr)
 	})
 
 	t.Run("should succeed - Execute switch active version operation not replacing pods", func(t *testing.T) {
@@ -141,8 +142,8 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.schedulerManager.EXPECT().UpdateScheduler(gomock.Any(), gomock.Any()).Return(nil)
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMinorScheduler.Name}, noReplaceDefinition)
-		require.NoError(t, err)
+		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMinorScheduler.Name}, noReplaceDefinition)
+		require.Nil(t, execErr)
 	})
 
 	t.Run("should succeed - Execute switch active version operation (no running rooms)", func(t *testing.T) {
@@ -159,8 +160,8 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.schedulerManager.EXPECT().UpdateScheduler(gomock.Any(), gomock.Any()).Return(nil)
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.Execute(context.Background(), &operation.Operation{SchedulerName: activeScheduler.Name}, definition)
-		require.NoError(t, err)
+		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: activeScheduler.Name}, definition)
+		require.Nil(t, execErr)
 	})
 
 	t.Run("should fail - Can't update scheduler (switch active version on database)", func(t *testing.T) {
@@ -172,8 +173,9 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.schedulerManager.EXPECT().UpdateScheduler(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMinorScheduler.Name}, noReplaceDefinition)
-		require.Error(t, err)
+		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMinorScheduler.Name}, noReplaceDefinition)
+		require.NotNil(t, execErr)
+		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 	})
 
 	t.Run("should fail - Can't create room", func(t *testing.T) {
@@ -201,8 +203,9 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("error")).MaxTimes(maxSurge)
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
-		require.Error(t, err)
+		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
+		require.NotNil(t, execErr)
+		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 	})
 
 	t.Run("should fail - Can't delete room", func(t *testing.T) {
@@ -231,8 +234,9 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(errors.New("error")).MaxTimes(maxSurge)
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
-		require.Error(t, err)
+		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
+		require.NotNil(t, execErr)
+		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 	})
 
 	t.Run("should fail - Can't find max surge", func(t *testing.T) {
@@ -244,8 +248,9 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.schedulerManager.EXPECT().GetSchedulerByVersion(gomock.Any(), newMajorScheduler.Name, newMajorScheduler.Spec.Version).Return(newMajorScheduler, nil)
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
-		require.Error(t, err)
+		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
+		require.NotNil(t, execErr)
+		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 	})
 
 	t.Run("should fail - Can't list rooms to delete", func(t *testing.T) {
@@ -260,8 +265,9 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.roomManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
-		require.Error(t, err)
+		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
+		require.NotNil(t, execErr)
+		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 	})
 
 	t.Run("should fail - Can't get new scheduler", func(t *testing.T) {
@@ -271,8 +277,9 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.schedulerManager.EXPECT().GetSchedulerByVersion(gomock.Any(), newMajorScheduler.Name, newMajorScheduler.Spec.Version).Return(nil, errors.New("error"))
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
-		require.Error(t, err)
+		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
+		require.NotNil(t, execErr)
+		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 	})
 
 	t.Run("should fail - Can't get active scheduler", func(t *testing.T) {
@@ -283,8 +290,9 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), activeScheduler.Name).Return(nil, errors.New("error"))
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
-		err = executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
-		require.Error(t, err)
+		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
+		require.NotNil(t, execErr)
+		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 	})
 }
 
@@ -369,8 +377,9 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 			SchedulerName:  newMajorScheduler.Name,
 			CreatedAt:      time.Now(),
 		}
-		err = executor.Execute(context.Background(), op, definition)
-		require.Error(t, err)
+		execErr := executor.Execute(context.Background(), op, definition)
+		require.NotNil(t, execErr)
+		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 
 		for range append(gameRoomListCycle1, gameRoomListCycle2...) {
 			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(nil)
@@ -431,8 +440,9 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 			SchedulerName:  newMajorScheduler.Name,
 			CreatedAt:      time.Now(),
 		}
-		err = executor.Execute(context.Background(), op, definition)
-		require.Error(t, err)
+		execErr := executor.Execute(context.Background(), op, definition)
+		require.NotNil(t, execErr)
+		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 
 		mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminated(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 

--- a/internal/core/operations/test_operation/test_operation_executor.go
+++ b/internal/core/operations/test_operation/test_operation_executor.go
@@ -33,11 +33,13 @@ import (
 
 type TestOperationExecutor struct{}
 
+var _ operations.Executor = (*TestOperationExecutor)(nil)
+
 func NewExecutor() *TestOperationExecutor {
 	return &TestOperationExecutor{}
 }
 
-func (e *TestOperationExecutor) Execute(ctx context.Context, _op *operation.Operation, definition operations.Definition) error {
+func (e *TestOperationExecutor) Execute(ctx context.Context, _op *operation.Operation, definition operations.Definition) operations.ExecutionError {
 	testOperationDefinition := definition.(*TestOperationDefinition)
 
 	zap.L().Sugar().Infof("sleeping routine for %d seconds", testOperationDefinition.SleepSeconds)
@@ -47,7 +49,7 @@ func (e *TestOperationExecutor) Execute(ctx context.Context, _op *operation.Oper
 	case <-ticker.C:
 
 	case <-ctx.Done():
-		return ctx.Err()
+		return operations.NewErrUnexpected(ctx.Err())
 	}
 
 	zap.L().Sugar().Infof("routine slept for %d seconds", testOperationDefinition.SleepSeconds)

--- a/internal/core/operations/test_operation/test_operation_executor.go
+++ b/internal/core/operations/test_operation/test_operation_executor.go
@@ -58,7 +58,7 @@ func (e *TestOperationExecutor) Execute(ctx context.Context, _op *operation.Oper
 }
 
 // Rollback will do nothing.
-func (e *TestOperationExecutor) Rollback(_ context.Context, _ *operation.Operation, _ operations.Definition, _ error) error {
+func (e *TestOperationExecutor) Rollback(_ context.Context, _ *operation.Operation, _ operations.Definition, _ operations.ExecutionError) error {
 	return nil
 }
 

--- a/internal/core/services/errors/errors.go
+++ b/internal/core/services/errors/errors.go
@@ -1,0 +1,72 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package errors
+
+import "fmt"
+
+type errorKind int
+
+const (
+	errGameRoomStatusWaitingTimeout errorKind = iota
+)
+
+var (
+	ErrGameRoomStatusWaitingTimeout = &serviceError{kind: errGameRoomStatusWaitingTimeout}
+)
+
+type serviceError struct {
+	kind    errorKind
+	message string
+	err     error
+}
+
+func (e *serviceError) Error() string {
+	if e.err == nil {
+		return e.message
+	}
+	if e.message == "" {
+		return e.err.Error()
+	}
+
+	return fmt.Sprintf("%s: %s", e.message, e.err)
+}
+
+func (e *serviceError) Is(other error) bool {
+	if err, ok := other.(*serviceError); ok {
+		return e.kind == err.kind
+	}
+
+	return false
+}
+
+func (e *serviceError) WithError(err error) *serviceError {
+	e.err = err
+	return e
+}
+
+func NewErrGameRoomStatusWaitingTimeout(format string, args ...interface{}) *serviceError {
+	return &serviceError{
+		kind:    errGameRoomStatusWaitingTimeout,
+		message: fmt.Sprintf(format, args...),
+	}
+}

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -32,6 +32,8 @@ import (
 	"sync"
 	"time"
 
+	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
+
 	"github.com/topfreegames/maestro/internal/core/entities/events"
 	"github.com/topfreegames/maestro/internal/core/logs"
 
@@ -41,7 +43,6 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 	"github.com/topfreegames/maestro/internal/core/ports"
 	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
-	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
 )
 
 const (
@@ -124,7 +125,7 @@ func (m *RoomManager) CreateRoomAndWaitForReadiness(ctx context.Context, schedul
 
 	if err != nil {
 		_ = m.DeleteRoomAndWaitForRoomTerminated(ctx, room)
-		return nil, nil, serviceerrors.NewErrGameRoomStatusWaitingTimeout("").WithError(err)
+		return nil, nil, err
 	}
 
 	return room, instance, err
@@ -147,11 +148,7 @@ func (m *RoomManager) DeleteRoomAndWaitForRoomTerminated(ctx context.Context, ga
 	timeoutContext, cancelFunc := context.WithTimeout(ctx, duration)
 	defer cancelFunc()
 	err = m.WaitRoomStatus(timeoutContext, gameRoom, game_room.GameStatusTerminating)
-	if err != nil {
-		return serviceerrors.NewErrGameRoomStatusWaitingTimeout("").WithError(err)
-	}
-
-	return nil
+	return err
 }
 
 func (m *RoomManager) UpdateRoom(ctx context.Context, gameRoom *game_room.GameRoom) error {
@@ -369,7 +366,11 @@ watchLoop:
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to wait until room has desired status: %s, reason: %w", status, err)
+		waitErr := fmt.Errorf("failed to wait until room has desired status: %s, reason: %w", status, err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			return serviceerrors.NewErrGameRoomStatusWaitingTimeout("").WithError(waitErr)
+		}
+		return waitErr
 	}
 
 	return nil

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -129,14 +129,14 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any())
 		operationManager.EXPECT().StartLeaseRenewGoRoutine(gomock.Any(), expectedOperation)
 
-		executionErr := fmt.Errorf("some execution error")
+		executionErr := operations.NewErrUnexpected(fmt.Errorf("some execution error"))
 		operationExecutor.EXPECT().Execute(gomock.Any(), expectedOperation, operationDefinition).Return(executionErr)
 		operationExecutor.EXPECT().Rollback(gomock.Any(), expectedOperation, operationDefinition, executionErr).Do(
 			func(ctx, operation, definition, executeErr interface{}) {
 				time.Sleep(time.Second * 1)
 			},
 		).Return(nil)
-		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation execution failed, reason: some execution error")
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation execution failed : Unexpected Error: some execution error - Contact the Maestro's responsible team for helping troubleshoot.")
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation rollback flow execution finished with success")
 
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)


### PR DESCRIPTION
## What ❓ 
Create custom errors for operation execution and services. Use a formatted error message when populating operation execution history with possible errors.

## Why 🤔 
Currently, we are not formatting error messages that are appended in the operation execution history, this behavior makes the user experience worse for understanding and dealing with the problem.