### PR TITLE
Enhance index documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,22 @@
+<img align="right" width="300" height="260" src="./images/gopher-maestro.png">
 # Overview
-Describe Maestro NEXT purpose.
-What it does, and the problem it solves.
+Maestro is a game room orchestration system. Each game room is a match execution context and a group of game rooms is organized in a Scheduler. Each time that a user requires some change in the Scheduler or game room, Maestro creates an Operation that is a change unit that will be enqueued and handled sequentially by a proper worker related exclusively to its respective Scheduler, in other words, each Scheduler has a worker that sequentialy handles Operations that is created to it.
+
+A Scheduler defines the requirements of a game room as to how much memory and CPU it will need to execute and other information.
+
+Each Operation has its own properties to be executed.
+
+Maestro has four components: Management API, Game Rooms API, Execution Worker, Runtime Watcher and Metrics Reporter. They all deliver together the Maestro features that will be described in the next sections.
 
 ## Features & Components
 
-TBD: Short list of the features or elements that the user needs to know to make the best of your application, with a short description.
-For details on how to use it, please use the Developers and User guides.
+Maestro is composed by:
+
+- *Management API:* this is the component that the users will use to create your requests to interact with Maestro. For example: create a Scheduler, get Scheduler information, etc.
+- *Execution Worker:* have an execution component to handle Operations to each Scheduler. For example: three Schedulers will have each one an execution component.
+- *Game Rooms API*: game rooms API expose an HTTP API to receive from game rooms messages that symbolize their respective status. For example: when a game room is ready to receive matches it will send a message informing that.
+- *Runtime Watcher:* is a component in Maestro that listen to Runtime events and reflect them in Maestro. For example: when a game room was created it caths this event and creates it in the maestro.
+- *Metrics Reporter:* time spaced this component query the Runtime for metrics related to rooms and expose them in an open metrics route. For example: how many occupied rooms and ready rooms are up.
 
 ## Support & Community
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 <img align="right" width="300" height="260" src="./images/gopher-maestro.png">
 # Overview
-Maestro is a game room orchestration system. Each game room is a match execution context and a group of game rooms is organized in a Scheduler. Each time that a user requires some change in the Scheduler or game room, Maestro creates an Operation that is a change unit that will be enqueued and handled sequentially by a proper worker related exclusively to its respective Scheduler, in other words, each Scheduler has a worker that sequentialy handles Operations that is created to it.
+Maestro is a game room orchestration system, which can be used by multiplayer games to manage the scalability of its game rooms (Aka game servers). Ideally, Maestro should be used by games that implement [dedicated game server](https://docs-multiplayer.unity3d.com/docs/reference/glossary/network-topologies/index.html#dedicated-game-server-dgs) (dgs) architecture. Each game room is a dedicated game server that runs in a match execution context, a group of game rooms is organized in a **Scheduler**. Each time that a user requires some change in the Scheduler or game room, Maestro creates an Operation that is a change unit that will be enqueued and handled sequentially by a proper worker related exclusively to its respective Scheduler, in other words, each Scheduler has a worker that sequentially handles Operations that is created to it.
 
 A Scheduler defines the requirements of a game room as to how much memory and CPU it will need to execute and other information.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Maestro is composed by:
 
 - *Management API:* this is the component that the users will use to create your requests to interact with Maestro. For example: create a Scheduler, get Scheduler information, etc.
 - *Execution Worker:* have an execution component to handle Operations to each Scheduler. For example: three Schedulers will have each one an execution component.
-- *Game Rooms API*: game rooms API expose an HTTP API to receive from game rooms messages that symbolize their respective status. For example: when a game room is ready to receive matches it will send a message informing that.
+- *Game Rooms API*: game rooms API expose an HTTP API or a GRPc service to receive game rooms messages that symbolize their respective status. For example: when a game room is ready to receive matches it will send a message informing that.
 - *Runtime Watcher:* is a component in Maestro that listen to Runtime events and reflect them in Maestro. For example: when a game room was created it is notified that this event happened.
 - *Metrics Reporter:* time spaced this component query the Runtime for metrics related to rooms and expose them in an open metrics route. For example: how many occupied rooms and ready rooms are up.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ A Scheduler defines the requirements of a game room as to how much memory and CP
 
 Each Operation has its own properties to be executed.
 
-Maestro has four components: Management API, Game Rooms API, Execution Worker, Runtime Watcher and Metrics Reporter. They all deliver together the Maestro features that will be described in the next sections.
+Maestro has five components: Management API, Game Rooms API, Execution Worker, Runtime Watcher and Metrics Reporter. They all deliver together the Maestro features that will be described in the next sections.
 
 ## Features & Components
 
@@ -15,7 +15,7 @@ Maestro is composed by:
 - *Management API:* this is the component that the users will use to create your requests to interact with Maestro. For example: create a Scheduler, get Scheduler information, etc.
 - *Execution Worker:* have an execution component to handle Operations to each Scheduler. For example: three Schedulers will have each one an execution component.
 - *Game Rooms API*: game rooms API expose an HTTP API to receive from game rooms messages that symbolize their respective status. For example: when a game room is ready to receive matches it will send a message informing that.
-- *Runtime Watcher:* is a component in Maestro that listen to Runtime events and reflect them in Maestro. For example: when a game room was created it caths this event and creates it in the maestro.
+- *Runtime Watcher:* is a component in Maestro that listen to Runtime events and reflect them in Maestro. For example: when a game room was created it is notified that this event happened.
 - *Metrics Reporter:* time spaced this component query the Runtime for metrics related to rooms and expose them in an open metrics route. For example: how many occupied rooms and ready rooms are up.
 
 ## Support & Community

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - Developers: 'Developers.md'
   - Architecture: 'Architecture.md'
   - OpenAPI: 'OpenAPI.md'
+  - Operations: 'Operations.md'
   - Guidelines: 'Guidelines.md'
 
 


### PR DESCRIPTION
### Why
Maestro index doc has no information about it. That decreases the user experience when reading the docs.

### What
- Add a quick description of Maestro in the `Index.md`
- Add `gopher-maestro` logo in the index.