### PR TITLE
Remove error log when cancelation was called

### DIFF
--- a/internal/core/operations/errors.go
+++ b/internal/core/operations/errors.go
@@ -22,7 +22,11 @@
 
 package operations
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"strings"
+)
 
 type errorKind int
 
@@ -44,6 +48,7 @@ type ExecutionError interface {
 	Kind() errorKind
 	FormattedMessage() string
 	Error() error
+	IsContextCanceled() bool
 }
 
 type operationExecutionError struct {
@@ -62,6 +67,10 @@ func (e *operationExecutionError) Kind() errorKind {
 
 func (e *operationExecutionError) FormattedMessage() string {
 	return e.formattedMessage
+}
+
+func (e *operationExecutionError) IsContextCanceled() bool {
+	return strings.Contains(e.err.Error(), context.Canceled.Error())
 }
 
 func NewErrUnexpected(err error) *operationExecutionError {

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -160,7 +160,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 				op.Status = operation.StatusCanceled
 
 				loopLogger.Info("operation execution canceled")
-				w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Canceling operation")
+				w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Operation canceled by the user")
 			} else {
 				op.Status = operation.StatusError
 
@@ -168,6 +168,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 				w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, fmt.Sprintf("Operation execution failed : %s", executionErr.FormattedMessage()))
 			}
 
+			w.operationManager.AppendOperationEventToExecutionHistory(ctx, op, "Starting operation rollback")
 			rollbackErr := w.executeRollbackCollectingLatencyMetrics(op.DefinitionName, func() error {
 				return executor.Rollback(w.workerContext, op, def, executionErr)
 			})

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -137,6 +137,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 			},
 		).Return(nil)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation execution failed : Unexpected Error: some execution error - Contact the Maestro's responsible team for helping troubleshoot.")
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Starting operation rollback")
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation rollback flow execution finished with success")
 
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
@@ -192,7 +193,8 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 				time.Sleep(time.Second * 1)
 			},
 		).Return(nil)
-		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Canceling operation")
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation canceled by the user")
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Starting operation rollback")
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation rollback flow execution finished with success")
 
 		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -152,6 +152,62 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		require.False(t, workerService.IsRunning())
 	})
 
+	t.Run("execute Rollback when a Execute was canceled", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		operationName := "test_operation"
+		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
+		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
+		operationManager := mock.NewMockOperationManager(mockCtrl)
+		operationExecutor.EXPECT().Name().Return(operationName).AnyTimes()
+		operationDefinition.EXPECT().Name().Return(operationName).AnyTimes()
+
+		defFunc := func() operations.Definition { return operationDefinition }
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[operationName] = defFunc
+
+		scheduler := &entities.Scheduler{Name: "random-scheduler"}
+		expectedOperation := &operation.Operation{
+			ID:             "random-operation-id",
+			SchedulerName:  scheduler.Name,
+			Status:         operation.StatusPending,
+			DefinitionName: operationName,
+		}
+
+		executors := map[string]operations.Executor{}
+		executors[operationName] = operationExecutor
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+
+		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(expectedOperation, operationDefinition, nil)
+		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Starting operation")
+		operationManager.EXPECT().GrantLease(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().StartOperation(gomock.Any(), expectedOperation, gomock.Any())
+		operationManager.EXPECT().StartLeaseRenewGoRoutine(gomock.Any(), expectedOperation)
+
+		executionErr := operations.NewErrUnexpected(fmt.Errorf("some execution error: %s", context.Canceled.Error()))
+		operationExecutor.EXPECT().Execute(gomock.Any(), expectedOperation, operationDefinition).Return(executionErr)
+		operationExecutor.EXPECT().Rollback(gomock.Any(), expectedOperation, operationDefinition, executionErr).Do(
+			func(ctx, operation, definition, executeErr interface{}) {
+				time.Sleep(time.Second * 1)
+			},
+		).Return(nil)
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Canceling operation")
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation rollback flow execution finished with success")
+
+		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().RevokeLease(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation finished")
+		// Ends the worker by cancelling it
+		operationManager.EXPECT().NextSchedulerOperation(gomock.Any(), expectedOperation.SchedulerName).Return(nil, nil, context.Canceled)
+
+		err := workerService.Start(context.Background())
+		require.NoError(t, err)
+
+		workerService.Stop(context.Background())
+		require.False(t, workerService.IsRunning())
+	})
+
 	t.Run("evict operation if there is no executor", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 


### PR DESCRIPTION
### Why
When one operation was canceled it add an error to the operation execution history.

### What
This PR proposes:
- Change the cancel message
- Remove the error when an operation was canceled
- Add an rollback start message