### PR TITLE
Make e2e tests run in parallel

### DIFF
--- a/e2e/suites/management/add_rooms_test.go
+++ b/e2e/suites/management/add_rooms_test.go
@@ -43,6 +43,8 @@ import (
 )
 
 func TestAddRooms(t *testing.T) {
+	t.Parallel()
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 		roomsStorage := roomStorageRedis.NewRedisStateStorage(redisClient)
 

--- a/e2e/suites/management/cancel_operation_test.go
+++ b/e2e/suites/management/cancel_operation_test.go
@@ -47,6 +47,8 @@ import (
 )
 
 func TestCancelOperation(t *testing.T) {
+	t.Parallel()
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 		operationStorage := operationadapters.NewRedisOperationStorage(redisClient, timeClock.NewClock())
 		operationFlow := operationadapters.NewRedisOperationFlow(redisClient)

--- a/e2e/suites/management/create_new_scheduler_version_test.go
+++ b/e2e/suites/management/create_new_scheduler_version_test.go
@@ -152,8 +152,8 @@ func TestCreateNewSchedulerVersion(t *testing.T) {
 					},
 				},
 				PortRange: &maestroApiV1.PortRange{
-					Start: 80,
-					End:   8000,
+					Start: 40000,
+					End:   60000,
 				},
 			}
 			updateResponse := &maestroApiV1.NewSchedulerVersionResponse{}
@@ -289,8 +289,8 @@ func createMajorVersionAndAssertPodsReplace(t *testing.T, roomsBeforeUpdate []st
 			},
 		},
 		PortRange: &maestroApiV1.PortRange{
-			Start: 80,
-			End:   8000,
+			Start: 40000,
+			End:   60000,
 		},
 		Forwarders: []*maestroApiV1.Forwarder{
 			{
@@ -477,8 +477,8 @@ func createMinorVersionAndAssertNoPodsReplace(t *testing.T, kubeClient kubernete
 			},
 		},
 		PortRange: &maestroApiV1.PortRange{
-			Start: 80,
-			End:   8000,
+			Start: 40000,
+			End:   60000,
 		},
 		Forwarders: []*maestroApiV1.Forwarder{
 			{

--- a/e2e/suites/management/create_new_scheduler_version_test.go
+++ b/e2e/suites/management/create_new_scheduler_version_test.go
@@ -48,6 +48,8 @@ import (
 )
 
 func TestCreateNewSchedulerVersion(t *testing.T) {
+	t.Parallel()
+
 	game := "create-new-scheduler-version-game"
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 		t.Run("Should Succeed - create minor version, no pods replaces, create major version, all pods are changed", func(t *testing.T) {

--- a/e2e/suites/management/create_scheduler_test.go
+++ b/e2e/suites/management/create_scheduler_test.go
@@ -101,8 +101,8 @@ func TestCreateScheduler(t *testing.T) {
 					},
 				},
 				PortRange: &maestroApiV1.PortRange{
-					Start: 80,
-					End:   8000,
+					Start: 40000,
+					End:   60000,
 				},
 			}
 
@@ -173,8 +173,8 @@ func TestCreateScheduler(t *testing.T) {
 					},
 				},
 				PortRange: &maestroApiV1.PortRange{
-					Start: 80,
-					End:   8000,
+					Start: 40000,
+					End:   60000,
 				},
 			}
 

--- a/e2e/suites/management/create_scheduler_test.go
+++ b/e2e/suites/management/create_scheduler_test.go
@@ -46,6 +46,8 @@ import (
 )
 
 func TestCreateScheduler(t *testing.T) {
+	t.Parallel()
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 		t.Run("should succeed", func(t *testing.T) {
 			roomsApiAddress := maestro.RoomsApiServer.ContainerInternalAddress

--- a/e2e/suites/management/events_forwarding_test.go
+++ b/e2e/suites/management/events_forwarding_test.go
@@ -43,6 +43,8 @@ import (
 )
 
 func TestEventsForwarding(t *testing.T) {
+	t.Parallel()
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 		schedulerWithForwarderAndRooms, roomsNames := createSchedulerWithForwarderAndRooms(t, maestro, kubeClient, managementApiClient, maestro.ServerMocks.GrpcForwarderAddress)
 		schedulerWithRooms, roomNameNoForwarder := createSchedulerWithRooms(t, maestro, kubeClient, managementApiClient)

--- a/e2e/suites/management/events_forwarding_test.go
+++ b/e2e/suites/management/events_forwarding_test.go
@@ -379,7 +379,7 @@ func TestEventsForwarding(t *testing.T) {
 			}
 
 			pingResponse := &maestroApiV1.UpdateRoomWithPingResponse{}
-			err = roomsApiClient.Do("POST", fmt.Sprintf("/scheduler/%s/rooms/%s/ping", schedulerWithForwarderAndRooms.Name, roomsNames[0]), pingRequest, pingResponse)
+			err = roomsApiClient.Do("PUT", fmt.Sprintf("/scheduler/%s/rooms/%s/ping", schedulerWithForwarderAndRooms.Name, roomsNames[0]), pingRequest, pingResponse)
 			require.NoError(t, err)
 			require.Equal(t, true, pingResponse.Success)
 		})
@@ -401,7 +401,7 @@ func TestEventsForwarding(t *testing.T) {
 				},
 			}
 			pingResponse := &maestroApiV1.UpdateRoomWithPingResponse{}
-			err := roomsApiClient.Do("POST", fmt.Sprintf("/scheduler/%s/rooms/%s/ping", schedulerWithRooms.Name, roomNameNoForwarder), pingRequest, pingResponse)
+			err := roomsApiClient.Do("PUT", fmt.Sprintf("/scheduler/%s/rooms/%s/ping", schedulerWithRooms.Name, roomNameNoForwarder), pingRequest, pingResponse)
 			require.NoError(t, err)
 			require.Equal(t, true, pingResponse.Success)
 		})
@@ -438,7 +438,7 @@ func TestEventsForwarding(t *testing.T) {
 				},
 			}
 			pingResponse := &maestroApiV1.UpdateRoomWithPingResponse{}
-			err = roomsApiClient.Do("POST", fmt.Sprintf("/scheduler/%s/rooms/%s/ping", schedulerWithForwarderAndRooms.Name, roomsNames[0]), pingRequest, pingResponse)
+			err = roomsApiClient.Do("PUT", fmt.Sprintf("/scheduler/%s/rooms/%s/ping", schedulerWithForwarderAndRooms.Name, roomsNames[0]), pingRequest, pingResponse)
 			require.NoError(t, err)
 			require.Equal(t, true, pingResponse.Success)
 		})
@@ -461,7 +461,7 @@ func TestEventsForwarding(t *testing.T) {
 				},
 			}
 			pingResponse := &maestroApiV1.UpdateRoomWithPingResponse{}
-			err := roomsApiClient.Do("POST", fmt.Sprintf("/scheduler/%s/rooms/%s/ping", schedulerWithInvalidGrpc.Name, invalidGrpcRooms[0]), pingRequest, pingResponse)
+			err := roomsApiClient.Do("PUT", fmt.Sprintf("/scheduler/%s/rooms/%s/ping", schedulerWithInvalidGrpc.Name, invalidGrpcRooms[0]), pingRequest, pingResponse)
 			require.NoError(t, err)
 			require.Equal(t, true, pingResponse.Success)
 		})

--- a/e2e/suites/management/get_scheduler_test.go
+++ b/e2e/suites/management/get_scheduler_test.go
@@ -38,6 +38,8 @@ import (
 )
 
 func TestGetScheduler(t *testing.T) {
+	t.Parallel()
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 		t.Run("Should Succeed - Get scheduler without query parameter version", func(t *testing.T) {
 			t.Parallel()

--- a/e2e/suites/management/get_schedulers_info_test.go
+++ b/e2e/suites/management/get_schedulers_info_test.go
@@ -38,6 +38,8 @@ import (
 )
 
 func TestGetSchedulersInfo(t *testing.T) {
+	t.Parallel()
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 
 		firstScheduler, err := createSchedulerAndWaitForIt(

--- a/e2e/suites/management/list_operations_test.go
+++ b/e2e/suites/management/list_operations_test.go
@@ -42,6 +42,8 @@ import (
 )
 
 func TestListOperations(t *testing.T) {
+	t.Parallel()
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 		t.Run("when listing operations should return all of them with filled fields", func(t *testing.T) {
 			t.Parallel()

--- a/e2e/suites/management/list_schedulers_test.go
+++ b/e2e/suites/management/list_schedulers_test.go
@@ -38,6 +38,8 @@ import (
 )
 
 func TestListSchedulers(t *testing.T) {
+	t.Parallel()
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 
 		firstScheduler, err := createSchedulerAndWaitForIt(

--- a/e2e/suites/management/operation_lease_test.go
+++ b/e2e/suites/management/operation_lease_test.go
@@ -41,6 +41,8 @@ import (
 )
 
 func TestOperationLease(t *testing.T) {
+	t.Parallel()
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {
 		operationLeaseStorage := operationadapters.NewRedisOperationLeaseStorage(redisClient, timeClock.NewClock())
 

--- a/e2e/suites/management/remove_rooms_test.go
+++ b/e2e/suites/management/remove_rooms_test.go
@@ -44,6 +44,8 @@ import (
 )
 
 func TestRemoveRooms(t *testing.T) {
+	t.Parallel()
+
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redisV8.Client, maestro *maestro.MaestroInstance) {
 		roomsStorage := roomStorageRedis.NewRedisStateStorage(redisClient)
 

--- a/e2e/suites/management/switch_active_version_test.go
+++ b/e2e/suites/management/switch_active_version_test.go
@@ -44,6 +44,8 @@ import (
 )
 
 func TestSwitchActiveVersion(t *testing.T) {
+	t.Parallel()
+
 	game := "switch-active-version-game"
 
 	framework.WithClients(t, func(roomsApiClient *framework.APIClient, managementApiClient *framework.APIClient, kubeClient kubernetes.Interface, redisClient *redis.Client, maestro *maestro.MaestroInstance) {

--- a/e2e/suites/management/switch_active_version_test.go
+++ b/e2e/suites/management/switch_active_version_test.go
@@ -107,8 +107,8 @@ func TestSwitchActiveVersion(t *testing.T) {
 					},
 				},
 				PortRange: &maestroApiV1.PortRange{
-					Start: 80,
-					End:   8000,
+					Start: 40000,
+					End:   60000,
 				},
 			}
 			updateResponse := &maestroApiV1.NewSchedulerVersionResponse{}
@@ -266,8 +266,8 @@ func TestSwitchActiveVersion(t *testing.T) {
 					},
 				},
 				PortRange: &maestroApiV1.PortRange{
-					Start: 80,
-					End:   8000,
+					Start: 40000,
+					End:   60000,
 				},
 			}
 			updateResponse := &maestroApiV1.NewSchedulerVersionResponse{}
@@ -407,8 +407,8 @@ func TestSwitchActiveVersion(t *testing.T) {
 					},
 				},
 				PortRange: &maestroApiV1.PortRange{
-					Start: 80,
-					End:   8000,
+					Start: 40000,
+					End:   60000,
 				},
 			}
 			updateResponse := &maestroApiV1.NewSchedulerVersionResponse{}
@@ -556,8 +556,8 @@ func TestSwitchActiveVersion(t *testing.T) {
 					},
 				},
 				PortRange: &maestroApiV1.PortRange{
-					Start: 80,
-					End:   8000,
+					Start: 40000,
+					End:   60000,
 				},
 				Forwarders: forwarders,
 			}

--- a/e2e/suites/management/utils.go
+++ b/e2e/suites/management/utils.go
@@ -99,8 +99,8 @@ func createSchedulerAndWaitForIt(
 			},
 		},
 		PortRange: &maestroApiV1.PortRange{
-			Start: 80,
-			End:   8000,
+			Start: 40000,
+			End:   60000,
 		},
 	}
 
@@ -214,8 +214,8 @@ func createSchedulerWithForwardersAndWaitForIt(
 			},
 		},
 		PortRange: &maestroApiV1.PortRange{
-			Start: 80,
-			End:   8000,
+			Start: 40000,
+			End:   60000,
 		},
 		MaxSurge:   "10%",
 		Forwarders: forwarders,


### PR DESCRIPTION
## What ❓ 
Add **t.Parallel()** call in e2e tests functions 

## Why 🤔 
With the fix in the port allocation logic, we can now assure that the e2e tests intermittence will drop drastically, enabling us to run e2e tests in parallel