### PR TITLE
refactors e2e method to test getOperation endpoint

### DIFF
--- a/e2e/suites/management/utils.go
+++ b/e2e/suites/management/utils.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -322,17 +323,15 @@ func waitForOperationToFinish(t *testing.T, managementApiClient *framework.APICl
 
 func waitForOperationToFinishByOperationId(t *testing.T, managementApiClient *framework.APIClient, schedulerName, operationId string) {
 	require.Eventually(t, func() bool {
-		listOperationsRequest := &maestroApiV1.ListOperationsRequest{}
-		listOperationsResponse := &maestroApiV1.ListOperationsResponse{}
-		err := managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations", schedulerName), listOperationsRequest, listOperationsResponse)
+		getOperationRequest := &maestroApiV1.GetOperationRequest{}
+		getOperationResponse := &maestroApiV1.GetOperationResponse{}
+		err := managementApiClient.Do("GET", fmt.Sprintf("/schedulers/%s/operations/%s", schedulerName, operationId), getOperationRequest, getOperationResponse)
 		require.NoError(t, err)
 
-		if len(listOperationsResponse.FinishedOperations) >= 1 {
-			for _, _operation := range listOperationsResponse.FinishedOperations {
-				if _operation.Id == operationId {
-					return true
-				}
-			}
+		op := getOperationResponse.GetOperation()
+		statusFinish, _ := operation.StatusFinished.String()
+		if op.GetStatus() == statusFinish {
+			return true
 		}
 
 		return false


### PR DESCRIPTION
### What?
Refactors e2e util "**waitForOperationToFinishByOperationId**" to use **GET /operations/:operation_id**.
### Why?
To guarantee on e2e that our Get operation is working properly, we want to refactor the method *waitForOperationToFinishByOperationId* since it's used on other e2e tests. The other e2e tests execution can validate this endpoint.