### PR TITLE
Fix/use correct k3s server url to add agents

### DIFF
--- a/config/rooms-api.local.yaml
+++ b/config/rooms-api.local.yaml
@@ -28,4 +28,4 @@ adapters:
     kubernetes:
       inCluster: false
       masterUrl: "https://127.0.0.1:6443"
-      kubeconfig: "./kubeconfig.yaml"
+      kubeconfig: "./kubeconfig/kubeconfig.yaml"

--- a/config/runtime-watcher.local.yaml
+++ b/config/runtime-watcher.local.yaml
@@ -22,7 +22,7 @@ adapters:
     kubernetes:
       inCluster: false
       masterUrl: "https://127.0.0.1:6443"
-      kubeconfig: "./kubeconfig.yaml"
+      kubeconfig: "./kubeconfig/kubeconfig.yaml"
   portAllocator:
     random:
       range: 60001-60010

--- a/config/worker.local.yaml
+++ b/config/worker.local.yaml
@@ -22,7 +22,7 @@ adapters:
     kubernetes:
       inCluster: false
       masterUrl: "https://127.0.0.1:6443"
-      kubeconfig: "./kubeconfig.yaml"
+      kubeconfig: "./kubeconfig/kubeconfig.yaml"
   portAllocator:
     random:
       range: 60001-60010

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
 
   k3s_server:
     image: "rancher/k3s:v1.19.11-k3s1"
-    command: server
+    command: server --node-name control-plane
     tmpfs:
     - /run
     - /var/run
@@ -24,7 +24,7 @@ services:
     volumes:
     - k3s-server:/var/lib/rancher/k3s
     # This is just so that we get the kubeconfig file out
-    - .:/output
+    - ./kubeconfig:/output
     ports:
     - 6443:6443  # Kubernetes API Server
     - 80:80      # Ingress controller port 80
@@ -43,7 +43,7 @@ services:
     privileged: true
     restart: always
     environment:
-    - K3S_URL=https://server:6443
+    - K3S_URL=https://k3s_server:6443
     - K3S_TOKEN=maestro
 
   postgres:

--- a/e2e/framework/maestro/docker-compose.yml
+++ b/e2e/framework/maestro/docker-compose.yml
@@ -82,7 +82,7 @@ services:
 
   k3s_server:
     image: "rancher/k3s:v1.22.7-k3s1"
-    command: server --bind-address k3s_server
+    command: server --bind-address k3s_server --node-name control-plane
     tmpfs:
     - /run
     - /var/run
@@ -117,7 +117,7 @@ services:
     privileged: true
     restart: always
     environment:
-    - K3S_URL=https://server:6443
+    - K3S_URL=https://k3s_server:6443
     - K3S_TOKEN=maestro
 
   postgres:


### PR DESCRIPTION
## What ❓ 
Fix k3s server url while creating k3s agents, we were using the wrong URL.

## Why 🤔 
By using the wrong URL, the k3s agent was not connecting nor being registered into the same cluster of the k3s server. This means that k3s agent was not being used, and if we would like to scale k3s agent to have more nodes enabled in the cluster, this would have no effect 