### PR TITLE
Implement PatchSchedulerAndSwitchActiveVersionOperation service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/slok/go-http-metrics v0.9.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1
 	github.com/topfreegames/protos v1.8.0
 	go.uber.org/zap v1.18.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -1055,6 +1055,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b h1:HxLVTlqcHhFAz3nWUcuvpH7WuOMv8LQoCWmruLfFH2U=

--- a/internal/core/ports/mock/scheduler_ports_mock.go
+++ b/internal/core/ports/mock/scheduler_ports_mock.go
@@ -156,19 +156,19 @@ func (mr *MockSchedulerManagerMockRecorder) GetSchedulersInfo(ctx, filter interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedulersInfo", reflect.TypeOf((*MockSchedulerManager)(nil).GetSchedulersInfo), ctx, filter)
 }
 
-// PatchSchedulerAndSwitchActiveVersionOperation mocks base method.
-func (m *MockSchedulerManager) PatchSchedulerAndSwitchActiveVersionOperation(ctx context.Context, schedulerName string, patchMap map[string]interface{}) (*operation.Operation, error) {
+// PatchSchedulerAndCreateNewSchedulerVersionOperation mocks base method.
+func (m *MockSchedulerManager) PatchSchedulerAndCreateNewSchedulerVersionOperation(ctx context.Context, schedulerName string, patchMap map[string]interface{}) (*operation.Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchSchedulerAndSwitchActiveVersionOperation", ctx, schedulerName, patchMap)
+	ret := m.ctrl.Call(m, "PatchSchedulerAndCreateNewSchedulerVersionOperation", ctx, schedulerName, patchMap)
 	ret0, _ := ret[0].(*operation.Operation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// PatchSchedulerAndSwitchActiveVersionOperation indicates an expected call of PatchSchedulerAndSwitchActiveVersionOperation.
-func (mr *MockSchedulerManagerMockRecorder) PatchSchedulerAndSwitchActiveVersionOperation(ctx, schedulerName, patchMap interface{}) *gomock.Call {
+// PatchSchedulerAndCreateNewSchedulerVersionOperation indicates an expected call of PatchSchedulerAndCreateNewSchedulerVersionOperation.
+func (mr *MockSchedulerManagerMockRecorder) PatchSchedulerAndCreateNewSchedulerVersionOperation(ctx, schedulerName, patchMap interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchSchedulerAndSwitchActiveVersionOperation", reflect.TypeOf((*MockSchedulerManager)(nil).PatchSchedulerAndSwitchActiveVersionOperation), ctx, schedulerName, patchMap)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchSchedulerAndCreateNewSchedulerVersionOperation", reflect.TypeOf((*MockSchedulerManager)(nil).PatchSchedulerAndCreateNewSchedulerVersionOperation), ctx, schedulerName, patchMap)
 }
 
 // UpdateScheduler mocks base method.

--- a/internal/core/ports/mock/scheduler_ports_mock.go
+++ b/internal/core/ports/mock/scheduler_ports_mock.go
@@ -156,6 +156,21 @@ func (mr *MockSchedulerManagerMockRecorder) GetSchedulersInfo(ctx, filter interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedulersInfo", reflect.TypeOf((*MockSchedulerManager)(nil).GetSchedulersInfo), ctx, filter)
 }
 
+// PatchSchedulerAndSwitchActiveVersionOperation mocks base method.
+func (m *MockSchedulerManager) PatchSchedulerAndSwitchActiveVersionOperation(ctx context.Context, schedulerName string, patchMap map[string]interface{}) (*operation.Operation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchSchedulerAndSwitchActiveVersionOperation", ctx, schedulerName, patchMap)
+	ret0, _ := ret[0].(*operation.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PatchSchedulerAndSwitchActiveVersionOperation indicates an expected call of PatchSchedulerAndSwitchActiveVersionOperation.
+func (mr *MockSchedulerManagerMockRecorder) PatchSchedulerAndSwitchActiveVersionOperation(ctx, schedulerName, patchMap interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchSchedulerAndSwitchActiveVersionOperation", reflect.TypeOf((*MockSchedulerManager)(nil).PatchSchedulerAndSwitchActiveVersionOperation), ctx, schedulerName, patchMap)
+}
+
 // UpdateScheduler mocks base method.
 func (m *MockSchedulerManager) UpdateScheduler(ctx context.Context, scheduler *entities.Scheduler) error {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/scheduler_ports.go
+++ b/internal/core/ports/scheduler_ports.go
@@ -43,6 +43,7 @@ type SchedulerManager interface {
 	GetSchedulersInfo(ctx context.Context, filter *filters.SchedulerFilter) ([]*entities.SchedulerInfo, error)
 	GetSchedulerVersions(ctx context.Context, schedulerName string) ([]*entities.SchedulerVersion, error)
 	DeleteScheduler(ctx context.Context, schedulerName string) error
+	PatchSchedulerAndSwitchActiveVersionOperation(ctx context.Context, schedulerName string, patchMap map[string]interface{}) (*operation.Operation, error)
 }
 
 // Secondary ports (output, driven ports)

--- a/internal/core/ports/scheduler_ports.go
+++ b/internal/core/ports/scheduler_ports.go
@@ -43,7 +43,7 @@ type SchedulerManager interface {
 	GetSchedulersInfo(ctx context.Context, filter *filters.SchedulerFilter) ([]*entities.SchedulerInfo, error)
 	GetSchedulerVersions(ctx context.Context, schedulerName string) ([]*entities.SchedulerVersion, error)
 	DeleteScheduler(ctx context.Context, schedulerName string) error
-	PatchSchedulerAndSwitchActiveVersionOperation(ctx context.Context, schedulerName string, patchMap map[string]interface{}) (*operation.Operation, error)
+	PatchSchedulerAndCreateNewSchedulerVersionOperation(ctx context.Context, schedulerName string, patchMap map[string]interface{}) (*operation.Operation, error)
 }
 
 // Secondary ports (output, driven ports)

--- a/internal/core/services/scheduler_manager/patch_scheduler/patch_scheduler.go
+++ b/internal/core/services/scheduler_manager/patch_scheduler/patch_scheduler.go
@@ -1,0 +1,141 @@
+package patch_scheduler
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/topfreegames/maestro/internal/core/entities"
+	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
+	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+)
+
+const (
+	LabelSchedulerName       = "name"
+	LabelSchedulerSpec       = "spec"
+	LabelSchedulerPortRange  = "port_range"
+	LabelSchedulerMaxSurge   = "max_surge"
+	LabelSchedulerForwarders = "forwarders"
+
+	LabelSpecTerminationGracePeriod = "termination_grace_period"
+	LabelSpecContainers             = "containers"
+	LabelSpecToleration             = "toleration"
+	LabelSpecAffinity               = "affinity"
+
+	LabelContainerImage           = "image"
+	LabelContainerImagePullPolicy = "image_pull_policy"
+	LabelContainerCommand         = "command"
+	LabelContainerEnvironment     = "environment"
+	LabelContainerRequests        = "requests"
+	LabelContainerLimits          = "limits"
+	LabelContainerPorts           = "ports"
+)
+
+func PatchScheduler(scheduler entities.Scheduler, patchMap map[string]interface{}) (*entities.Scheduler, error) {
+	if _, ok := patchMap[LabelSchedulerPortRange]; ok {
+		if scheduler.PortRange, ok = patchMap[LabelSchedulerPortRange].(*entities.PortRange); !ok {
+			return nil, fmt.Errorf("error parsing scheduler: port range malformed")
+		}
+	}
+
+	if _, ok := patchMap[LabelSchedulerMaxSurge]; ok {
+		scheduler.MaxSurge = fmt.Sprint(patchMap[LabelSchedulerMaxSurge])
+	}
+
+	if _, ok := patchMap[LabelSchedulerForwarders]; ok {
+		if scheduler.Forwarders, ok = patchMap[LabelSchedulerForwarders].([]*forwarder.Forwarder); !ok {
+			return nil, fmt.Errorf("error parsing scheduler: forwarders malformed")
+		}
+	}
+
+	if _, ok := patchMap[LabelSchedulerSpec]; ok {
+		var patchSpecMap map[string]interface{}
+		if patchSpecMap, ok = patchMap[LabelSchedulerSpec].(map[string]interface{}); !ok {
+			return nil, fmt.Errorf("error parsing scheduler: spec malformed")
+		}
+		spec, err := patchSpec(scheduler.Spec, patchSpecMap)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing scheduler: %w", err)
+		}
+
+		scheduler.Spec = *spec
+	}
+
+	return &scheduler, nil
+}
+
+func patchSpec(spec game_room.Spec, patchMap map[string]interface{}) (*game_room.Spec, error) {
+	if _, ok := patchMap[LabelSpecTerminationGracePeriod]; ok {
+		if spec.TerminationGracePeriod, ok = patchMap[LabelSpecTerminationGracePeriod].(time.Duration); !ok {
+			return nil, fmt.Errorf("error parsing spec: termination grace period malformed")
+		}
+	}
+
+	if _, ok := patchMap[LabelSpecToleration]; ok {
+		spec.Toleration = fmt.Sprint(patchMap[LabelSpecToleration])
+	}
+
+	if _, ok := patchMap[LabelSpecAffinity]; ok {
+		spec.Affinity = fmt.Sprint(patchMap[LabelSpecAffinity])
+	}
+
+	if _, ok := patchMap[LabelSpecContainers]; ok {
+		var patchContainersMap []map[string]interface{}
+		if patchContainersMap, ok = patchMap[LabelSpecContainers].([]map[string]interface{}); !ok {
+			return nil, fmt.Errorf("error parsing spec: containers malformed")
+		}
+		containers, err := patchContainers(spec.Containers, patchContainersMap)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing spec: %w", err)
+		}
+		spec.Containers = containers
+	}
+
+	return &spec, nil
+}
+
+func patchContainers(containers []game_room.Container, patchSlice []map[string]interface{}) ([]game_room.Container, error) {
+	for i, patchMap := range patchSlice {
+		if len(containers) <= i {
+			containers = append(containers, game_room.Container{})
+		}
+		if _, ok := patchMap[LabelContainerImage]; ok {
+			containers[i].Image = fmt.Sprint(patchMap[LabelContainerImage])
+		}
+
+		if _, ok := patchMap[LabelContainerImagePullPolicy]; ok {
+			containers[i].ImagePullPolicy = fmt.Sprint(patchMap[LabelContainerImagePullPolicy])
+		}
+
+		if _, ok := patchMap[LabelContainerCommand]; ok {
+			if containers[i].Command, ok = patchMap[LabelContainerCommand].([]string); !ok {
+				return nil, fmt.Errorf("error parsing containers: command malformed")
+			}
+		}
+
+		if _, ok := patchMap[LabelContainerEnvironment]; ok {
+			if containers[i].Environment, ok = patchMap[LabelContainerEnvironment].([]game_room.ContainerEnvironment); !ok {
+				return nil, fmt.Errorf("error parsing containers: environment malformed")
+			}
+		}
+
+		if _, ok := patchMap[LabelContainerRequests]; ok {
+			if containers[i].Requests, ok = patchMap[LabelContainerRequests].(game_room.ContainerResources); !ok {
+				return nil, fmt.Errorf("error parsing containers: requests malformed")
+			}
+		}
+
+		if _, ok := patchMap[LabelContainerLimits]; ok {
+			if containers[i].Limits, ok = patchMap[LabelContainerLimits].(game_room.ContainerResources); !ok {
+				return nil, fmt.Errorf("error parsing containers: limits malformed")
+			}
+		}
+
+		if _, ok := patchMap[LabelContainerPorts]; ok {
+			if containers[i].Ports, ok = patchMap[LabelContainerPorts].([]game_room.ContainerPort); !ok {
+				return nil, fmt.Errorf("error parsing containers: ports malformed")
+			}
+		}
+	}
+
+	return containers, nil
+}

--- a/internal/core/services/scheduler_manager/patch_scheduler/patch_scheduler.go
+++ b/internal/core/services/scheduler_manager/patch_scheduler/patch_scheduler.go
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package patch_scheduler
 
 import (

--- a/internal/core/services/scheduler_manager/patch_scheduler/patch_scheduler_test.go
+++ b/internal/core/services/scheduler_manager/patch_scheduler/patch_scheduler_test.go
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package patch_scheduler_test
 
 import (

--- a/internal/core/services/scheduler_manager/patch_scheduler/patch_scheduler_test.go
+++ b/internal/core/services/scheduler_manager/patch_scheduler/patch_scheduler_test.go
@@ -1,0 +1,662 @@
+package patch_scheduler_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/topfreegames/maestro/internal/core/entities"
+	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
+	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+	"github.com/topfreegames/maestro/internal/core/services/scheduler_manager/patch_scheduler"
+)
+
+func TestPatchScheduler(t *testing.T) {
+	type Input struct {
+		Scheduler *entities.Scheduler
+		PatchMap  map[string]interface{}
+	}
+
+	type Output struct {
+		ChangeSchedulerFunc func() *entities.Scheduler
+		Error               error
+	}
+
+	testCases := []struct {
+		Title string
+		Input
+		Output
+	}{
+		// Scheduler success cases
+
+		{
+			Title: "Have max surge return scheduler with changed MaxSurge",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerMaxSurge: "30%",
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.MaxSurge = "30%"
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+		{
+			Title: "Have port range return scheduler with changed PortRange",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerPortRange: &entities.PortRange{
+						Start: 10000,
+						End:   60000,
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.PortRange = &entities.PortRange{
+						Start: 10000,
+						End:   60000,
+					}
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+		{
+			Title: " Have forwarders return scheduler with changed Forwarders",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerForwarders: []*forwarder.Forwarder{
+						{
+							Name:        "first-forwarder",
+							Enabled:     false,
+							ForwardType: forwarder.TypeGrpc,
+							Address:     "localhost:2000",
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Forwarders = []*forwarder.Forwarder{
+						{
+							Name:        "first-forwarder",
+							Enabled:     false,
+							ForwardType: forwarder.TypeGrpc,
+							Address:     "localhost:2000",
+						},
+					}
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+
+		// Scheduler Errors
+
+		{
+			Title: "Have port range wrong return error",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerPortRange: "wrong port range",
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					return basicSchedulerToPatchSchedulerTests()
+				},
+				Error: fmt.Errorf("error parsing scheduler: port range malformed"),
+			},
+		},
+		{
+			Title: " Have wrong forwarders return error",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerForwarders: "wrong forwarders",
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					return basicSchedulerToPatchSchedulerTests()
+				},
+				Error: fmt.Errorf("error parsing scheduler: forwarders malformed"),
+			},
+		},
+
+		// Spec Success cases
+
+		{
+			Title: "Have termination grace period return scheduler with changed TerminationGracePeriod",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecTerminationGracePeriod: time.Duration(12),
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.TerminationGracePeriod = time.Duration(12)
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+		{
+			Title: "Have Toleration return scheduler with changed Toleration",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecToleration: "toleration",
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.Toleration = "toleration"
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+		{
+			Title: "Have affinity return scheduler with changed Affinity",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecAffinity: "affinity",
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.Affinity = "affinity"
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+
+		// Spec errors
+
+		{
+			Title: "Have termination grace period return scheduler with changed TerminationGracePeriod",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecTerminationGracePeriod: "wrong termination grace period",
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					return basicSchedulerToPatchSchedulerTests()
+				},
+				Error: fmt.Errorf("error parsing scheduler: error parsing spec: termination grace period malformed"),
+			},
+		},
+
+		// Containers success
+
+		{
+			Title: "Have image return scheduler with changed Image",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerImage: "some-image",
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.Containers[0].Image = "some-image"
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+		{
+			Title: "Have ImagePullPolicy return scheduler with changed ImagePullPolicy",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerImagePullPolicy: "LocalFirst",
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.Containers[0].ImagePullPolicy = "LocalFirst"
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+		{
+			Title: "Have Command return scheduler with changed Command",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerCommand: []string{"/bin/sh", "command"},
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.Containers[0].Command = []string{"/bin/sh", "command"}
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+		{
+			Title: "Have Environment return scheduler with changed Environment",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerEnvironment: []game_room.ContainerEnvironment{
+									{
+										Name:  "some-name",
+										Value: "some-value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.Containers[0].Environment = []game_room.ContainerEnvironment{
+						{
+							Name:  "some-name",
+							Value: "some-value",
+						},
+					}
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+		{
+			Title: "Have Requests return scheduler with changed Requests",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerRequests: game_room.ContainerResources{
+									Memory: "1000",
+									CPU:    "500m",
+								},
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.Containers[0].Requests = game_room.ContainerResources{
+						Memory: "1000",
+						CPU:    "500m",
+					}
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+		{
+			Title: "Have Limits return scheduler with changed Limits",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerLimits: game_room.ContainerResources{
+									Memory: "1000Mi",
+									CPU:    "500m",
+								},
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.Containers[0].Limits = game_room.ContainerResources{
+						Memory: "1000Mi",
+						CPU:    "500m",
+					}
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+		{
+			Title: "Have Ports return scheduler with changed Ports",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerPorts: []game_room.ContainerPort{
+									{
+										Name:     "some-port",
+										Protocol: "TCP",
+										Port:     2048,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.Containers[0].Ports = []game_room.ContainerPort{
+						{
+							Name:     "some-port",
+							Protocol: "TCP",
+							Port:     2048,
+						},
+					}
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+
+		{
+			Title: "Creating a new container return scheduler adding that container",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{},
+							map[string]interface{}{
+								patch_scheduler.LabelContainerPorts: []game_room.ContainerPort{
+									{
+										Name:     "some-port",
+										Protocol: "TCP",
+										Port:     2048,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					scheduler := basicSchedulerToPatchSchedulerTests()
+					scheduler.Spec.Containers = append(scheduler.Spec.Containers, game_room.Container{
+						Ports: []game_room.ContainerPort{
+							{
+								Name:     "some-port",
+								Protocol: "TCP",
+								Port:     2048,
+							},
+						},
+					})
+
+					return scheduler
+				},
+				Error: nil,
+			},
+		},
+
+		// Containers errors
+
+		{
+			Title: "Have wrong Command return error",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerCommand: "wrong-command",
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					return basicSchedulerToPatchSchedulerTests()
+				},
+				Error: fmt.Errorf("error parsing scheduler: error parsing spec: error parsing containers: command malformed"),
+			},
+		},
+		{
+			Title: "Have wrong Environment return error",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerEnvironment: "wrong-environment",
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					return basicSchedulerToPatchSchedulerTests()
+				},
+				Error: fmt.Errorf("error parsing scheduler: error parsing spec: error parsing containers: environment malformed"),
+			},
+		},
+		{
+			Title: "Have wrong Requests return error",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerRequests: "wrong-requests",
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					return basicSchedulerToPatchSchedulerTests()
+				},
+				Error: fmt.Errorf("error parsing scheduler: error parsing spec: error parsing containers: requests malformed"),
+			},
+		},
+		{
+			Title: "Have wrong Limits return error",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerLimits: "wrong-limits",
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					return basicSchedulerToPatchSchedulerTests()
+				},
+				Error: fmt.Errorf("error parsing scheduler: error parsing spec: error parsing containers: limits malformed"),
+			},
+		},
+		{
+			Title: "Have wrong Ports return error",
+			Input: Input{
+				Scheduler: basicSchedulerToPatchSchedulerTests(),
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							map[string]interface{}{
+								patch_scheduler.LabelContainerPorts: "wrong-ports",
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ChangeSchedulerFunc: func() *entities.Scheduler {
+					return basicSchedulerToPatchSchedulerTests()
+				},
+				Error: fmt.Errorf("error parsing scheduler: error parsing spec: error parsing containers: ports malformed"),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			expectedScheduler := testCase.Output.ChangeSchedulerFunc()
+			scheduler, err := patch_scheduler.PatchScheduler(*testCase.Input.Scheduler, testCase.Input.PatchMap)
+
+			if testCase.Output.Error != nil {
+				assert.EqualError(t, err, testCase.Output.Error.Error())
+				return
+			}
+
+			assert.Equal(t, expectedScheduler.MaxSurge, scheduler.MaxSurge)
+			assert.EqualValues(t, expectedScheduler.PortRange, scheduler.PortRange)
+			forwarders := expectedScheduler.Forwarders
+			for i, expectedForwarder := range expectedScheduler.Forwarders {
+				assert.EqualValues(t, expectedForwarder, forwarders[i])
+			}
+
+			expectedSpec := expectedScheduler.Spec
+			spec := scheduler.Spec
+
+			assert.Equal(t, expectedSpec.TerminationGracePeriod, spec.TerminationGracePeriod)
+			assert.Equal(t, expectedSpec.Toleration, spec.Toleration)
+			assert.Equal(t, expectedSpec.Affinity, spec.Affinity)
+
+			containers := spec.Containers
+			for i, expectedContainer := range expectedSpec.Containers {
+				assert.Equal(t, expectedContainer.Image, containers[i].Image)
+				assert.Equal(t, expectedContainer.ImagePullPolicy, containers[i].ImagePullPolicy)
+				assert.EqualValues(t, expectedContainer.Command, containers[i].Command)
+				assert.Equal(t, expectedContainer.ImagePullPolicy, containers[i].ImagePullPolicy)
+
+				environment := containers[i].Environment
+				for j, expectedEnvironment := range expectedContainer.Environment {
+					assert.EqualValues(t, expectedEnvironment, environment[j])
+				}
+				assert.EqualValues(t, expectedContainer.Requests, containers[i].Requests)
+				assert.EqualValues(t, expectedContainer.Limits, containers[i].Limits)
+
+				containerPorts := containers[i].Ports
+				for j, expectedPort := range expectedContainer.Ports {
+					assert.EqualValues(t, expectedPort, containerPorts[j])
+				}
+			}
+		})
+	}
+}
+
+// basicSchedulerToPatchSchedulerTests generates a valid scheduler with the required fields.
+func basicSchedulerToPatchSchedulerTests() *entities.Scheduler {
+	return &entities.Scheduler{
+		Name:            "scheduler",
+		Game:            "game",
+		State:           entities.StateCreating,
+		MaxSurge:        "10%",
+		RollbackVersion: "v1.0.0",
+		Spec: game_room.Spec{
+			Version:                "v1.1.0",
+			TerminationGracePeriod: 60,
+			Toleration:             "toleration",
+			Affinity:               "affinity",
+			Containers: []game_room.Container{
+				{
+					Name:            "default",
+					Image:           "some-image",
+					ImagePullPolicy: "Always",
+					Command:         []string{"hello"},
+					Ports: []game_room.ContainerPort{
+						{Name: "tcp", Protocol: "tcp", Port: 80},
+					},
+					Requests: game_room.ContainerResources{
+						CPU:    "10m",
+						Memory: "100Mi",
+					},
+					Limits: game_room.ContainerResources{
+						CPU:    "10m",
+						Memory: "100Mi",
+					},
+				},
+			},
+		},
+		PortRange: &entities.PortRange{
+			Start: 40000,
+			End:   60000,
+		},
+	}
+}

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -39,6 +39,7 @@ import (
 	"github.com/topfreegames/maestro/internal/core/operations/create_scheduler"
 	"github.com/topfreegames/maestro/internal/core/operations/remove_rooms"
 	"github.com/topfreegames/maestro/internal/core/ports"
+	portsErrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 	"go.uber.org/zap"
 )
 
@@ -144,19 +145,19 @@ func (s *SchedulerManager) CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx 
 func (s *SchedulerManager) PatchSchedulerAndCreateNewSchedulerVersionOperation(ctx context.Context, schedulerName string, patchMap map[string]interface{}) (*operation.Operation, error) {
 	scheduler, err := s.schedulerStorage.GetScheduler(ctx, schedulerName)
 	if err != nil {
-		return nil, fmt.Errorf("no scheduler found, can not create new version for inexistent scheduler: %w", err)
+		return nil, portsErrors.NewErrNotFound("no scheduler found, can not create new version for inexistent scheduler: %s", err.Error())
 	}
 
 	scheduler, err = patch_scheduler.PatchScheduler(*scheduler, patchMap)
 	if err != nil {
-		return nil, fmt.Errorf("error patching scheduler: %w", err)
+		return nil, portsErrors.NewErrInvalidArgument("error patching scheduler: %s", err.Error())
 	}
 
 	opDef := &newschedulerversion.CreateNewSchedulerVersionDefinition{NewScheduler: scheduler}
 
 	op, err := s.operationManager.CreateOperation(ctx, scheduler.Name, opDef)
 	if err != nil {
-		return nil, fmt.Errorf("failed to schedule %s operation: %w", opDef.Name(), err)
+		return nil, portsErrors.NewErrUnexpected("failed to schedule %s operation: %s", opDef.Name(), err.Error())
 	}
 
 	return op, nil

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -141,7 +141,7 @@ func (s *SchedulerManager) CreateNewSchedulerVersionAndEnqueueSwitchVersion(ctx 
 	return nil
 }
 
-func (s *SchedulerManager) PatchSchedulerAndSwitchActiveVersionOperation(ctx context.Context, schedulerName string, patchMap map[string]interface{}) (*operation.Operation, error) {
+func (s *SchedulerManager) PatchSchedulerAndCreateNewSchedulerVersionOperation(ctx context.Context, schedulerName string, patchMap map[string]interface{}) (*operation.Operation, error) {
 	scheduler, err := s.schedulerStorage.GetScheduler(ctx, schedulerName)
 	if err != nil {
 		return nil, fmt.Errorf("no scheduler found, can not create new version for inexistent scheduler: %w", err)

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -27,11 +27,15 @@ package scheduler_manager
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/operations"
+	"github.com/topfreegames/maestro/internal/core/operations/newschedulerversion"
 	"github.com/topfreegames/maestro/internal/core/ports/mock"
+	"github.com/topfreegames/maestro/internal/core/services/scheduler_manager/patch_scheduler"
 
 	"github.com/topfreegames/maestro/internal/core/ports"
 
@@ -832,6 +836,146 @@ func TestDeleteScheduler(t *testing.T) {
 	})
 }
 
+func TestPatchSchedulerAndSwitchActiveVersionOperation(t *testing.T) {
+	type Input struct {
+		PatchMap map[string]interface{}
+	}
+	type ExpectedMock struct {
+		GetSchedulerError        error
+		ChangedSchedulerFunction func() *entities.Scheduler
+		CreateOperationReturn    *operation.Operation
+		CreateOperationError     error
+	}
+	type Output struct {
+		*operation.Operation
+		Err error
+	}
+
+	scheduler := newValidScheduler()
+
+	testCases := []struct {
+		Title string
+		Input
+		ExpectedMock
+		Output
+	}{
+		{
+			Title: "There are parameters then send scheduler to CreateNewSchedulerVersionDefinition to changing it",
+			Input: Input{
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerMaxSurge: "12%",
+				},
+			},
+			ExpectedMock: ExpectedMock{
+				GetSchedulerError: nil,
+				ChangedSchedulerFunction: func() *entities.Scheduler {
+					scheduler.MaxSurge = "12%"
+					return scheduler
+				},
+				CreateOperationReturn: &operation.Operation{ID: "some-id"},
+				CreateOperationError:  nil,
+			},
+			Output: Output{
+				Operation: &operation.Operation{ID: "some-id"},
+				Err:       nil,
+			},
+		},
+		{
+			Title: "GetScheduler returns in error then return error",
+			Input: Input{
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerMaxSurge: "12%",
+				},
+			},
+			ExpectedMock: ExpectedMock{
+				GetSchedulerError: fmt.Errorf("error on get scheduler"),
+				ChangedSchedulerFunction: func() *entities.Scheduler {
+					scheduler.MaxSurge = "15%"
+					return scheduler
+				},
+				CreateOperationReturn: nil,
+				CreateOperationError:  nil,
+			},
+			Output: Output{
+				Operation: nil,
+				Err:       fmt.Errorf("no scheduler found, can not create new version for inexistent scheduler:"),
+			},
+		},
+		{
+			Title: "CreateOperation returns in error then return error",
+			Input: Input{
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerMaxSurge: "17%",
+				},
+			},
+			ExpectedMock: ExpectedMock{
+				GetSchedulerError: nil,
+				ChangedSchedulerFunction: func() *entities.Scheduler {
+					scheduler.MaxSurge = "17%"
+					return scheduler
+				},
+				CreateOperationReturn: nil,
+				CreateOperationError:  fmt.Errorf("error on create operation"),
+			},
+			Output: Output{
+				Operation: nil,
+				Err:       fmt.Errorf("failed to schedule create_new_scheduler_version operation:"),
+			},
+		},
+		{
+			Title: "PatchScheduler returns in error then return error",
+			Input: Input{
+				PatchMap: map[string]interface{}{
+					patch_scheduler.LabelSchedulerPortRange: "wrong-port-range-format",
+				},
+			},
+			ExpectedMock: ExpectedMock{
+				GetSchedulerError: nil,
+				ChangedSchedulerFunction: func() *entities.Scheduler {
+					scheduler.MaxSurge = "19%"
+					return scheduler
+				},
+				CreateOperationReturn: nil,
+				CreateOperationError:  nil,
+			},
+			Output: Output{
+				Operation: nil,
+				Err:       fmt.Errorf("error patching scheduler:"),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			ctx := context.Background()
+			mockCtrl := gomock.NewController(t)
+			mockOperationManager := mock.NewMockOperationManager(mockCtrl)
+			mockSchedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+			schedulerManager := NewSchedulerManager(mockSchedulerStorage, nil, mockOperationManager, nil)
+
+			mockSchedulerStorage.EXPECT().GetScheduler(gomock.Any(), scheduler.Name).Return(scheduler, testCase.ExpectedMock.GetSchedulerError)
+			mockOperationManager.EXPECT().
+				CreateOperation(gomock.Any(), scheduler.Name, gomock.Any()).Do(func(_ context.Context, _ string, op operations.Definition) {
+				newSchedulerVersion, ok := op.(*newschedulerversion.CreateNewSchedulerVersionDefinition)
+				assert.True(t, ok)
+				assert.EqualValues(t, testCase.ExpectedMock.ChangedSchedulerFunction(), newSchedulerVersion.NewScheduler)
+			}).
+				Return(testCase.ExpectedMock.CreateOperationReturn, testCase.ExpectedMock.CreateOperationError).
+				AnyTimes()
+
+			op, err := schedulerManager.PatchSchedulerAndSwitchActiveVersionOperation(ctx, scheduler.Name, testCase.Input.PatchMap)
+			if testCase.Output.Err != nil {
+				assert.ErrorContains(t, err, testCase.Output.Err.Error())
+
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.EqualValues(t, testCase.Output.Operation, op)
+		})
+	}
+}
+
 // newValidScheduler generates a valid scheduler with the required fields.
 func newValidScheduler() *entities.Scheduler {
 	return &entities.Scheduler{
@@ -872,7 +1016,7 @@ func newValidScheduler() *entities.Scheduler {
 	}
 }
 
-// newValidScheduler generates an invalid scheduler
+// newInvalidScheduler generate an invalid Scheduler,.
 func newInvalidScheduler() *entities.Scheduler {
 	return &entities.Scheduler{
 		Name:            "",

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -963,7 +963,7 @@ func TestPatchSchedulerAndSwitchActiveVersionOperation(t *testing.T) {
 				Return(testCase.ExpectedMock.CreateOperationReturn, testCase.ExpectedMock.CreateOperationError).
 				AnyTimes()
 
-			op, err := schedulerManager.PatchSchedulerAndSwitchActiveVersionOperation(ctx, scheduler.Name, testCase.Input.PatchMap)
+			op, err := schedulerManager.PatchSchedulerAndCreateNewSchedulerVersionOperation(ctx, scheduler.Name, testCase.Input.PatchMap)
 			if testCase.Output.Err != nil {
 				assert.ErrorContains(t, err, testCase.Output.Err.Error())
 


### PR DESCRIPTION
### Why
Maestro needs a new route to patch a scheduler. And to it, a service that executes this function should be done.

### What
- Implement a `PatchSchedulerAndSwitchActiveVersionOperation`
- Create a `patch_scheduler` package