### PR TITLE
takes off command required field from container

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -6,9 +6,10 @@ require (
 	github.com/go-redis/redis/v8 v8.10.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1
 	github.com/testcontainers/testcontainers-go v0.11.1
 	github.com/topfreegames/maestro v0.0.0-00010101000000-000000000000
+	go.uber.org/zap v1.18.1
 	google.golang.org/protobuf v1.27.1
 	k8s.io/api v0.22.1
 	k8s.io/apimachinery v0.22.1
@@ -74,7 +75,6 @@ require (
 	go.opentelemetry.io/otel/trace v0.20.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
-	go.uber.org/zap v1.18.1 // indirect
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
 	golang.org/x/oauth2 v0.0.0-20210615190721-d04028783cf1 // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -1114,8 +1114,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/internal/api/handlers/schedulers_handler_test.go
+++ b/internal/api/handlers/schedulers_handler_test.go
@@ -607,7 +607,6 @@ func TestCreateScheduler(t *testing.T) {
 		assert.Contains(t, schedulerMessage, "Scheduler.Spec.TerminationGracePeriod: TerminationGracePeriod must be greater than 0")
 		assert.Contains(t, schedulerMessage, "Scheduler.Spec.Containers[0].Name: Name is a required field")
 		assert.Contains(t, schedulerMessage, "Scheduler.Spec.Containers[0].Image: Image is a required field")
-		assert.Contains(t, schedulerMessage, "Scheduler.Spec.Containers[0].Command: Command is a required field")
 		assert.Contains(t, schedulerMessage, "Scheduler.Spec.Containers[0].Ports[0].Name: Name must be a maximum of 15 characters in length")
 		assert.Contains(t, schedulerMessage, "Scheduler.Spec.Containers[0].Requests.CPU: CPU is a required field")
 		assert.Contains(t, schedulerMessage, "Scheduler.Spec.Containers[0].Requests.Memory: Memory is a required field")

--- a/internal/core/entities/game_room/container.go
+++ b/internal/core/entities/game_room/container.go
@@ -23,10 +23,10 @@
 package game_room
 
 type Container struct {
-	Name            string                 `validate:"required,kube_resource_name"`
-	Image           string                 `validate:"required"`
-	ImagePullPolicy string                 `validate:"required,image_pull_policy"`
-	Command         []string               `validate:"required"`
+	Name            string `validate:"required,kube_resource_name"`
+	Image           string `validate:"required"`
+	ImagePullPolicy string `validate:"required,image_pull_policy"`
+	Command         []string
 	Environment     []ContainerEnvironment `validate:"dive"`
 	Requests        ContainerResources
 	Limits          ContainerResources


### PR DESCRIPTION
### What?
Takes off "command" requirement from spec.container[].command. This is important
### Why?
The scheduler should be able to have a image without a command.