### PR TITLE
fix ports incremented on forwarder event method

### DIFF
--- a/internal/core/services/events_forwarder/events_forwarder_service.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service.go
@@ -249,6 +249,9 @@ func (es *EventsForwarderService) selectPort(address *game_room.Address) (int32,
 }
 
 func (es *EventsForwarderService) incrementEventAttributesWithPortsInfo(event *events.Event, ports []game_room.Port) error {
+	if len(ports) == 0 {
+		return nil
+	}
 	portsMap := make([]map[string]interface{}, 0)
 	for _, port := range ports {
 		portsMap = append(portsMap, map[string]interface{}{
@@ -257,10 +260,12 @@ func (es *EventsForwarderService) incrementEventAttributesWithPortsInfo(event *e
 			"protocol": port.Protocol,
 		})
 	}
+
 	portsJson, err := json.Marshal(portsMap)
 	if err != nil {
 		return err
 	}
+
 	event.Attributes["ports"] = string(portsJson)
 	return nil
 }

--- a/internal/core/services/events_forwarder/events_forwarder_service.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service.go
@@ -24,6 +24,7 @@ package events_forwarder
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -134,7 +135,10 @@ func (es *EventsForwarderService) forwardRoomEvent(
 	if err != nil {
 		return fmt.Errorf("no room port found to forward roomEvent. Forwarder name: \"%v\", Scheduler: \"%v\"", _forwarder.Name, event.SchedulerID)
 	}
-	es.incrementEventAttributesWithPortsInfo(event, instance.Address.Ports)
+	err = es.incrementEventAttributesWithPortsInfo(event, instance.Address.Ports)
+	if err != nil {
+		return err
+	}
 
 	roomEvent, err := events.ConvertToRoomEventType(eventType)
 	if err != nil {
@@ -244,16 +248,21 @@ func (es *EventsForwarderService) selectPort(address *game_room.Address) (int32,
 	return selectedPort, nil
 }
 
-func (es *EventsForwarderService) incrementEventAttributesWithPortsInfo(event *events.Event, ports []game_room.Port) {
-	portsMap := make(map[int]interface{})
-	for i, port := range ports {
-		portsMap[i] = map[string]interface{}{
+func (es *EventsForwarderService) incrementEventAttributesWithPortsInfo(event *events.Event, ports []game_room.Port) error {
+	portsMap := make([]map[string]interface{}, 0)
+	for _, port := range ports {
+		portsMap = append(portsMap, map[string]interface{}{
 			"port":     port.Port,
 			"name":     port.Name,
 			"protocol": port.Protocol,
-		}
+		})
 	}
-	event.Attributes["ports"] = portsMap
+	portsJson, err := json.Marshal(portsMap)
+	if err != nil {
+		return err
+	}
+	event.Attributes["ports"] = string(portsJson)
+	return nil
 }
 
 func (es *EventsForwarderService) getPlayerInfo(event *events.Event) (string, error) {

--- a/internal/core/services/events_forwarder/events_forwarder_service_test.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service_test.go
@@ -27,6 +27,7 @@ package events_forwarder_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -194,6 +195,16 @@ func TestEventsForwarderService_ProduceEvent(t *testing.T) {
 		err := eventsForwarderService.ProduceEvent(context.Background(), event)
 		require.NoError(t, err)
 		require.NotEmpty(t, event.Attributes["ports"])
+
+		portsUnmarshalled := make([]map[string]interface{}, 0)
+		err = json.Unmarshal([]byte(event.Attributes["ports"].(string)), &portsUnmarshalled)
+		require.NoError(t, err)
+
+		for _, _port := range portsUnmarshalled {
+			require.NotNil(t, _port["name"])
+			require.NotNil(t, _port["protocol"])
+			require.NotNil(t, _port["port"])
+		}
 	})
 
 	t.Run("should fail when event type is not in eventAttributes", func(t *testing.T) {


### PR DESCRIPTION
### What?
Fix `incrementEventAttributesWithPortsInfo` method to correctly add ports info to event.
### Why?
The ports attribute included in metadata is very important for games to correctly connect to game rooms.

### New output:
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/25515954/162496284-10d895e4-8fdc-430b-8185-bcb23b538922.png">
