### PR TITLE
Implement ForwarderClient SendRoomStatus method

### DIFF
--- a/internal/adapters/events/forwarder_client.go
+++ b/internal/adapters/events/forwarder_client.go
@@ -93,6 +93,20 @@ func (f *ForwarderClient) SendRoomReSync(ctx context.Context, forwarder forwarde
 	})
 }
 
+// SendRoomStatus fetch or create a grpc client and send a room status event to forwarder.
+func (f *ForwarderClient) SendRoomStatus(ctx context.Context, forwarder forwarder.Forwarder, in *pb.RoomStatus) (*pb.Response, error) {
+	client, err := f.getGrpcClient(Address(forwarder.Address))
+	if err != nil {
+		return nil, errors.NewErrUnexpected("failed to connect at %s", forwarder.Address).WithError(err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, forwarder.Options.Timeout*time.Millisecond)
+	defer cancel()
+	return runReportingLatencyMetrics("SendRoomStatus", func() (*pb.Response, error) {
+		return client.SendRoomStatus(ctx, in)
+	})
+}
+
 // SendPlayerEvent fetch or create a grpc client and send a player event to forwarder.
 func (f *ForwarderClient) SendPlayerEvent(ctx context.Context, forwarder forwarder.Forwarder, in *pb.PlayerEvent) (*pb.Response, error) {
 	client, err := f.getGrpcClient(Address(forwarder.Address))

--- a/internal/core/ports/events_ports.go
+++ b/internal/core/ports/events_ports.go
@@ -52,6 +52,7 @@ type EventsForwarder interface {
 type ForwarderClient interface {
 	SendRoomEvent(ctx context.Context, forwarder forwarder.Forwarder, in *pb.RoomEvent) (*pb.Response, error)
 	SendRoomReSync(ctx context.Context, forwarder forwarder.Forwarder, in *pb.RoomStatus) (*pb.Response, error)
+	SendRoomStatus(ctx context.Context, forwarder forwarder.Forwarder, in *pb.RoomStatus) (*pb.Response, error)
 	SendPlayerEvent(ctx context.Context, forwarder forwarder.Forwarder, in *pb.PlayerEvent) (*pb.Response, error)
 	CacheFlush()
 	CacheDelete(forwarderAddress string) error

--- a/internal/core/ports/mock/events_ports_mock.go
+++ b/internal/core/ports/mock/events_ports_mock.go
@@ -209,3 +209,18 @@ func (mr *MockForwarderClientMockRecorder) SendRoomReSync(ctx, forwarder, in int
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendRoomReSync", reflect.TypeOf((*MockForwarderClient)(nil).SendRoomReSync), ctx, forwarder, in)
 }
+
+// SendRoomStatus mocks base method.
+func (m *MockForwarderClient) SendRoomStatus(ctx context.Context, forwarder forwarder.Forwarder, in *eventforwarder.RoomStatus) (*eventforwarder.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendRoomStatus", ctx, forwarder, in)
+	ret0, _ := ret[0].(*eventforwarder.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SendRoomStatus indicates an expected call of SendRoomStatus.
+func (mr *MockForwarderClientMockRecorder) SendRoomStatus(ctx, forwarder, in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendRoomStatus", reflect.TypeOf((*MockForwarderClient)(nil).SendRoomStatus), ctx, forwarder, in)
+}

--- a/test/data/events_mock/events-forwarder-grpc-send-room-status-failure.json
+++ b/test/data/events_mock/events-forwarder-grpc-send-room-status-failure.json
@@ -1,0 +1,19 @@
+{
+  "service": "GRPCForwarder",
+  "method": "SendRoomStatus",
+  "input": {
+    "contains": {
+      "room": {
+        "metadata":{
+          "mockIdentifier": "f7415c97-5c28-418b-b19b-87380e2d0113"
+        }
+      }
+    }
+  },
+  "output": {
+    "data": {
+      "code": 500,
+      "message": "Internal server error from matchmaker"
+    }
+  }
+}

--- a/test/data/events_mock/events-forwarder-grpc-send-room-status-success.json
+++ b/test/data/events_mock/events-forwarder-grpc-send-room-status-success.json
@@ -1,0 +1,19 @@
+{
+  "service": "GRPCForwarder",
+  "method": "SendRoomStatus",
+  "input": {
+    "contains": {
+      "room": {
+        "metadata":{
+          "mockIdentifier": "65e810a0-bb81-4633-93c9-826414a0062d"
+        }
+      }
+    }
+  },
+  "output": {
+    "data": {
+      "code": 200,
+      "message": "Event received with success"
+    }
+  }
+}


### PR DESCRIPTION
## What ❓ 
Implement SendRoomStatus method in ForwarderClient

## Why 🤔 
We need to add a new method SendRoomStatus in the forwarder client so we can forward room status events successfully.