### PR TITLE
Update events forwarder with status type

### DIFF
--- a/internal/core/entities/events/player_event_test.go
+++ b/internal/core/entities/events/player_event_test.go
@@ -40,7 +40,7 @@ func TestPlayerEvent(t *testing.T) {
 		require.IsType(t, PlayerEventType("playerJoin"), converted)
 	})
 
-	t.Run("with error when converting to RoomPingEventType", func(t *testing.T) {
+	t.Run("with error when converting to RoomStatusType", func(t *testing.T) {
 
 		_, err := ConvertToPlayerEventType("INVALID")
 		require.Error(t, err)

--- a/internal/core/entities/events/room_event.go
+++ b/internal/core/entities/events/room_event.go
@@ -25,13 +25,13 @@ package events
 import "fmt"
 
 type RoomEventAttributes struct {
-	Game      string
-	RoomId    string
-	Host      string
-	Port      int32
-	EventType RoomEventType
-	PingType  *RoomPingEventType
-	Other     map[string]interface{}
+	Game           string
+	RoomId         string
+	Host           string
+	Port           int32
+	EventType      RoomEventType
+	RoomStatusType *RoomStatusType
+	Other          map[string]interface{}
 }
 
 type RoomEventType string
@@ -39,15 +39,16 @@ type RoomEventType string
 const (
 	Ping      RoomEventType = "resync"
 	Arbitrary RoomEventType = "roomEvent"
+	Status    RoomEventType = "status"
 )
 
-type RoomPingEventType string
+type RoomStatusType string
 
 const (
-	RoomPingReady       RoomPingEventType = "roomReady"
-	RoomPingOccupied    RoomPingEventType = "roomOccupied"
-	RoomPingTerminating RoomPingEventType = "roomTerminating"
-	RoomPingTerminated  RoomPingEventType = "roomTerminated"
+	RoomStatusReady       RoomStatusType = "roomReady"
+	RoomStatusOccupied    RoomStatusType = "roomOccupied"
+	RoomStatusTerminating RoomStatusType = "roomTerminating"
+	RoomStatusTerminated  RoomStatusType = "roomTerminated"
 )
 
 func ConvertToRoomEventType(value string) (RoomEventType, error) {
@@ -72,17 +73,17 @@ func FromRoomEventTypeToString(eventType RoomEventType) string {
 	}
 }
 
-func ConvertToRoomPingEventType(value string) (RoomPingEventType, error) {
+func ConvertToRoomPingEventType(value string) (RoomStatusType, error) {
 	switch value {
 	case "ready":
-		return RoomPingReady, nil
+		return RoomStatusReady, nil
 	case "occupied":
-		return RoomPingOccupied, nil
+		return RoomStatusOccupied, nil
 	case "terminating":
-		return RoomPingTerminating, nil
+		return RoomStatusTerminating, nil
 	case "terminated":
-		return RoomPingTerminated, nil
+		return RoomStatusTerminated, nil
 	default:
-		return "", fmt.Errorf("invalid RoomPingEventType. Should be \"ready\", \"occupied\", \"terminating\" or \"terminated\"")
+		return "", fmt.Errorf("invalid RoomStatusType. Should be \"ready\", \"occupied\", \"terminating\" or \"terminated\"")
 	}
 }

--- a/internal/core/entities/events/room_event_test.go
+++ b/internal/core/entities/events/room_event_test.go
@@ -40,22 +40,22 @@ func TestRoomEvent(t *testing.T) {
 		require.IsType(t, RoomEventType("roomEvent"), converted)
 	})
 
-	t.Run("with success when converting to RoomPingEventType", func(t *testing.T) {
+	t.Run("with success when converting to RoomStatusType", func(t *testing.T) {
 		converted, err := ConvertToRoomPingEventType("ready")
 		require.NoError(t, err)
-		require.IsType(t, RoomPingEventType("ready"), converted)
+		require.IsType(t, RoomStatusType("ready"), converted)
 
 		converted, err = ConvertToRoomPingEventType("occupied")
 		require.NoError(t, err)
-		require.IsType(t, RoomPingEventType("occupied"), converted)
+		require.IsType(t, RoomStatusType("occupied"), converted)
 
 		converted, err = ConvertToRoomPingEventType("terminating")
 		require.NoError(t, err)
-		require.IsType(t, RoomPingEventType("terminating"), converted)
+		require.IsType(t, RoomStatusType("terminating"), converted)
 
 		converted, err = ConvertToRoomPingEventType("terminated")
 		require.NoError(t, err)
-		require.IsType(t, RoomPingEventType("terminated"), converted)
+		require.IsType(t, RoomStatusType("terminated"), converted)
 	})
 
 	t.Run("with error when converting to RoomEventType", func(t *testing.T) {
@@ -64,7 +64,7 @@ func TestRoomEvent(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("with error when converting to RoomPingEventType", func(t *testing.T) {
+	t.Run("with error when converting to RoomStatusType", func(t *testing.T) {
 
 		_, err := ConvertToRoomPingEventType("INVALID")
 		require.Error(t, err)

--- a/internal/core/services/events_forwarder/events_forwarder_service.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service.go
@@ -145,7 +145,7 @@ func (es *EventsForwarderService) forwardRoomEvent(
 		return err
 	}
 
-	var pingType events.RoomPingEventType
+	var pingType events.RoomStatusType
 	if roomEvent == events.Ping {
 		if _, ok := event.Attributes["pingType"]; !ok {
 			return errors.New("roomEvent of type ping must contain key \"pingType\" in eventAttributes")
@@ -157,13 +157,13 @@ func (es *EventsForwarderService) forwardRoomEvent(
 	}
 
 	roomAttributes := events.RoomEventAttributes{
-		Game:      scheduler.Game,
-		RoomId:    event.RoomID,
-		Host:      instance.Address.Host,
-		Port:      selectedPort,
-		EventType: roomEvent,
-		PingType:  &pingType,
-		Other:     event.Attributes,
+		Game:           scheduler.Game,
+		RoomId:         event.RoomID,
+		Host:           instance.Address.Host,
+		Port:           selectedPort,
+		EventType:      roomEvent,
+		RoomStatusType: &pingType,
+		Other:          event.Attributes,
 	}
 	err = es.eventsForwarder.ForwardRoomEvent(ctx, roomAttributes, *_forwarder)
 	if err != nil {


### PR DESCRIPTION
## What ❓ 
Create new **RoomEventType** enum option named **Status**, update eventsForwarder **ForwardRoomEvent** method to treat the new status room event type scenario, inclusing unitary tests refactor.

## Why 🤔 
We need to add this new room event type so we can identify and forward room status events successfully. 

## Dependencies ⛓️ 
This PR depends on https://github.com/topfreegames/maestro/pull/402, review it first before reviewing this PR.