### PR TITLE
Feature/implement update room status handler

### DIFF
--- a/e2e/framework/maestro/servermocks/events-forwarder-grpc-send-room-status-event-failure.json
+++ b/e2e/framework/maestro/servermocks/events-forwarder-grpc-send-room-status-event-failure.json
@@ -1,0 +1,25 @@
+{
+  "service": "GRPCForwarder",
+  "method": "SendRoomStatus",
+  "input": {
+    "contains": {
+      "room": {
+        "metadata":{
+          "eventMetadata1": "value1",
+          "eventMetadata2": "true",
+          "forwarderMetadata1": "value1",
+          "forwarderMetadata2": "245",
+          "roomType": "green",
+          "mockIdentifier": "24db7925-fdc9-45ef-8b87-f1fff6a9eaaa"
+        }
+      },
+      "statusType": 3
+    }
+  },
+  "output": {
+    "data": {
+      "code": 500,
+      "message": "Internal server error from matchmaker"
+    }
+  }
+}

--- a/e2e/framework/maestro/servermocks/events-forwarder-grpc-send-room-status-event-success.json
+++ b/e2e/framework/maestro/servermocks/events-forwarder-grpc-send-room-status-event-success.json
@@ -1,0 +1,25 @@
+{
+  "service": "GRPCForwarder",
+  "method": "SendRoomStatus",
+  "input": {
+    "contains": {
+      "room": {
+        "metadata":{
+          "eventMetadata1": "value1",
+          "eventMetadata2": "true",
+          "forwarderMetadata1": "value1",
+          "forwarderMetadata2": "245",
+          "roomType": "green",
+          "mockIdentifier": "9da046b8-3ef9-4f28-966d-d5c0cd1fe627"
+        }
+      },
+      "statusType": 3
+    }
+  },
+  "output": {
+    "data": {
+      "code": 200,
+      "message": "Event received with success"
+    }
+  }
+}

--- a/internal/core/entities/events/room_event.go
+++ b/internal/core/entities/events/room_event.go
@@ -57,6 +57,8 @@ func ConvertToRoomEventType(value string) (RoomEventType, error) {
 		return Ping, nil
 	case "roomEvent":
 		return Arbitrary, nil
+	case "roomStatus":
+		return Status, nil
 	default:
 		return "", fmt.Errorf("invalid RoomEventType. Should be \"resync\" or \"roomEvent\"")
 	}
@@ -68,6 +70,8 @@ func FromRoomEventTypeToString(eventType RoomEventType) string {
 		return "resync"
 	case Arbitrary:
 		return "roomEvent"
+	case Status:
+		return "roomStatus"
 	default:
 		return ""
 	}


### PR DESCRIPTION
### What ❓
Implement UpdateRoomStatus handler logic by producing status events, including unitary and e2e tests.

### Why 🤔
This is the last PR to fully implement the room status event forwarding feature.

### Dependencies ⛓️
This PR depends on https://github.com/topfreegames/maestro/pull/402 and https://github.com/topfreegames/maestro/pull/403, review it first before reviewing this PR.