### PR TITLE
include Getting Started documentation to run maestro-next locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,3 +140,15 @@ deps/down: ## Delete containers dependencies.
 	@echo "Deleting dependencies "
 	@docker-compose --project-name maestro down
 	@echo "Dependencies deleted successfully."
+
+
+#-------------------------------------------------------------------------------
+#  Easily start Maestro
+#-------------------------------------------------------------------------------
+.PHONY: maestro/start
+maestro/start: build-linux-x86_64 ## Start Maestro with all of its dependencies
+	@echo "Starting maestro..."
+	@cd ./e2e/framework/maestro; docker-compose --project-name maestro up -d
+	@go run main.go migrate;
+	@cd ./e2e/framework/maestro; docker-compose --project-name maestro start
+	@echo "Maestro is up and running!"

--- a/Makefile
+++ b/Makefile
@@ -146,9 +146,9 @@ deps/down: ## Delete containers dependencies.
 #  Easily start Maestro
 #-------------------------------------------------------------------------------
 .PHONY: maestro/start
-maestro/start: build-linux-x86_64 ## Start Maestro with all of its dependencies
+maestro/start: build-linux-x86_64 ## Start Maestro with all of its dependencies.
 	@echo "Starting maestro..."
 	@cd ./e2e/framework/maestro; docker-compose --project-name maestro up -d
 	@go run main.go migrate;
-	@cd ./e2e/framework/maestro; docker-compose --project-name maestro start
+	@cd ./e2e/framework/maestro; docker-compose --project-name maestro start worker runtime-watcher #Worker and watcher do not work before migration, so we start them after it.
 	@echo "Maestro is up and running!"

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,0 +1,95 @@
+To help you get along with Maestro, by the end of this section you should have a scheduler up and running.
+
+## Prerequisites
+- Golang v1.17+
+- Linux/MacOS environment
+- Docker
+
+### Clone Repository
+Clone the [repository](https://github.com/topfreegames/maestro) to your favorite folder.
+
+## Building and running locally
+> For this step, you need docker running on your machine.
+
+In the folder where the project was cloned, simply run:
+
+```shell
+make maestro/start
+```
+
+This will build and start all containers needed by Maestro, such as databases and maestro-modules. 
+Because of that, be aware that it might take some time to finish.
+
+## Find rooms-api address
+To simulate a game room, it's important to find the address of running **rooms-api** on the local network.
+
+To do that, with Maestro containers running, simply use:
+
+```shell
+docker inspect -f '{{range.NetworkSettings.Networks}}{{.Gateway}}{{end}}' maestro_rooms-api_1
+```
+
+This command should give you an IP address. 
+This IP is important because the game rooms will use it to communicate their status.
+
+An example of the answer could be: **172.30.0.1**. This is the **ROOMS_API_ADDRESS**.
+
+## Create a scheduler
+If everything is working as expected till now and each Maestro-module is up and running, use the command below to create a new scheduler:
+
+> Be aware to change the {{ROOMS_API_ADDRESS}} for the one found above.
+```shell
+curl --request POST \
+  --url http://localhost:8080/schedulers \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"name": "scheduler-run-local",
+	"game": "game-test",
+	"state": "creating",
+	"portRange": {
+		"start": 1,
+		"end": 1000
+	},
+	"maxSurge": "10%",
+	"spec": {
+		"terminationGracePeriod": "100",
+		"containers": [
+			{
+				"name": "alpine",
+				"image": "alpine",
+				"imagePullPolicy": "IfNotPresent",
+				"command": [
+					"sh",
+					"-c",
+					"apk add curl && while true; do curl --request PUT {{ROOMS_API_ADDRESS}}:8070/scheduler/$MAESTRO_SCHEDULER_NAME/rooms/$MAESTRO_ROOM_ID/ping --data-raw '\''{\"status\": \"ready\",\"timestamp\": \"12312312313\"}'\'' && sleep 5; done"
+				],
+				"environment": [],
+				"requests": {
+					"memory": "100Mi",
+					"cpu": "100m"
+				},
+				"limits": {
+					"memory": "200Mi",
+					"cpu": "200m"
+				},
+				"ports": [
+					{
+						"name": "port-name",
+						"protocol": "tcp",
+						"port": 12345
+					}
+				]
+			}
+		],
+		"toleration": "",
+		"affinity": ""
+	},
+	"forwarders": []
+}'
+```
+
+## Congratulations
+If you followed the steps above (should not be hard) you have Maestro running in your local machine, and with a [scheduler](Scheduler.md) to try different [operations](Operations.md) on it.
+Feel free to explore the available endpoints in the [API](OpenAPI.md) hitting directly the management-API.
+
+If you have any doubts or feedbacks regarding this process, feel free to reach out in [Maestro's GitHub repository](https://github.com/topfreegames/maestro) and open an issue/question.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -26,7 +26,7 @@ To simulate a game room, it's important to find the address of running **rooms-a
 To do that, with Maestro containers running, simply use:
 
 ```shell
-docker inspect -f '{{range.NetworkSettings.Networks}}{{.Gateway}}{{end}}' maestro_rooms-api_1
+docker inspect -f '{{range.NetworkSettings.Networks}}{{.Gateway}}{{end}}' {{ROOMS_API_CONTAINER_NAME}}
 ```
 
 This command should give you an IP address. 
@@ -35,7 +35,8 @@ This IP is important because the game rooms will use it to communicate their sta
 An example of the answer could be: **172.30.0.1**. This is the **ROOMS_API_ADDRESS**.
 
 ## Create a scheduler
-If everything is working as expected till now and each Maestro-module is up and running, use the command below to create a new scheduler:
+If everything is working as expected now, each Maestro-module is up and running. 
+Use the command below to create a new scheduler:
 
 > Be aware to change the {{ROOMS_API_ADDRESS}} for the one found above.
 ```shell
@@ -89,7 +90,7 @@ curl --request POST \
 ```
 
 ## Congratulations
-If you followed the steps above (should not be hard) you have Maestro running in your local machine, and with a [scheduler](Scheduler.md) to try different [operations](Operations.md) on it.
+If you followed the steps above you have Maestro running in your local machine, and with a [scheduler](Scheduler.md) to try different [operations](Operations.md) on it.
 Feel free to explore the available endpoints in the [API](OpenAPI.md) hitting directly the management-API.
 
 If you have any doubts or feedbacks regarding this process, feel free to reach out in [Maestro's GitHub repository](https://github.com/topfreegames/maestro) and open an issue/question.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -32,8 +32,6 @@ docker inspect -f '{{range.NetworkSettings.Networks}}{{.Gateway}}{{end}}' {{ROOM
 This command should give you an IP address. 
 This IP is important because the game rooms will use it to communicate their status.
 
-An example of the answer could be: **172.30.0.1**. This is the **ROOMS_API_ADDRESS**.
-
 ## Create a scheduler
 If everything is working as expected now, each Maestro-module is up and running. 
 Use the command below to create a new scheduler:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ repo_url: https://github.com/topfreegames/maestro
 
 nav:
   - Home: 'index.md'
+  - Getting Started: 'GettingStarted.md'
   - Scheduler: 'Scheduler.md'
   - UserGuides: 'User Guides.md'
   - Developers: 'Developers.md'


### PR DESCRIPTION
### What?
Include 'Getting Started' documentation .md

### Why?
To create a better user experience using Maestro-Next, we understand that running the application locally is very important to simulate its usage and help users understand how Maestro can be useful for them