### PR TITLE
Move scheduler_handler adapters to request_adapters package

### DIFF
--- a/e2e/suites/management/patch_scheduler_test.go
+++ b/e2e/suites/management/patch_scheduler_test.go
@@ -123,6 +123,8 @@ func TestPatchScheduler(t *testing.T) {
 			}
 			patchSchedulerResponse := &maestrov1.PatchSchedulerResponse{}
 			err = managementApiClient.Do("PATCH", fmt.Sprintf("/schedulers/%s", scheduler.Name), patchSchedulerRequest, patchSchedulerResponse)
+			fmt.Println(err)
+			fmt.Println(patchSchedulerResponse)
 			require.NoError(t, err)
 
 			waitForOperationToFinishByOperationId(t, managementApiClient, scheduler.Name, patchSchedulerResponse.OperationId)

--- a/internal/api/handlers/request_adapters/schedulers.go
+++ b/internal/api/handlers/request_adapters/schedulers.go
@@ -23,7 +23,11 @@
 package request_adapters
 
 import (
+	"fmt"
 	"time"
+
+	_struct "google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
@@ -36,7 +40,7 @@ func FromApiPatchSchedulerRequestToChangeMap(request *api.PatchSchedulerRequest)
 	patchMap := make(map[string]interface{})
 
 	if request.Spec != nil {
-		patchMap[patch_scheduler.LabelSchedulerSpec] = FromApiOptionalSpecToChangeMap(request.Spec)
+		patchMap[patch_scheduler.LabelSchedulerSpec] = fromApiOptionalSpecToChangeMap(request.Spec)
 	}
 
 	if request.PortRange != nil {
@@ -51,13 +55,96 @@ func FromApiPatchSchedulerRequestToChangeMap(request *api.PatchSchedulerRequest)
 	}
 
 	if request.Forwarders != nil {
-		patchMap[patch_scheduler.LabelSchedulerForwarders] = FromApiForwarders(request.GetForwarders())
+		patchMap[patch_scheduler.LabelSchedulerForwarders] = fromApiForwarders(request.GetForwarders())
 	}
 
 	return patchMap
 }
 
-func FromApiOptionalSpecToChangeMap(request *api.OptionalSpec) map[string]interface{} {
+func FromApiCreateSchedulerRequestToEntity(request *api.CreateSchedulerRequest) (*entities.Scheduler, error) {
+	return entities.NewScheduler(
+		request.GetName(),
+		request.GetGame(),
+		entities.StateCreating,
+		request.GetMaxSurge(),
+		*fromApiSpec(request.GetSpec()),
+		entities.NewPortRange(
+			request.GetPortRange().GetStart(),
+			request.GetPortRange().GetEnd(),
+		),
+		fromApiForwarders(request.GetForwarders()),
+	)
+}
+
+func FromEntitySchedulerToListResponse(entity *entities.Scheduler) *api.SchedulerWithoutSpec {
+	return &api.SchedulerWithoutSpec{
+		Name:      entity.Name,
+		Game:      entity.Game,
+		State:     entity.State,
+		Version:   entity.Spec.Version,
+		PortRange: getPortRange(entity.PortRange),
+		CreatedAt: timestamppb.New(entity.CreatedAt),
+		MaxSurge:  entity.MaxSurge,
+	}
+}
+
+func FromApiNewSchedulerVersionRequestToEntity(request *api.NewSchedulerVersionRequest) (*entities.Scheduler, error) {
+	return entities.NewScheduler(
+		request.GetName(),
+		request.GetGame(),
+		entities.StateCreating,
+		request.GetMaxSurge(),
+		*fromApiSpec(request.GetSpec()),
+		entities.NewPortRange(
+			request.GetPortRange().GetStart(),
+			request.GetPortRange().GetEnd(),
+		),
+		fromApiForwarders(request.GetForwarders()),
+	)
+}
+
+func FromEntitySchedulerToResponse(entity *entities.Scheduler) (*api.Scheduler, error) {
+	forwarders, err := fromEntityForwardersToResponse(entity.Forwarders)
+	if err != nil {
+		return nil, err
+	}
+	return &api.Scheduler{
+		Name:       entity.Name,
+		Game:       entity.Game,
+		State:      entity.State,
+		PortRange:  getPortRange(entity.PortRange),
+		CreatedAt:  timestamppb.New(entity.CreatedAt),
+		MaxSurge:   entity.MaxSurge,
+		Spec:       getSpec(entity.Spec),
+		Forwarders: forwarders,
+	}, nil
+}
+
+func FromEntitySchedulerVersionListToResponse(entity []*entities.SchedulerVersion) []*api.SchedulerVersion {
+	versions := make([]*api.SchedulerVersion, len(entity))
+	for i, version := range entity {
+		versions[i] = &api.SchedulerVersion{
+			Version:   version.Version,
+			IsActive:  version.IsActive,
+			CreatedAt: timestamppb.New(version.CreatedAt),
+		}
+	}
+	return versions
+}
+
+func FromEntitySchedulerInfoToListResponse(entity *entities.SchedulerInfo) *api.SchedulerInfo {
+	return &api.SchedulerInfo{
+		Name:             entity.Name,
+		Game:             entity.Game,
+		State:            entity.State,
+		RoomsReady:       int32(entity.RoomsReady),
+		RoomsOccupied:    int32(entity.RoomsOccupied),
+		RoomsPending:     int32(entity.RoomsPending),
+		RoomsTerminating: int32(entity.RoomsTerminating),
+	}
+}
+
+func fromApiOptionalSpecToChangeMap(request *api.OptionalSpec) map[string]interface{} {
 	changeMap := make(map[string]interface{})
 
 	if request.TerminationGracePeriod != nil {
@@ -65,7 +152,7 @@ func FromApiOptionalSpecToChangeMap(request *api.OptionalSpec) map[string]interf
 	}
 
 	if request.Containers != nil {
-		changeMap[patch_scheduler.LabelSpecContainers] = FromApiOptinalContainersToChangeMap(request.GetContainers())
+		changeMap[patch_scheduler.LabelSpecContainers] = fromApiOptionalContainersToChangeMap(request.GetContainers())
 	}
 
 	if request.Toleration != nil {
@@ -79,7 +166,7 @@ func FromApiOptionalSpecToChangeMap(request *api.OptionalSpec) map[string]interf
 	return changeMap
 }
 
-func FromApiOptinalContainersToChangeMap(request []*api.OptionalContainer) []map[string]interface{} {
+func fromApiOptionalContainersToChangeMap(request []*api.OptionalContainer) []map[string]interface{} {
 	returnSlice := make([]map[string]interface{}, 0, len(request))
 
 	for _, container := range request {
@@ -102,7 +189,7 @@ func FromApiOptinalContainersToChangeMap(request []*api.OptionalContainer) []map
 		}
 
 		if container.Environment != nil {
-			changeMap[patch_scheduler.LabelContainerEnvironment] = FromApiContainerEnvironments(container.GetEnvironment())
+			changeMap[patch_scheduler.LabelContainerEnvironment] = fromApiContainerEnvironments(container.GetEnvironment())
 		}
 
 		if container.Requests != nil {
@@ -120,7 +207,7 @@ func FromApiOptinalContainersToChangeMap(request []*api.OptionalContainer) []map
 		}
 
 		if container.Ports != nil {
-			changeMap[patch_scheduler.LabelContainerPorts] = FromApiContainerPorts(container.GetPorts())
+			changeMap[patch_scheduler.LabelContainerPorts] = fromApiContainerPorts(container.GetPorts())
 		}
 
 		returnSlice = append(returnSlice, changeMap)
@@ -129,28 +216,91 @@ func FromApiOptinalContainersToChangeMap(request []*api.OptionalContainer) []map
 	return returnSlice
 }
 
-func FromApiForwarders(apiForwarders []*api.Forwarder) []*forwarder.Forwarder {
-	var forwarders []*forwarder.Forwarder
-	for _, apiForwarder := range apiForwarders {
-		forwarderStruct := forwarder.Forwarder{
-			Name:        apiForwarder.GetName(),
-			Enabled:     apiForwarder.GetEnable(),
-			ForwardType: forwarder.ForwardType(apiForwarder.GetType()),
-			Address:     apiForwarder.GetAddress(),
+func fromEntityForwardersToResponse(entities []*forwarder.Forwarder) ([]*api.Forwarder, error) {
+	forwarders := make([]*api.Forwarder, len(entities))
+	for i, entity := range entities {
+		opts, err := fromEntityForwardOptions(entity.Options)
+		if err != nil {
+			return nil, err
 		}
 
-		if apiForwarder.Options != nil {
-			forwarderStruct.Options = &forwarder.ForwardOptions{
-				Timeout:  time.Duration(apiForwarder.Options.GetTimeout()),
-				Metadata: apiForwarder.Options.Metadata.AsMap(),
-			}
+		forwarders[i] = &api.Forwarder{
+			Name:    entity.Name,
+			Enable:  entity.Enabled,
+			Type:    fmt.Sprint(entity.ForwardType),
+			Address: entity.Address,
+			Options: opts,
 		}
-		forwarders = append(forwarders, &forwarderStruct)
 	}
-	return forwarders
+	return forwarders, nil
 }
 
-func FromApiContainerEnvironments(apiEnvironments []*api.ContainerEnvironment) []game_room.ContainerEnvironment {
+func fromEntityForwardOptions(entity *forwarder.ForwardOptions) (*api.ForwarderOptions, error) {
+	if entity == nil {
+		return nil, nil
+	}
+	protoStruct, err := _struct.NewStruct(entity.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.ForwarderOptions{
+		Timeout:  int64(entity.Timeout),
+		Metadata: protoStruct,
+	}, nil
+}
+
+func fromApiSpec(apiSpec *api.Spec) *game_room.Spec {
+	return game_room.NewSpec(
+		"",
+		time.Duration(apiSpec.GetTerminationGracePeriod()),
+		fromApiContainers(apiSpec.GetContainers()),
+		apiSpec.GetToleration(),
+		apiSpec.GetAffinity(),
+	)
+}
+
+func fromApiContainers(apiContainers []*api.Container) []game_room.Container {
+	var containers []game_room.Container
+	for _, apiContainer := range apiContainers {
+		container := game_room.Container{
+			Name:            apiContainer.GetName(),
+			Image:           apiContainer.GetImage(),
+			ImagePullPolicy: apiContainer.GetImagePullPolicy(),
+			Command:         apiContainer.GetCommand(),
+			Ports:           fromApiContainerPorts(apiContainer.GetPorts()),
+			Environment:     fromApiContainerEnvironments(apiContainer.GetEnvironment()),
+			Requests: game_room.ContainerResources{
+				CPU:    apiContainer.GetRequests().GetCpu(),
+				Memory: apiContainer.GetRequests().GetMemory(),
+			},
+			Limits: game_room.ContainerResources{
+				CPU:    apiContainer.GetLimits().GetCpu(),
+				Memory: apiContainer.GetLimits().GetMemory(),
+			},
+		}
+		containers = append(containers, container)
+	}
+
+	return containers
+}
+
+func fromApiContainerPorts(apiPorts []*api.ContainerPort) []game_room.ContainerPort {
+	var ports []game_room.ContainerPort
+	for _, apiPort := range apiPorts {
+		port := game_room.ContainerPort{
+			Name:     apiPort.GetName(),
+			Port:     int(apiPort.GetPort()),
+			Protocol: apiPort.GetProtocol(),
+			HostPort: int(apiPort.GetHostPort()),
+		}
+		ports = append(ports, port)
+	}
+
+	return ports
+}
+
+func fromApiContainerEnvironments(apiEnvironments []*api.ContainerEnvironment) []game_room.ContainerEnvironment {
 	var environments []game_room.ContainerEnvironment
 	for _, apiEnvironment := range apiEnvironments {
 		environment := game_room.ContainerEnvironment{
@@ -179,17 +329,111 @@ func FromApiContainerEnvironments(apiEnvironments []*api.ContainerEnvironment) [
 	return environments
 }
 
-func FromApiContainerPorts(apiPorts []*api.ContainerPort) []game_room.ContainerPort {
-	var ports []game_room.ContainerPort
-	for _, apiPort := range apiPorts {
-		port := game_room.ContainerPort{
-			Name:     apiPort.GetName(),
-			Port:     int(apiPort.GetPort()),
-			Protocol: apiPort.GetProtocol(),
-			HostPort: int(apiPort.GetHostPort()),
+func fromApiForwarders(apiForwarders []*api.Forwarder) []*forwarder.Forwarder {
+	var forwarders []*forwarder.Forwarder
+	for _, apiForwarder := range apiForwarders {
+		_forwarder := forwarder.Forwarder{
+			Name:        apiForwarder.GetName(),
+			Enabled:     apiForwarder.GetEnable(),
+			ForwardType: forwarder.ForwardType(apiForwarder.GetType()),
+			Address:     apiForwarder.GetAddress(),
+			Options: &forwarder.ForwardOptions{
+				Timeout:  time.Duration(apiForwarder.Options.GetTimeout()),
+				Metadata: apiForwarder.Options.Metadata.AsMap(),
+			},
 		}
-		ports = append(ports, port)
+		forwarders = append(forwarders, &_forwarder)
+	}
+	return forwarders
+}
+
+func getPortRange(portRange *entities.PortRange) *api.PortRange {
+	if portRange != nil {
+		return &api.PortRange{
+			Start: portRange.Start,
+			End:   portRange.End,
+		}
 	}
 
-	return ports
+	return nil
+}
+
+func getSpec(spec game_room.Spec) *api.Spec {
+	if spec.Version != "" {
+		return &api.Spec{
+			Version:                spec.Version,
+			Toleration:             spec.Toleration,
+			Containers:             fromEntityContainerToApiContainer(spec.Containers),
+			TerminationGracePeriod: int64(spec.TerminationGracePeriod),
+			Affinity:               spec.Affinity,
+		}
+	}
+
+	return nil
+}
+
+func fromEntityContainerToApiContainer(containers []game_room.Container) []*api.Container {
+	var convertedContainers []*api.Container
+	for _, container := range containers {
+		convertedContainers = append(convertedContainers, &api.Container{
+			Name:            container.Name,
+			Image:           container.Image,
+			ImagePullPolicy: container.ImagePullPolicy,
+			Command:         container.Command,
+			Environment:     fromEntityContainerEnvironmentToApiContainerEnvironment(container.Environment),
+			Requests:        fromEntityContainerResourcesToApiContainerResources(container.Requests),
+			Limits:          fromEntityContainerResourcesToApiContainerResources(container.Limits),
+			Ports:           fromEntityContainerPortsToApiContainerPorts(container.Ports),
+		})
+	}
+	return convertedContainers
+}
+
+func fromEntityContainerEnvironmentToApiContainerEnvironment(environments []game_room.ContainerEnvironment) []*api.ContainerEnvironment {
+	var convertedContainerEnvironment []*api.ContainerEnvironment
+	for _, environment := range environments {
+		apiContainerEnv := &api.ContainerEnvironment{
+			Name: environment.Name,
+		}
+		switch {
+		case environment.Value != "":
+			envValue := environment.Value
+			apiContainerEnv.Value = &envValue
+		case environment.ValueFrom != nil && environment.ValueFrom.SecretKeyRef != nil:
+			apiContainerEnv.ValueFrom = &api.ContainerEnvironmentValueFrom{
+				SecretKeyRef: &api.ContainerEnvironmentValueFromSecretKeyRef{
+					Name: environment.ValueFrom.SecretKeyRef.Name,
+					Key:  environment.ValueFrom.SecretKeyRef.Key,
+				},
+			}
+		case environment.ValueFrom != nil && environment.ValueFrom.FieldRef != nil:
+			apiContainerEnv.ValueFrom = &api.ContainerEnvironmentValueFrom{
+				FieldRef: &api.ContainerEnvironmentValueFromFieldRef{
+					FieldPath: environment.ValueFrom.FieldRef.FieldPath,
+				},
+			}
+		}
+		convertedContainerEnvironment = append(convertedContainerEnvironment, apiContainerEnv)
+	}
+	return convertedContainerEnvironment
+}
+
+func fromEntityContainerResourcesToApiContainerResources(resources game_room.ContainerResources) *api.ContainerResources {
+	return &api.ContainerResources{
+		Memory: resources.Memory,
+		Cpu:    resources.CPU,
+	}
+}
+
+func fromEntityContainerPortsToApiContainerPorts(ports []game_room.ContainerPort) []*api.ContainerPort {
+	var convertedContainerPort []*api.ContainerPort
+	for _, port := range ports {
+		convertedContainerPort = append(convertedContainerPort, &api.ContainerPort{
+			Name:     port.Name,
+			Protocol: port.Protocol,
+			Port:     int32(port.Port),
+			HostPort: int32(port.HostPort),
+		})
+	}
+	return convertedContainerPort
 }

--- a/internal/api/handlers/request_adapters/schedulers.go
+++ b/internal/api/handlers/request_adapters/schedulers.go
@@ -332,17 +332,22 @@ func fromApiContainerEnvironments(apiEnvironments []*api.ContainerEnvironment) [
 func fromApiForwarders(apiForwarders []*api.Forwarder) []*forwarder.Forwarder {
 	var forwarders []*forwarder.Forwarder
 	for _, apiForwarder := range apiForwarders {
-		_forwarder := forwarder.Forwarder{
+		var options *forwarder.ForwardOptions
+		if apiForwarder.GetOptions() != nil {
+			options = &forwarder.ForwardOptions{
+				Timeout:  time.Duration(apiForwarder.Options.GetTimeout()),
+				Metadata: apiForwarder.Options.Metadata.AsMap(),
+			}
+		}
+
+		forwarderStruct := forwarder.Forwarder{
 			Name:        apiForwarder.GetName(),
 			Enabled:     apiForwarder.GetEnable(),
 			ForwardType: forwarder.ForwardType(apiForwarder.GetType()),
 			Address:     apiForwarder.GetAddress(),
-			Options: &forwarder.ForwardOptions{
-				Timeout:  time.Duration(apiForwarder.Options.GetTimeout()),
-				Metadata: apiForwarder.Options.Metadata.AsMap(),
-			},
+			Options:     options,
 		}
-		forwarders = append(forwarders, &_forwarder)
+		forwarders = append(forwarders, &forwarderStruct)
 	}
 	return forwarders
 }

--- a/internal/api/handlers/request_adapters/schedulers_test.go
+++ b/internal/api/handlers/request_adapters/schedulers_test.go
@@ -149,7 +149,7 @@ func TestFromApiPatchSchedulerRequestToChangeMap(t *testing.T) {
 							Enabled:     false,
 							ForwardType: forwarder.ForwardType("another-type"),
 							Address:     "localhost:8888",
-							Options: nil,
+							Options:     nil,
 						},
 					},
 				},

--- a/internal/api/handlers/request_adapters/schedulers_test.go
+++ b/internal/api/handlers/request_adapters/schedulers_test.go
@@ -26,14 +26,15 @@
 package request_adapters_test
 
 import (
+	"testing"
+	"time"
+
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 	"github.com/topfreegames/maestro/internal/validations"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/topfreegames/maestro/internal/api/handlers/request_adapters"
@@ -1032,7 +1033,7 @@ func TestFromEntitySchedulerToResponse(t *testing.T) {
 						Start: 10000,
 						End:   60000,
 					},
-					MaxSurge:  maxSurgeValue,
+					MaxSurge: maxSurgeValue,
 					Forwarders: []*forwarder.Forwarder{
 						{
 							Name:        "some-forwarder",
@@ -1049,9 +1050,9 @@ func TestFromEntitySchedulerToResponse(t *testing.T) {
 			},
 			Output: Output{
 				ApiScheduler: &api.Scheduler{
-					Name:  genericString,
-					Game:  genericString,
-					State: "creating",
+					Name:      genericString,
+					Game:      genericString,
+					State:     "creating",
 					CreatedAt: timestamppb.New(genericTime),
 					Spec: &api.Spec{
 						Version:                genericValidVersion,
@@ -1200,7 +1201,7 @@ func TestFromEntitySchedulerVersionListToResponse(t *testing.T) {
 					{
 						Version:   "v1.0.0",
 						IsActive:  false,
-						CreatedAt: genericTime.Add(-time.Hour*24),
+						CreatedAt: genericTime.Add(-time.Hour * 24),
 					},
 				},
 			},
@@ -1214,7 +1215,7 @@ func TestFromEntitySchedulerVersionListToResponse(t *testing.T) {
 					{
 						Version:   "v1.0.0",
 						IsActive:  false,
-						CreatedAt: timestamppb.New(genericTime.Add(-time.Hour*24)),
+						CreatedAt: timestamppb.New(genericTime.Add(-time.Hour * 24)),
 					},
 				},
 			},
@@ -1237,7 +1238,6 @@ func TestFromEntitySchedulerInfoToListResponse(t *testing.T) {
 	type Output struct {
 		ApiSchedulerInfo *api.SchedulerInfo
 	}
-
 
 	genericString := "some-value"
 	genericInt := 62

--- a/internal/api/handlers/request_adapters/schedulers_test.go
+++ b/internal/api/handlers/request_adapters/schedulers_test.go
@@ -126,9 +126,7 @@ func TestFromApiPatchSchedulerRequestToChangeMap(t *testing.T) {
 							Enable:  false,
 							Type:    "another-type",
 							Address: "localhost:8888",
-							Options: &api.ForwarderOptions{
-								Timeout: int64(10),
-							},
+							Options: nil,
 						},
 					},
 				},
@@ -151,10 +149,7 @@ func TestFromApiPatchSchedulerRequestToChangeMap(t *testing.T) {
 							Enabled:     false,
 							ForwardType: forwarder.ForwardType("another-type"),
 							Address:     "localhost:8888",
-							Options: &forwarder.ForwardOptions{
-								Timeout:  time.Duration(10),
-								Metadata: map[string]interface{}{},
-							},
+							Options: nil,
 						},
 					},
 				},

--- a/internal/api/handlers/request_adapters/schedulers_test.go
+++ b/internal/api/handlers/request_adapters/schedulers_test.go
@@ -26,463 +26,20 @@
 package request_adapters_test
 
 import (
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/topfreegames/maestro/internal/core/entities"
+	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
+	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+	"github.com/topfreegames/maestro/internal/validations"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/topfreegames/maestro/internal/api/handlers/request_adapters"
-	"github.com/topfreegames/maestro/internal/core/entities"
-	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
-	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 	"github.com/topfreegames/maestro/internal/core/services/scheduler_manager/patch_scheduler"
 	api "github.com/topfreegames/maestro/pkg/api/v1"
 )
-
-func TestFromApiContainerPort(t *testing.T) {
-	type Input struct {
-		Ports []*api.ContainerPort
-	}
-
-	type Output struct {
-		Ports []game_room.ContainerPort
-	}
-
-	testCases := []struct {
-		Title string
-		Input
-		Output
-	}{
-		{
-			Title: "should convert api.ContainerPort to game_room.ContainerPort",
-			Input: Input{
-				Ports: []*api.ContainerPort{
-					{
-						Name:     "some-port",
-						Protocol: "TCP",
-						Port:     72,
-						HostPort: 1234,
-					},
-					{
-						Name:     "another-port",
-						Protocol: "UDP",
-						Port:     73,
-						HostPort: 12345,
-					},
-				},
-			},
-			Output: Output{
-				Ports: []game_room.ContainerPort{
-					{
-						Name:     "some-port",
-						Protocol: "TCP",
-						Port:     72,
-						HostPort: 1234,
-					},
-					{
-						Name:     "another-port",
-						Protocol: "UDP",
-						Port:     73,
-						HostPort: 12345,
-					},
-				},
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.Title, func(t *testing.T) {
-			returnValues := request_adapters.FromApiContainerPorts(testCase.Input.Ports)
-			assert.EqualValues(t, testCase.Output.Ports, returnValues)
-		})
-	}
-}
-
-func TestFromApiContainerEnvironments(t *testing.T) {
-	type Input struct {
-		Environments []*api.ContainerEnvironment
-	}
-
-	type Output struct {
-		Environments []game_room.ContainerEnvironment
-	}
-
-	value := "some-value"
-
-	testCases := []struct {
-		Title string
-		Input
-		Output
-	}{
-		{
-			Title: "should convert api.ContainerEnvironment to game_room.ContainerEnvironment",
-			Input: Input{
-				Environments: []*api.ContainerEnvironment{
-					{
-						Name:  "some-environment",
-						Value: &value,
-					},
-					{
-						Name: "another-environment",
-						ValueFrom: &api.ContainerEnvironmentValueFrom{
-							FieldRef: &api.ContainerEnvironmentValueFromFieldRef{
-								FieldPath: "some-field-path",
-							},
-						},
-					},
-					{
-						Name: "another-environment",
-						ValueFrom: &api.ContainerEnvironmentValueFrom{
-							SecretKeyRef: &api.ContainerEnvironmentValueFromSecretKeyRef{
-								Name: "some-name",
-								Key:  "some-key",
-							},
-						},
-					},
-				},
-			},
-			Output: Output{
-				Environments: []game_room.ContainerEnvironment{
-					{
-						Name:  "some-environment",
-						Value: "some-value",
-					},
-					{
-						Name: "another-environment",
-						ValueFrom: &game_room.ValueFrom{
-							FieldRef: &game_room.FieldRef{
-								FieldPath: "some-field-path",
-							},
-						},
-					},
-					{
-						Name: "another-environment",
-						ValueFrom: &game_room.ValueFrom{
-							SecretKeyRef: &game_room.SecretKeyRef{
-								Name: "some-name",
-								Key:  "some-key",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.Title, func(t *testing.T) {
-			returnValues := request_adapters.FromApiContainerEnvironments(testCase.Input.Environments)
-			assert.EqualValues(t, testCase.Output.Environments, returnValues)
-		})
-	}
-}
-
-func TestFromApiForwarders(t *testing.T) {
-	type Input struct {
-		Forwarders []*api.Forwarder
-	}
-
-	type Output struct {
-		Forwarders []*forwarder.Forwarder
-	}
-
-	testCases := []struct {
-		Title string
-		Input
-		Output
-	}{
-		{
-			Title: "should convert api.Forwarder to forwarder.Forwarder",
-			Input: Input{
-				Forwarders: []*api.Forwarder{
-					{
-						Name:    "some-forwarder",
-						Enable:  true,
-						Type:    "some-type",
-						Address: "localhost:8080",
-						Options: &api.ForwarderOptions{
-							Timeout: int64(10),
-						},
-					},
-					{
-						Name:    "another-forwarder",
-						Enable:  false,
-						Type:    "another-type",
-						Address: "localhost:8888",
-						Options: &api.ForwarderOptions{
-							Timeout: int64(10),
-						},
-					},
-				},
-			},
-			Output: Output{
-				Forwarders: []*forwarder.Forwarder{
-					{
-						Name:        "some-forwarder",
-						Enabled:     true,
-						ForwardType: forwarder.ForwardType("some-type"),
-						Address:     "localhost:8080",
-						Options: &forwarder.ForwardOptions{
-							Timeout:  time.Duration(10),
-							Metadata: map[string]interface{}{},
-						},
-					},
-					{
-						Name:        "another-forwarder",
-						Enabled:     false,
-						ForwardType: forwarder.ForwardType("another-type"),
-						Address:     "localhost:8888",
-						Options: &forwarder.ForwardOptions{
-							Timeout:  time.Duration(10),
-							Metadata: map[string]interface{}{},
-						},
-					},
-				},
-			},
-		},
-		{
-			Title: "should convert api.Forwarder to forwarder.Forwarder when options is nil",
-			Input: Input{
-				Forwarders: []*api.Forwarder{
-					{
-						Name:    "some-forwarder",
-						Enable:  true,
-						Type:    "some-type",
-						Address: "localhost:8080",
-						Options: nil,
-					},
-				},
-			},
-			Output: Output{
-				Forwarders: []*forwarder.Forwarder{
-					{
-						Name:        "some-forwarder",
-						Enabled:     true,
-						ForwardType: forwarder.ForwardType("some-type"),
-						Address:     "localhost:8080",
-						Options:     nil,
-					},
-				},
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.Title, func(t *testing.T) {
-			returnValues := request_adapters.FromApiForwarders(testCase.Input.Forwarders)
-			assert.EqualValues(t, testCase.Output.Forwarders, returnValues)
-		})
-	}
-}
-
-func TestFromApiOptinalContainersToChangeMap(t *testing.T) {
-	type Input struct {
-		Containers []*api.OptionalContainer
-	}
-
-	type Output struct {
-		Containers []map[string]interface{}
-	}
-
-	value := "some-value"
-
-	testCases := []struct {
-		Title string
-		Input
-		Output
-	}{
-		{
-			Title: "should convert api.OptionalContainer to change map",
-			Input: Input{
-				Containers: []*api.OptionalContainer{
-					{
-						Name: &value,
-					},
-					{
-						Image: &value,
-					},
-					{
-						ImagePullPolicy: &value,
-					},
-					{
-						Command: []string{"/bin/sh", "command"},
-					},
-					{
-						Environment: []*api.ContainerEnvironment{
-							{
-								Name:  "some-environment",
-								Value: &value,
-							},
-						},
-					},
-					{
-						Requests: &api.ContainerResources{
-							Memory: "1000m",
-							Cpu:    "100",
-						},
-					},
-					{
-						Limits: &api.ContainerResources{
-							Memory: "2000m",
-							Cpu:    "200",
-						},
-					},
-					{
-						Ports: []*api.ContainerPort{
-							{
-								Name:     "some-port",
-								Protocol: "TCP",
-								Port:     123,
-								HostPort: 1234,
-							},
-						},
-					},
-				},
-			},
-			Output: Output{
-				Containers: []map[string]interface{}{
-					map[string]interface{}{
-						patch_scheduler.LabelContainerName: value,
-					},
-					map[string]interface{}{
-						patch_scheduler.LabelContainerImage: value,
-					},
-					map[string]interface{}{
-						patch_scheduler.LabelContainerImagePullPolicy: value,
-					},
-					map[string]interface{}{
-						patch_scheduler.LabelContainerCommand: []string{"/bin/sh", "command"},
-					},
-					map[string]interface{}{
-						patch_scheduler.LabelContainerEnvironment: []game_room.ContainerEnvironment{
-							{
-								Name:  "some-environment",
-								Value: "some-value",
-							},
-						},
-					},
-					map[string]interface{}{
-						patch_scheduler.LabelContainerRequests: game_room.ContainerResources{
-							CPU:    "100",
-							Memory: "1000m",
-						},
-					},
-					map[string]interface{}{
-						patch_scheduler.LabelContainerLimits: game_room.ContainerResources{
-							CPU:    "200",
-							Memory: "2000m",
-						},
-					},
-					map[string]interface{}{
-						patch_scheduler.LabelContainerPorts: []game_room.ContainerPort{
-							{
-								Name:     "some-port",
-								Protocol: "TCP",
-								Port:     int(123),
-								HostPort: int(1234),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.Title, func(t *testing.T) {
-			returnValues := request_adapters.FromApiOptinalContainersToChangeMap(testCase.Input.Containers)
-			assert.EqualValues(t, testCase.Output.Containers, returnValues)
-		})
-	}
-}
-
-func TestFromApiOptionalSpecToChangeMap(t *testing.T) {
-	type Input struct {
-		Spec *api.OptionalSpec
-	}
-
-	type Output struct {
-		Spec map[string]interface{}
-	}
-
-	terminationValue := int64(62)
-	containerValue := "value"
-	tolerationValue := "some-toleration"
-	affinityValue := "some-affinity"
-
-	testCases := []struct {
-		Title string
-		Input
-		Output
-	}{
-		{
-			Title: "only termination grace period should convert api.OptionalSpec to change map",
-			Input: Input{
-				Spec: &api.OptionalSpec{
-					TerminationGracePeriod: &terminationValue,
-				},
-			},
-			Output: Output{
-				Spec: map[string]interface{}{
-					patch_scheduler.LabelSpecTerminationGracePeriod: time.Duration(terminationValue),
-				},
-			},
-		},
-		{
-			Title: "only containers should convert api.OptionalSpec to change map",
-			Input: Input{
-				Spec: &api.OptionalSpec{
-					Containers: []*api.OptionalContainer{
-						{
-							Image: &containerValue,
-						},
-					},
-				},
-			},
-			Output: Output{
-				Spec: map[string]interface{}{
-					patch_scheduler.LabelSpecContainers: []map[string]interface{}{
-						{
-							patch_scheduler.LabelContainerImage: containerValue,
-						},
-					},
-				},
-			},
-		},
-		{
-			Title: "only toleration should convert api.OptionalSpec to change map",
-			Input: Input{
-				Spec: &api.OptionalSpec{
-					Toleration: &tolerationValue,
-				},
-			},
-			Output: Output{
-				Spec: map[string]interface{}{
-					patch_scheduler.LabelSpecToleration: tolerationValue,
-				},
-			},
-		},
-		{
-			Title: "only affinity should convert api.OptionalSpec to change map",
-			Input: Input{
-				Spec: &api.OptionalSpec{
-					Affinity: &affinityValue,
-				},
-			},
-			Output: Output{
-				Spec: map[string]interface{}{
-					patch_scheduler.LabelSpecAffinity: affinityValue,
-				},
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.Title, func(t *testing.T) {
-			returnValues := request_adapters.FromApiOptionalSpecToChangeMap(testCase.Input.Spec)
-			assert.EqualValues(t, testCase.Output.Spec, returnValues)
-		})
-	}
-}
 
 func TestFromApiPatchSchedulerRequestToChangeMap(t *testing.T) {
 	type Input struct {
@@ -495,6 +52,8 @@ func TestFromApiPatchSchedulerRequestToChangeMap(t *testing.T) {
 
 	terminationValue := int64(62)
 	maxSurgeValue := "60%"
+	genericString := "some-value"
+	genericStringList := []string{"some-value", "another-value"}
 
 	testCases := []struct {
 		Title string
@@ -600,12 +159,1125 @@ func TestFromApiPatchSchedulerRequestToChangeMap(t *testing.T) {
 				},
 			},
 		},
+		{
+			Title: "only containers should convert api.PatchSchedulerRequest to change map",
+			Input: Input{
+				PatchScheduler: &api.PatchSchedulerRequest{
+					Spec: &api.OptionalSpec{Containers: []*api.OptionalContainer{
+						{
+							Name: &genericString,
+						},
+						{
+							Image: &genericString,
+						},
+						{
+							ImagePullPolicy: &genericString,
+						},
+						{
+							Command: genericStringList,
+						},
+						{
+							Environment: []*api.ContainerEnvironment{
+								{
+									Name:  genericString,
+									Value: &genericString,
+								},
+							},
+						},
+						{
+							Requests: &api.ContainerResources{
+								Memory: "1000m",
+								Cpu:    "100",
+							},
+						},
+						{
+							Limits: &api.ContainerResources{
+								Memory: "2000m",
+								Cpu:    "200",
+							},
+						},
+						{
+							Ports: []*api.ContainerPort{
+								{
+									Name:     "some-port",
+									Protocol: "TCP",
+									Port:     123,
+									HostPort: 1234,
+								},
+							},
+						},
+					}},
+				},
+			},
+			Output: Output{
+				PatchScheduler: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecContainers: []map[string]interface{}{
+							{
+								patch_scheduler.LabelContainerName: genericString,
+							},
+							{
+								patch_scheduler.LabelContainerImage: genericString,
+							},
+							{
+								patch_scheduler.LabelContainerImagePullPolicy: genericString,
+							},
+							{
+								patch_scheduler.LabelContainerCommand: genericStringList,
+							},
+							{
+								patch_scheduler.LabelContainerEnvironment: []game_room.ContainerEnvironment{
+									{
+										Name:  genericString,
+										Value: genericString,
+									},
+								},
+							},
+							{
+								patch_scheduler.LabelContainerRequests: game_room.ContainerResources{
+									CPU:    "100",
+									Memory: "1000m",
+								},
+							},
+							{
+								patch_scheduler.LabelContainerLimits: game_room.ContainerResources{
+									CPU:    "200",
+									Memory: "2000m",
+								},
+							},
+							{
+								patch_scheduler.LabelContainerPorts: []game_room.ContainerPort{
+									{
+										Name:     "some-port",
+										Protocol: "TCP",
+										Port:     int(123),
+										HostPort: int(1234),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Title: "only toleration should convert api.PatchSchedulerRequest to change map",
+			Input: Input{
+				PatchScheduler: &api.PatchSchedulerRequest{
+					Spec: &api.OptionalSpec{Toleration: &genericString},
+				},
+			},
+			Output: Output{
+				PatchScheduler: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecToleration: genericString,
+					},
+				},
+			},
+		},
+		{
+			Title: "only affinity should convert api.PatchSchedulerRequest to change map",
+			Input: Input{
+				PatchScheduler: &api.PatchSchedulerRequest{
+					Spec: &api.OptionalSpec{Affinity: &genericString},
+				},
+			},
+			Output: Output{
+				PatchScheduler: map[string]interface{}{
+					patch_scheduler.LabelSchedulerSpec: map[string]interface{}{
+						patch_scheduler.LabelSpecAffinity: genericString,
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Title, func(t *testing.T) {
 			returnValues := request_adapters.FromApiPatchSchedulerRequestToChangeMap(testCase.Input.PatchScheduler)
 			assert.EqualValues(t, testCase.Output.PatchScheduler, returnValues)
+		})
+	}
+}
+
+func TestFromApiCreateSchedulerRequestToEntity(t *testing.T) {
+	err := validations.RegisterValidations()
+	if err != nil {
+		t.Errorf("unexpected error %d'", err)
+	}
+
+	type Input struct {
+		CreateScheduler *api.CreateSchedulerRequest
+	}
+
+	type Output struct {
+		Scheduler *entities.Scheduler
+	}
+
+	genericInt32 := int32(62)
+	genericInt := 62
+	maxSurgeValue := "60%"
+	genericString := "some-value"
+	genericValidVersion := "v1.0.0"
+	genericStringList := []string{"some-value", "another-value"}
+
+	testCases := []struct {
+		Title string
+		Input
+		Output
+	}{
+		{
+			Title: "convert create api scheduler to entity scheduler",
+			Input: Input{
+				CreateScheduler: &api.CreateSchedulerRequest{
+					Name: genericString,
+					Game: genericString,
+					Spec: &api.Spec{
+						Version:                genericValidVersion,
+						TerminationGracePeriod: 10,
+						Toleration:             genericString,
+						Affinity:               genericString,
+						Containers: []*api.Container{
+							{
+								Name:            genericString,
+								Image:           genericString,
+								ImagePullPolicy: genericString,
+								Command:         genericStringList,
+								Environment: []*api.ContainerEnvironment{
+									{
+										Name:  genericString,
+										Value: &genericString,
+									},
+									{
+										Name: genericString,
+										ValueFrom: &api.ContainerEnvironmentValueFrom{
+											FieldRef: &api.ContainerEnvironmentValueFromFieldRef{FieldPath: genericString},
+										},
+									},
+									{
+										Name: genericString,
+										ValueFrom: &api.ContainerEnvironmentValueFrom{
+											SecretKeyRef: &api.ContainerEnvironmentValueFromSecretKeyRef{
+												Name: genericString,
+												Key:  genericString,
+											},
+										},
+									},
+								},
+								Requests: &api.ContainerResources{
+									Memory: "1000m",
+									Cpu:    "100",
+								},
+								Limits: &api.ContainerResources{
+									Memory: "1000m",
+									Cpu:    "100",
+								},
+								Ports: []*api.ContainerPort{
+									{
+										Name:     genericString,
+										Port:     genericInt32,
+										Protocol: "TCP",
+									},
+								},
+							},
+						},
+					},
+					PortRange: &api.PortRange{
+						Start: 10000,
+						End:   60000,
+					},
+					MaxSurge: maxSurgeValue,
+					Forwarders: []*api.Forwarder{
+						{
+							Name:    "some-forwarder",
+							Enable:  true,
+							Type:    "some-type",
+							Address: "localhost:8080",
+							Options: &api.ForwarderOptions{
+								Timeout: int64(10),
+							},
+						},
+						{
+							Name:    "another-forwarder",
+							Enable:  false,
+							Type:    "another-type",
+							Address: "localhost:8888",
+							Options: &api.ForwarderOptions{
+								Timeout: int64(10),
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				Scheduler: &entities.Scheduler{
+					Name:  genericString,
+					Game:  genericString,
+					State: entities.StateCreating,
+					Spec: game_room.Spec{
+						Version:                genericValidVersion,
+						TerminationGracePeriod: time.Duration(10),
+						Containers: []game_room.Container{
+							{
+								Name:            genericString,
+								Image:           genericString,
+								ImagePullPolicy: genericString,
+								Command:         genericStringList,
+								Environment: []game_room.ContainerEnvironment{
+									{
+										Name:  genericString,
+										Value: genericString,
+									},
+									{
+										Name: genericString,
+										ValueFrom: &game_room.ValueFrom{
+											FieldRef: &game_room.FieldRef{FieldPath: genericString},
+										},
+									},
+									{
+										Name: genericString,
+										ValueFrom: &game_room.ValueFrom{
+											SecretKeyRef: &game_room.SecretKeyRef{
+												Name: genericString,
+												Key:  genericString,
+											},
+										},
+									},
+								},
+								Requests: game_room.ContainerResources{
+									Memory: "1000m",
+									CPU:    "100",
+								},
+								Limits: game_room.ContainerResources{
+									Memory: "1000m",
+									CPU:    "100",
+								},
+								Ports: []game_room.ContainerPort{
+									{
+										Name:     genericString,
+										Port:     genericInt,
+										Protocol: "TCP",
+									},
+								},
+							},
+						},
+						Toleration: genericString,
+						Affinity:   genericString,
+					},
+					PortRange: &entities.PortRange{
+						Start: 10000,
+						End:   60000,
+					},
+					MaxSurge: maxSurgeValue,
+					Forwarders: []*forwarder.Forwarder{
+						{
+							Name:        "some-forwarder",
+							Enabled:     true,
+							ForwardType: forwarder.ForwardType("some-type"),
+							Address:     "localhost:8080",
+							Options: &forwarder.ForwardOptions{
+								Timeout:  time.Duration(10),
+								Metadata: map[string]interface{}{},
+							},
+						},
+						{
+							Name:        "another-forwarder",
+							Enabled:     false,
+							ForwardType: forwarder.ForwardType("another-type"),
+							Address:     "localhost:8888",
+							Options: &forwarder.ForwardOptions{
+								Timeout:  time.Duration(10),
+								Metadata: map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			_scheduler, _ := request_adapters.FromApiCreateSchedulerRequestToEntity(testCase.Input.CreateScheduler)
+			assert.EqualValues(t, testCase.Output.Scheduler, _scheduler)
+		})
+	}
+}
+
+func TestFromEntitySchedulerToListResponse(t *testing.T) {
+	err := validations.RegisterValidations()
+	if err != nil {
+		t.Errorf("unexpected error %d'", err)
+	}
+
+	type Input struct {
+		Scheduler *entities.Scheduler
+	}
+
+	type Output struct {
+		SchedulerWithoutSpec *api.SchedulerWithoutSpec
+	}
+
+	genericInt := 62
+	maxSurgeValue := "60%"
+	genericString := "some-value"
+	genericValidVersion := "v1.0.0"
+	genericStringList := []string{"some-value", "another-value"}
+	genericTime := time.Now()
+
+	testCases := []struct {
+		Title string
+		Input
+		Output
+	}{
+		{
+			Title: "receives entity scheduler without portRange, return api scheduler without spec",
+			Input: Input{
+				Scheduler: &entities.Scheduler{
+					Name:      genericString,
+					Game:      genericString,
+					State:     entities.StateCreating,
+					CreatedAt: genericTime,
+					Spec: game_room.Spec{
+						Version:                genericValidVersion,
+						TerminationGracePeriod: time.Duration(10),
+						Containers: []game_room.Container{
+							{
+								Name:            genericString,
+								Image:           genericString,
+								ImagePullPolicy: genericString,
+								Command:         genericStringList,
+								Environment: []game_room.ContainerEnvironment{
+									{
+										Name:  genericString,
+										Value: genericString,
+									},
+									{
+										Name: genericString,
+										ValueFrom: &game_room.ValueFrom{
+											FieldRef: &game_room.FieldRef{FieldPath: genericString},
+										},
+									},
+									{
+										Name: genericString,
+										ValueFrom: &game_room.ValueFrom{
+											SecretKeyRef: &game_room.SecretKeyRef{
+												Name: genericString,
+												Key:  genericString,
+											},
+										},
+									},
+								},
+								Requests: game_room.ContainerResources{
+									Memory: "1000m",
+									CPU:    "100",
+								},
+								Limits: game_room.ContainerResources{
+									Memory: "1000m",
+									CPU:    "100",
+								},
+								Ports: []game_room.ContainerPort{
+									{
+										Name:     genericString,
+										Port:     genericInt,
+										Protocol: "TCP",
+									},
+								},
+							},
+						},
+						Toleration: genericString,
+						Affinity:   genericString,
+					},
+					PortRange: nil,
+					MaxSurge:  maxSurgeValue,
+					Forwarders: []*forwarder.Forwarder{
+						{
+							Name:        "some-forwarder",
+							Enabled:     true,
+							ForwardType: forwarder.ForwardType("some-type"),
+							Address:     "localhost:8080",
+							Options: &forwarder.ForwardOptions{
+								Timeout:  time.Duration(10),
+								Metadata: map[string]interface{}{},
+							},
+						},
+						{
+							Name:        "another-forwarder",
+							Enabled:     false,
+							ForwardType: forwarder.ForwardType("another-type"),
+							Address:     "localhost:8888",
+							Options: &forwarder.ForwardOptions{
+								Timeout:  time.Duration(10),
+								Metadata: map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				SchedulerWithoutSpec: &api.SchedulerWithoutSpec{
+					Name:      genericString,
+					Game:      genericString,
+					State:     "creating",
+					Version:   genericValidVersion,
+					PortRange: nil,
+					CreatedAt: timestamppb.New(genericTime),
+					MaxSurge:  maxSurgeValue,
+				},
+			},
+		},
+		{
+			Title: "receives entity scheduler with portRange, return api scheduler without spec",
+			Input: Input{
+				Scheduler: &entities.Scheduler{
+					Name:      genericString,
+					Game:      genericString,
+					State:     entities.StateCreating,
+					CreatedAt: genericTime,
+					Spec: game_room.Spec{
+						Version:                genericValidVersion,
+						TerminationGracePeriod: time.Duration(10),
+						Containers: []game_room.Container{
+							{
+								Name:            genericString,
+								Image:           genericString,
+								ImagePullPolicy: genericString,
+								Command:         genericStringList,
+								Environment: []game_room.ContainerEnvironment{
+									{
+										Name:  genericString,
+										Value: genericString,
+									},
+									{
+										Name: genericString,
+										ValueFrom: &game_room.ValueFrom{
+											FieldRef: &game_room.FieldRef{FieldPath: genericString},
+										},
+									},
+									{
+										Name: genericString,
+										ValueFrom: &game_room.ValueFrom{
+											SecretKeyRef: &game_room.SecretKeyRef{
+												Name: genericString,
+												Key:  genericString,
+											},
+										},
+									},
+								},
+								Requests: game_room.ContainerResources{
+									Memory: "1000m",
+									CPU:    "100",
+								},
+								Limits: game_room.ContainerResources{
+									Memory: "1000m",
+									CPU:    "100",
+								},
+								Ports: []game_room.ContainerPort{
+									{
+										Name:     genericString,
+										Port:     genericInt,
+										Protocol: "TCP",
+									},
+								},
+							},
+						},
+						Toleration: genericString,
+						Affinity:   genericString,
+					},
+					PortRange: &entities.PortRange{
+						Start: 10000,
+						End:   60000,
+					},
+					MaxSurge: maxSurgeValue,
+					Forwarders: []*forwarder.Forwarder{
+						{
+							Name:        "some-forwarder",
+							Enabled:     true,
+							ForwardType: forwarder.ForwardType("some-type"),
+							Address:     "localhost:8080",
+							Options: &forwarder.ForwardOptions{
+								Timeout:  time.Duration(10),
+								Metadata: map[string]interface{}{},
+							},
+						},
+						{
+							Name:        "another-forwarder",
+							Enabled:     false,
+							ForwardType: forwarder.ForwardType("another-type"),
+							Address:     "localhost:8888",
+							Options: &forwarder.ForwardOptions{
+								Timeout:  time.Duration(10),
+								Metadata: map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				SchedulerWithoutSpec: &api.SchedulerWithoutSpec{
+					Name:    genericString,
+					Game:    genericString,
+					State:   "creating",
+					Version: genericValidVersion,
+					PortRange: &api.PortRange{
+						Start: 10000,
+						End:   60000,
+					},
+					CreatedAt: timestamppb.New(genericTime),
+					MaxSurge:  maxSurgeValue,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			returnValues := request_adapters.FromEntitySchedulerToListResponse(testCase.Input.Scheduler)
+
+			assert.EqualValues(t, testCase.Output.SchedulerWithoutSpec, returnValues)
+		})
+	}
+}
+
+func TestFromApiNewSchedulerVersionRequestToEntity(t *testing.T) {
+	err := validations.RegisterValidations()
+	if err != nil {
+		t.Errorf("unexpected error %d'", err)
+	}
+
+	type Input struct {
+		NewSchedulerVersion *api.NewSchedulerVersionRequest
+	}
+
+	type Output struct {
+		Scheduler *entities.Scheduler
+	}
+
+	genericInt32 := int32(62)
+	genericInt := 62
+	maxSurgeValue := "60%"
+	genericString := "some-value"
+	genericValidVersion := "v1.0.0"
+	genericStringList := []string{"some-value", "another-value"}
+
+	testCases := []struct {
+		Title string
+		Input
+		Output
+	}{
+		{
+			Title: "convert newSchedulerVersion api scheduler to entity scheduler",
+			Input: Input{
+				NewSchedulerVersion: &api.NewSchedulerVersionRequest{
+					Name: genericString,
+					Game: genericString,
+					Spec: &api.Spec{
+						Version:                genericValidVersion,
+						TerminationGracePeriod: 10,
+						Toleration:             genericString,
+						Affinity:               genericString,
+						Containers: []*api.Container{
+							{
+								Name:            genericString,
+								Image:           genericString,
+								ImagePullPolicy: genericString,
+								Command:         genericStringList,
+								Environment: []*api.ContainerEnvironment{
+									{
+										Name:  genericString,
+										Value: &genericString,
+									},
+									{
+										Name: genericString,
+										ValueFrom: &api.ContainerEnvironmentValueFrom{
+											FieldRef: &api.ContainerEnvironmentValueFromFieldRef{FieldPath: genericString},
+										},
+									},
+									{
+										Name: genericString,
+										ValueFrom: &api.ContainerEnvironmentValueFrom{
+											SecretKeyRef: &api.ContainerEnvironmentValueFromSecretKeyRef{
+												Name: genericString,
+												Key:  genericString,
+											},
+										},
+									},
+								},
+								Requests: &api.ContainerResources{
+									Memory: "1000m",
+									Cpu:    "100",
+								},
+								Limits: &api.ContainerResources{
+									Memory: "1000m",
+									Cpu:    "100",
+								},
+								Ports: []*api.ContainerPort{
+									{
+										Name:     genericString,
+										Port:     genericInt32,
+										Protocol: "TCP",
+									},
+								},
+							},
+						},
+					},
+					PortRange: &api.PortRange{
+						Start: 10000,
+						End:   60000,
+					},
+					MaxSurge: maxSurgeValue,
+					Forwarders: []*api.Forwarder{
+						{
+							Name:    "some-forwarder",
+							Enable:  true,
+							Type:    "some-type",
+							Address: "localhost:8080",
+							Options: &api.ForwarderOptions{
+								Timeout: int64(10),
+							},
+						},
+						{
+							Name:    "another-forwarder",
+							Enable:  false,
+							Type:    "another-type",
+							Address: "localhost:8888",
+							Options: &api.ForwarderOptions{
+								Timeout: int64(10),
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				Scheduler: &entities.Scheduler{
+					Name:  genericString,
+					Game:  genericString,
+					State: entities.StateCreating,
+					Spec: game_room.Spec{
+						Version:                genericValidVersion,
+						TerminationGracePeriod: time.Duration(10),
+						Containers: []game_room.Container{
+							{
+								Name:            genericString,
+								Image:           genericString,
+								ImagePullPolicy: genericString,
+								Command:         genericStringList,
+								Environment: []game_room.ContainerEnvironment{
+									{
+										Name:  genericString,
+										Value: genericString,
+									},
+									{
+										Name: genericString,
+										ValueFrom: &game_room.ValueFrom{
+											FieldRef: &game_room.FieldRef{FieldPath: genericString},
+										},
+									},
+									{
+										Name: genericString,
+										ValueFrom: &game_room.ValueFrom{
+											SecretKeyRef: &game_room.SecretKeyRef{
+												Name: genericString,
+												Key:  genericString,
+											},
+										},
+									},
+								},
+								Requests: game_room.ContainerResources{
+									Memory: "1000m",
+									CPU:    "100",
+								},
+								Limits: game_room.ContainerResources{
+									Memory: "1000m",
+									CPU:    "100",
+								},
+								Ports: []game_room.ContainerPort{
+									{
+										Name:     genericString,
+										Port:     genericInt,
+										Protocol: "TCP",
+									},
+								},
+							},
+						},
+						Toleration: genericString,
+						Affinity:   genericString,
+					},
+					PortRange: &entities.PortRange{
+						Start: 10000,
+						End:   60000,
+					},
+					MaxSurge: maxSurgeValue,
+					Forwarders: []*forwarder.Forwarder{
+						{
+							Name:        "some-forwarder",
+							Enabled:     true,
+							ForwardType: forwarder.ForwardType("some-type"),
+							Address:     "localhost:8080",
+							Options: &forwarder.ForwardOptions{
+								Timeout:  time.Duration(10),
+								Metadata: map[string]interface{}{},
+							},
+						},
+						{
+							Name:        "another-forwarder",
+							Enabled:     false,
+							ForwardType: forwarder.ForwardType("another-type"),
+							Address:     "localhost:8888",
+							Options: &forwarder.ForwardOptions{
+								Timeout:  time.Duration(10),
+								Metadata: map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			_scheduler, _ := request_adapters.FromApiNewSchedulerVersionRequestToEntity(testCase.Input.NewSchedulerVersion)
+			assert.EqualValues(t, testCase.Output.Scheduler, _scheduler)
+		})
+	}
+}
+
+func TestFromEntitySchedulerToResponse(t *testing.T) {
+	err := validations.RegisterValidations()
+	if err != nil {
+		t.Errorf("unexpected error %d'", err)
+	}
+
+	type Input struct {
+		Scheduler *entities.Scheduler
+	}
+
+	type Output struct {
+		ApiScheduler *api.Scheduler
+	}
+
+	genericInt32 := int32(62)
+	genericInt := 62
+	maxSurgeValue := "60%"
+	genericString := "some-value"
+	genericValidVersion := "v1.0.0"
+	genericStringList := []string{"some-value", "another-value"}
+	genericTime := time.Now()
+
+	testCases := []struct {
+		Title string
+		Input
+		Output
+	}{
+		{
+			Title: "receives entity scheduler return api scheduler",
+			Input: Input{
+				Scheduler: &entities.Scheduler{
+					Name:      genericString,
+					Game:      genericString,
+					State:     entities.StateCreating,
+					CreatedAt: genericTime,
+					Spec: game_room.Spec{
+						Version:                genericValidVersion,
+						TerminationGracePeriod: time.Duration(10),
+						Containers: []game_room.Container{
+							{
+								Name:            genericString,
+								Image:           genericString,
+								ImagePullPolicy: genericString,
+								Command:         genericStringList,
+								Environment: []game_room.ContainerEnvironment{
+									{
+										Name:  genericString,
+										Value: genericString,
+									},
+									{
+										Name: genericString,
+										ValueFrom: &game_room.ValueFrom{
+											FieldRef: &game_room.FieldRef{FieldPath: genericString},
+										},
+									},
+									{
+										Name: genericString,
+										ValueFrom: &game_room.ValueFrom{
+											SecretKeyRef: &game_room.SecretKeyRef{
+												Name: genericString,
+												Key:  genericString,
+											},
+										},
+									},
+								},
+								Requests: game_room.ContainerResources{
+									Memory: "1000m",
+									CPU:    "100",
+								},
+								Limits: game_room.ContainerResources{
+									Memory: "1000m",
+									CPU:    "100",
+								},
+								Ports: []game_room.ContainerPort{
+									{
+										Name:     genericString,
+										Port:     genericInt,
+										Protocol: "TCP",
+									},
+								},
+							},
+						},
+						Toleration: genericString,
+						Affinity:   genericString,
+					},
+					PortRange: &entities.PortRange{
+						Start: 10000,
+						End:   60000,
+					},
+					MaxSurge:  maxSurgeValue,
+					Forwarders: []*forwarder.Forwarder{
+						{
+							Name:        "some-forwarder",
+							Enabled:     true,
+							ForwardType: forwarder.ForwardType("some-type"),
+							Address:     "localhost:8080",
+							Options: &forwarder.ForwardOptions{
+								Timeout:  time.Duration(10),
+								Metadata: map[string]interface{}{"some-value": "another-value"},
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ApiScheduler: &api.Scheduler{
+					Name:  genericString,
+					Game:  genericString,
+					State: "creating",
+					CreatedAt: timestamppb.New(genericTime),
+					Spec: &api.Spec{
+						Version:                genericValidVersion,
+						TerminationGracePeriod: 10,
+						Containers: []*api.Container{
+							{
+								Name:            genericString,
+								Image:           genericString,
+								ImagePullPolicy: genericString,
+								Command:         genericStringList,
+								Environment: []*api.ContainerEnvironment{
+									{
+										Name:  genericString,
+										Value: &genericString,
+									},
+									{
+										Name: genericString,
+										ValueFrom: &api.ContainerEnvironmentValueFrom{
+											FieldRef: &api.ContainerEnvironmentValueFromFieldRef{FieldPath: genericString},
+										},
+									},
+									{
+										Name: genericString,
+										ValueFrom: &api.ContainerEnvironmentValueFrom{
+											SecretKeyRef: &api.ContainerEnvironmentValueFromSecretKeyRef{
+												Name: genericString,
+												Key:  genericString,
+											},
+										},
+									},
+								},
+								Requests: &api.ContainerResources{
+									Memory: "1000m",
+									Cpu:    "100",
+								},
+								Limits: &api.ContainerResources{
+									Memory: "1000m",
+									Cpu:    "100",
+								},
+								Ports: []*api.ContainerPort{
+									{
+										Name:     genericString,
+										Port:     genericInt32,
+										Protocol: "TCP",
+									},
+								},
+							},
+						},
+						Toleration: genericString,
+						Affinity:   genericString,
+					},
+					PortRange: &api.PortRange{
+						Start: 10000,
+						End:   60000,
+					},
+					MaxSurge: maxSurgeValue,
+					Forwarders: []*api.Forwarder{
+						{
+							Name:    "some-forwarder",
+							Enable:  true,
+							Type:    "some-type",
+							Address: "localhost:8080",
+							Options: &api.ForwarderOptions{
+								Timeout: int64(10),
+								Metadata: &structpb.Struct{
+									Fields: map[string]*structpb.Value{
+										"some-value": {
+											Kind: &structpb.Value_StringValue{
+												StringValue: "another-value",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			returnValues, _ := request_adapters.FromEntitySchedulerToResponse(testCase.Input.Scheduler)
+
+			assert.EqualValues(t, testCase.Output.ApiScheduler, returnValues)
+		})
+	}
+}
+
+func TestFromEntitySchedulerVersionListToResponse(t *testing.T) {
+	type Input struct {
+		SchedulerVersionList []*entities.SchedulerVersion
+	}
+
+	type Output struct {
+		ApiSchedulerVersionList []*api.SchedulerVersion
+	}
+
+	genericTime := time.Now()
+
+	testCases := []struct {
+		Title string
+		Input
+		Output
+	}{
+		{
+			Title: "List have no value returns empty list successfully",
+			Input: Input{
+				SchedulerVersionList: []*entities.SchedulerVersion{},
+			},
+			Output: Output{
+				ApiSchedulerVersionList: []*api.SchedulerVersion{},
+			},
+		},
+		{
+			Title: "List have 1 value returns converted list successfully",
+			Input: Input{
+				SchedulerVersionList: []*entities.SchedulerVersion{
+					{
+						Version:   "v1.0.0",
+						IsActive:  true,
+						CreatedAt: genericTime,
+					},
+				},
+			},
+			Output: Output{
+				ApiSchedulerVersionList: []*api.SchedulerVersion{
+					{
+						Version:   "v1.0.0",
+						IsActive:  true,
+						CreatedAt: timestamppb.New(genericTime),
+					},
+				},
+			},
+		},
+		{
+			Title: "List have more than 1 value returns converted list successfully",
+			Input: Input{
+				SchedulerVersionList: []*entities.SchedulerVersion{
+					{
+						Version:   "v1.1.0",
+						IsActive:  true,
+						CreatedAt: genericTime,
+					},
+					{
+						Version:   "v1.0.0",
+						IsActive:  false,
+						CreatedAt: genericTime.Add(-time.Hour*24),
+					},
+				},
+			},
+			Output: Output{
+				ApiSchedulerVersionList: []*api.SchedulerVersion{
+					{
+						Version:   "v1.1.0",
+						IsActive:  true,
+						CreatedAt: timestamppb.New(genericTime),
+					},
+					{
+						Version:   "v1.0.0",
+						IsActive:  false,
+						CreatedAt: timestamppb.New(genericTime.Add(-time.Hour*24)),
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			returnValues := request_adapters.FromEntitySchedulerVersionListToResponse(testCase.Input.SchedulerVersionList)
+			assert.EqualValues(t, testCase.Output.ApiSchedulerVersionList, returnValues)
+		})
+	}
+}
+
+func TestFromEntitySchedulerInfoToListResponse(t *testing.T) {
+	type Input struct {
+		SchedulerInfo *entities.SchedulerInfo
+	}
+
+	type Output struct {
+		ApiSchedulerInfo *api.SchedulerInfo
+	}
+
+
+	genericString := "some-value"
+	genericInt := 62
+
+	testCases := []struct {
+		Title string
+		Input
+		Output
+	}{
+		{
+			Title: "only spec should convert api.PatchSchedulerRequest to change map",
+			Input: Input{
+				SchedulerInfo: &entities.SchedulerInfo{
+					Name:             genericString,
+					Game:             genericString,
+					State:            entities.StateCreating,
+					RoomsReady:       genericInt,
+					RoomsOccupied:    genericInt,
+					RoomsPending:     genericInt,
+					RoomsTerminating: genericInt,
+				},
+			},
+			Output: Output{
+				ApiSchedulerInfo: &api.SchedulerInfo{
+					Name:             genericString,
+					Game:             genericString,
+					State:            "creating",
+					RoomsReady:       int32(genericInt),
+					RoomsOccupied:    int32(genericInt),
+					RoomsPending:     int32(genericInt),
+					RoomsTerminating: int32(genericInt),
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			returnValues := request_adapters.FromEntitySchedulerInfoToListResponse(testCase.Input.SchedulerInfo)
+			assert.EqualValues(t, testCase.Output.ApiSchedulerInfo, returnValues)
 		})
 	}
 }


### PR DESCRIPTION
### What?
Move scheduler_handler adapters to request_adapters package
### Why?
The scheduler_handler had a massive amount of methods that were not handler methods, but adapters to the relation API <> Maestro

### Format Refactors
Some methods on the adapter were simply static methods used by the public methods. Because of that, these methods were made private, and the tests were adapted to test the public methods. The unit tests made for those static methods were absorbed by the new tests for the public ones