### PR TITLE
refactor operations handler adapters

### DIFF
--- a/internal/api/handlers/operations_handler.go
+++ b/internal/api/handlers/operations_handler.go
@@ -24,26 +24,22 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
+	"github.com/topfreegames/maestro/internal/api/handlers/request_adapters"
 	portsErrors "github.com/topfreegames/maestro/internal/core/ports/errors"
-
-	"go.uber.org/zap"
-	_struct "google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/topfreegames/maestro/internal/core/logs"
 	"github.com/topfreegames/maestro/internal/core/ports"
+	"go.uber.org/zap"
 
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	api "github.com/topfreegames/maestro/pkg/api/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type OperationsHandler struct {
@@ -75,7 +71,7 @@ func (h *OperationsHandler) ListOperations(ctx context.Context, request *api.Lis
 	}
 	sortOperationsByCreatedAt(pendingOperationEntities, sortingOrder)
 
-	pendingOperationResponse, err := h.fromOperationsToResponses(pendingOperationEntities)
+	pendingOperationResponse, err := request_adapters.FromOperationsToResponses(pendingOperationEntities)
 	if err != nil {
 		handlerLogger.Error("error converting pending operations", zap.Error(err))
 		return nil, status.Error(codes.Unknown, err.Error())
@@ -88,7 +84,7 @@ func (h *OperationsHandler) ListOperations(ctx context.Context, request *api.Lis
 	}
 	sortOperationsByCreatedAt(activeOperationEntities, sortingOrder)
 
-	activeOperationResponses, err := h.fromOperationsToResponses(activeOperationEntities)
+	activeOperationResponses, err := request_adapters.FromOperationsToResponses(activeOperationEntities)
 	if err != nil {
 		handlerLogger.Error("error converting active operations", zap.Error(err))
 		return nil, status.Error(codes.Unknown, err.Error())
@@ -101,7 +97,7 @@ func (h *OperationsHandler) ListOperations(ctx context.Context, request *api.Lis
 	}
 	sortOperationsByCreatedAt(finishedOperationEntities, sortingOrder)
 
-	finishedOperationResponse, err := h.fromOperationsToResponses(finishedOperationEntities)
+	finishedOperationResponse, err := request_adapters.FromOperationsToResponses(finishedOperationEntities)
 	if err != nil {
 		handlerLogger.Error("error converting finished operations", zap.Error(err))
 		return nil, status.Error(codes.Unknown, err.Error())
@@ -143,77 +139,12 @@ func (h *OperationsHandler) GetOperation(ctx context.Context, request *api.GetOp
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
 
-	convertedOp, err := h.fromOperationToResponse(op)
+	convertedOp, err := request_adapters.FromOperationToResponse(op)
 	if err != nil {
 		handlerLogger.Error("invalid operation object. Fail to convert", zap.Error(err))
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
 	return &api.GetOperationResponse{Operation: convertedOp}, nil
-}
-
-func (h *OperationsHandler) fromOperationsToResponses(entities []*operation.Operation) ([]*api.Operation, error) {
-	responses := make([]*api.Operation, len(entities))
-	for i, entity := range entities {
-		response, err := h.fromOperationToResponse(entity)
-		if err != nil {
-			return nil, err
-		}
-		responses[i] = response
-	}
-
-	return responses, nil
-}
-
-func (h *OperationsHandler) fromOperationToResponse(entity *operation.Operation) (*api.Operation, error) {
-	operation := &api.Operation{
-		Id:             entity.ID,
-		DefinitionName: entity.DefinitionName,
-		SchedulerName:  entity.SchedulerName,
-		CreatedAt:      timestamppb.New(entity.CreatedAt),
-	}
-
-	var err error
-	operation.Status, err = entity.Status.String()
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert operation entity to response: %w", err)
-	}
-
-	operation.ExecutionHistory = h.fromOperationEventsToResponse(entity.ExecutionHistory)
-
-	if len(entity.Input) > 0 {
-		var inputMap map[string]interface{} = make(map[string]interface{})
-		err = json.Unmarshal(entity.Input, &inputMap)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert input to struct: %w", err)
-		}
-		operation.Input, err = _struct.NewStruct(inputMap)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert input to response struct: %w", err)
-	}
-
-	if entity.Lease != nil {
-		operation.Lease = &api.Lease{Ttl: entity.Lease.Ttl.UTC().Format(time.RFC3339)}
-		return operation, nil
-	}
-
-	return operation, nil
-}
-
-func (h *OperationsHandler) fromOperationEventsToResponse(entities []operation.OperationEvent) []*api.OperationEvent {
-	apiOperationEvents := make([]*api.OperationEvent, 0, len(entities))
-	for _, entity := range entities {
-		apiOperationEvents = append(apiOperationEvents, h.fromOperationEventToResponse(entity))
-	}
-
-	return apiOperationEvents
-}
-
-func (h *OperationsHandler) fromOperationEventToResponse(entity operation.OperationEvent) *api.OperationEvent {
-	return &api.OperationEvent{
-		CreatedAt: timestamppb.New(entity.CreatedAt),
-		Event:     entity.Event,
-	}
 }
 
 func sortOperationsByCreatedAt(operations []*operation.Operation, order string) {

--- a/internal/api/handlers/request_adapters/operations.go
+++ b/internal/api/handlers/request_adapters/operations.go
@@ -1,0 +1,77 @@
+package request_adapters
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	api "github.com/topfreegames/maestro/pkg/api/v1"
+	_struct "google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func FromOperationsToResponses(entities []*operation.Operation) ([]*api.Operation, error) {
+	responses := make([]*api.Operation, len(entities))
+	for i, entity := range entities {
+		response, err := FromOperationToResponse(entity)
+		if err != nil {
+			return nil, err
+		}
+		responses[i] = response
+	}
+
+	return responses, nil
+}
+
+func FromOperationToResponse(entity *operation.Operation) (*api.Operation, error) {
+	apiOperation := &api.Operation{
+		Id:             entity.ID,
+		DefinitionName: entity.DefinitionName,
+		SchedulerName:  entity.SchedulerName,
+		CreatedAt:      timestamppb.New(entity.CreatedAt),
+	}
+
+	var err error
+	apiOperation.Status, err = entity.Status.String()
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert operation entity to response: %w", err)
+	}
+
+	apiOperation.ExecutionHistory = fromOperationEventsToResponse(entity.ExecutionHistory)
+
+	if len(entity.Input) > 0 {
+		var inputMap map[string]interface{} = make(map[string]interface{})
+		err = json.Unmarshal(entity.Input, &inputMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert input to struct: %w", err)
+		}
+		apiOperation.Input, err = _struct.NewStruct(inputMap)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert input to response struct: %w", err)
+	}
+
+	if entity.Lease != nil {
+		apiOperation.Lease = &api.Lease{Ttl: entity.Lease.Ttl.UTC().Format(time.RFC3339)}
+		return apiOperation, nil
+	}
+
+	return apiOperation, nil
+}
+
+func fromOperationEventsToResponse(entities []operation.OperationEvent) []*api.OperationEvent {
+	apiOperationEvents := make([]*api.OperationEvent, 0, len(entities))
+	for _, entity := range entities {
+		apiOperationEvents = append(apiOperationEvents, fromOperationEventToResponse(entity))
+	}
+
+	return apiOperationEvents
+}
+
+func fromOperationEventToResponse(entity operation.OperationEvent) *api.OperationEvent {
+	return &api.OperationEvent{
+		CreatedAt: timestamppb.New(entity.CreatedAt),
+		Event:     entity.Event,
+	}
+}

--- a/internal/api/handlers/request_adapters/operations.go
+++ b/internal/api/handlers/request_adapters/operations.go
@@ -46,15 +46,15 @@ func FromOperationToResponse(entity *operation.Operation) (*api.Operation, error
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert input to struct: %w", err)
 		}
+
 		apiOperation.Input, err = _struct.NewStruct(inputMap)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert input to response struct: %w", err)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert input to response struct: %w", err)
+		}
 	}
 
 	if entity.Lease != nil {
 		apiOperation.Lease = &api.Lease{Ttl: entity.Lease.Ttl.UTC().Format(time.RFC3339)}
-		return apiOperation, nil
 	}
 
 	return apiOperation, nil

--- a/internal/api/handlers/request_adapters/operations_test.go
+++ b/internal/api/handlers/request_adapters/operations_test.go
@@ -1,0 +1,314 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build unit
+// +build unit
+
+package request_adapters_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/topfreegames/maestro/internal/api/handlers/request_adapters"
+	api "github.com/topfreegames/maestro/pkg/api/v1"
+	_struct "google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestFromOperationsToResponses(t *testing.T) {
+	type Input struct {
+		Operations []*operation.Operation
+	}
+
+	type Output struct {
+		ApiOperations []*api.Operation
+		GivesError    bool
+	}
+
+	type genericStruct struct {
+		GenericAttribute string
+	}
+	genericString := "some-value"
+	genericTime := time.Now()
+	genericJsonStruct, _ := json.Marshal(genericStruct{"some-value"})
+
+	inputMap := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(genericJsonStruct), &inputMap)
+	genericApiStruct, _ := _struct.NewStruct(inputMap)
+
+	testCases := []struct {
+		Title string
+		Input
+		Output
+	}{
+		{
+			Title: "receives valid operation in list, returns list with converted operation",
+			Input: Input{
+				Operations: []*operation.Operation{
+					{
+						ID:             genericString,
+						Status:         operation.StatusPending,
+						DefinitionName: genericString,
+						SchedulerName:  genericString,
+						Lease: &operation.OperationLease{
+							OperationID: genericString,
+							Ttl:         genericTime,
+						},
+						CreatedAt: genericTime,
+						Input:     []byte(genericJsonStruct),
+						ExecutionHistory: []operation.OperationEvent{
+							{
+								CreatedAt: genericTime,
+								Event:     genericString,
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ApiOperations: []*api.Operation{
+					{
+						Id:             genericString,
+						Status:         "pending",
+						DefinitionName: genericString,
+						Lease:          &api.Lease{Ttl: genericTime.UTC().Format(time.RFC3339)},
+						SchedulerName:  genericString,
+						CreatedAt:      timestamppb.New(genericTime),
+						Input:          genericApiStruct,
+						ExecutionHistory: []*api.OperationEvent{
+							{
+								CreatedAt: timestamppb.New(genericTime),
+								Event:     genericString,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Title: "receives invalid operation in list, returns err",
+			Input: Input{
+				Operations: []*operation.Operation{
+					{
+						ID:             genericString,
+						Status:         operation.StatusPending,
+						DefinitionName: genericString,
+						SchedulerName:  genericString,
+						Lease: &operation.OperationLease{
+							OperationID: genericString,
+							Ttl:         genericTime,
+						},
+						CreatedAt: genericTime,
+						Input:     []byte("some-value"),
+						ExecutionHistory: []operation.OperationEvent{
+							{
+								CreatedAt: genericTime,
+								Event:     genericString,
+							},
+						},
+					},
+				},
+			},
+			Output: Output{
+				ApiOperations: nil,
+				GivesError:    true,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			returnValues, err := request_adapters.FromOperationsToResponses(testCase.Input.Operations)
+			if testCase.Output.GivesError {
+				assert.Error(t, err)
+			}
+			assert.EqualValues(t, testCase.Output.ApiOperations, returnValues)
+		})
+	}
+}
+
+func TestFromOperationToResponse(t *testing.T) {
+	type Input struct {
+		Operation *operation.Operation
+	}
+
+	type Output struct {
+		ApiOperation *api.Operation
+		GivesError   bool
+	}
+
+	type genericStruct struct {
+		GenericAttribute string
+	}
+	genericString := "some-value"
+	genericTime := time.Now()
+	genericJsonStruct, _ := json.Marshal(genericStruct{"some-value"})
+
+	inputMap := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(genericJsonStruct), &inputMap)
+	genericApiStruct, _ := _struct.NewStruct(inputMap)
+
+	testCases := []struct {
+		Title string
+		Input
+		Output
+	}{
+		{
+			Title: "receives valid complete operation, returns converted operation",
+			Input: Input{
+				Operation: &operation.Operation{
+					ID:             genericString,
+					Status:         operation.StatusPending,
+					DefinitionName: genericString,
+					SchedulerName:  genericString,
+					Lease: &operation.OperationLease{
+						OperationID: genericString,
+						Ttl:         genericTime,
+					},
+					CreatedAt: genericTime,
+					Input:     []byte(genericJsonStruct),
+					ExecutionHistory: []operation.OperationEvent{
+						{
+							CreatedAt: genericTime,
+							Event:     genericString,
+						},
+					},
+				},
+			},
+			Output: Output{
+				ApiOperation: &api.Operation{
+					Id:             genericString,
+					Status:         "pending",
+					DefinitionName: genericString,
+					Lease:          &api.Lease{Ttl: genericTime.UTC().Format(time.RFC3339)},
+					SchedulerName:  genericString,
+					CreatedAt:      timestamppb.New(genericTime),
+					Input:          genericApiStruct,
+					ExecutionHistory: []*api.OperationEvent{
+						{
+							CreatedAt: timestamppb.New(genericTime),
+							Event:     genericString,
+						},
+					},
+				},
+			},
+		},
+		{
+			Title: "receives operation without lease, returns converted operation",
+			Input: Input{
+				Operation: &operation.Operation{
+					ID:             genericString,
+					Status:         operation.StatusPending,
+					DefinitionName: genericString,
+					SchedulerName:  genericString,
+					CreatedAt:      genericTime,
+					ExecutionHistory: []operation.OperationEvent{
+						{
+							CreatedAt: genericTime,
+							Event:     genericString,
+						},
+					},
+				},
+			},
+			Output: Output{
+				ApiOperation: &api.Operation{
+					Id:             genericString,
+					Status:         "pending",
+					DefinitionName: genericString,
+					SchedulerName:  genericString,
+					CreatedAt:      timestamppb.New(genericTime),
+					ExecutionHistory: []*api.OperationEvent{
+						{
+							CreatedAt: timestamppb.New(genericTime),
+							Event:     genericString,
+						},
+					},
+				},
+			},
+		},
+		{
+			Title: "receives invalid operation in list, returns err",
+			Input: Input{
+				Operation: &operation.Operation{
+					ID:             genericString,
+					Status:         operation.StatusPending,
+					DefinitionName: genericString,
+					SchedulerName:  genericString,
+					Lease: &operation.OperationLease{
+						OperationID: genericString,
+						Ttl:         genericTime,
+					},
+					CreatedAt: genericTime,
+					Input:     []byte("some-value"),
+					ExecutionHistory: []operation.OperationEvent{
+						{
+							CreatedAt: genericTime,
+							Event:     genericString,
+						},
+					},
+				},
+			},
+			Output: Output{
+				ApiOperation: nil,
+				GivesError:   true,
+			},
+		},
+		{
+			Title: "receives operation with invalid status, returns error",
+			Input: Input{
+				Operation: &operation.Operation{
+					ID:             genericString,
+					Status:         55,
+					DefinitionName: genericString,
+					SchedulerName:  genericString,
+					CreatedAt:      genericTime,
+					Input:          []byte(genericJsonStruct),
+					ExecutionHistory: []operation.OperationEvent{
+						{
+							CreatedAt: genericTime,
+							Event:     genericString,
+						},
+					},
+				},
+			},
+			Output: Output{
+				ApiOperation: nil,
+				GivesError:   true,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			returnValues, err := request_adapters.FromOperationToResponse(testCase.Input.Operation)
+			if testCase.Output.GivesError {
+				assert.Error(t, err)
+			}
+			assert.EqualValues(t, testCase.Output.ApiOperation, returnValues)
+		})
+	}
+}


### PR DESCRIPTION
### What?
Refactor operations handler adapters.
### Why?
To improve operations_handler readability and maintainability.
### How?
Moving operations adapters from operations_handler.go to request_adapters/operations.go