### PR TITLE
alter channel size of runtime watcher

### DIFF
--- a/internal/adapters/runtime/kubernetes/game_room_watcher.go
+++ b/internal/adapters/runtime/kubernetes/game_room_watcher.go
@@ -43,7 +43,7 @@ import (
 
 var (
 	defaultResyncTime = 30 * time.Second
-	eventsChanSize    = 100
+	eventsChanSize    = 2000
 )
 
 type kubernetesWatcher struct {


### PR DESCRIPTION
### What?
Change runtime watcher events channel size
### Why?
This value is too low now.
### Next Steps
This value should be a config value, so we can alter it on maestro deploy instead of making a new commit.