### PR TITLE
Use goroutines for processing runtime watcher events

### DIFF
--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
@@ -73,33 +73,29 @@ func (w *runtimeWatcherWorker) Start(ctx context.Context) error {
 
 	// TODO(guilhermocc): We need to deal better with this events chan processing by using https://github.com/kubernetes/client-go/blob/master/util/workqueue/doc.go
 	for i := 0; i < 200; i++ {
-		go func() error {
-			goroutineLogger := w.logger.With(zap.Int("goroutine", i))
+		go func(goroutineNumber int) {
+			goroutineLogger := w.logger.With(zap.Int("goroutine", goroutineNumber))
 			goroutineLogger.Info("Starting event processing goroutine")
 			for {
 				select {
 				case event, ok := <-resultChan:
 					if !ok {
-						return nil
+						return
 					}
 					err := w.processEvent(w.ctx, event)
 					if err != nil {
 						w.logger.Warn("failed to process event", zap.Error(err))
 					}
 				case <-w.ctx.Done():
-					return nil
+					return
 				}
 			}
-		}()
+		}(i)
 	}
 
-	for {
-		select {
-		case <-w.ctx.Done():
-			watcher.Stop()
-			return nil
-		}
-	}
+	<-w.ctx.Done()
+	watcher.Stop()
+	return nil
 }
 
 func (w *runtimeWatcherWorker) Stop(_ context.Context) {


### PR DESCRIPTION
Use goroutines for processing runtime watcher events, we have identified that runtime watcher is having some problems while processing a large number of runtime watcher events.