### PR TITLE
Fix/runtime watcher duplicated events

### DIFF
--- a/internal/adapters/runtime/kubernetes/game_room_convert.go
+++ b/internal/adapters/runtime/kubernetes/game_room_convert.go
@@ -370,10 +370,11 @@ func convertPod(pod *v1.Pod, node *v1.Node) (*game_room.Instance, error) {
 	}
 
 	return &game_room.Instance{
-		ID:          pod.ObjectMeta.Name,
-		SchedulerID: pod.ObjectMeta.Namespace,
-		Status:      convertPodStatus(pod),
-		Address:     address,
+		ID:              pod.ObjectMeta.Name,
+		SchedulerID:     pod.ObjectMeta.Namespace,
+		Status:          convertPodStatus(pod),
+		Address:         address,
+		ResourceVersion: pod.ResourceVersion,
 	}, nil
 }
 

--- a/internal/core/entities/game_room/instance.go
+++ b/internal/core/entities/game_room/instance.go
@@ -77,8 +77,9 @@ type Address struct {
 }
 
 type Instance struct {
-	ID          string         `json:"id"`
-	SchedulerID string         `json:"schedulerId"`
-	Status      InstanceStatus `json:"status"`
-	Address     *Address       `json:"address"`
+	ID              string         `json:"id"`
+	SchedulerID     string         `json:"schedulerId"`
+	Status          InstanceStatus `json:"status"`
+	Address         *Address       `json:"address"`
+	ResourceVersion string         `json:"resourceVersion"`
 }

--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
@@ -73,33 +73,29 @@ func (w *runtimeWatcherWorker) Start(ctx context.Context) error {
 
 	// TODO(guilhermocc): We need to deal better with this events chan processing by using https://github.com/kubernetes/client-go/blob/master/util/workqueue/doc.go
 	for i := 0; i < 200; i++ {
-		go func() error {
-			goroutineLogger := w.logger.With(zap.Int("goroutine", i))
+		go func(goroutineNumber int) {
+			goroutineLogger := w.logger.With(zap.Int("goroutine", goroutineNumber))
 			goroutineLogger.Info("Starting event processing goroutine")
 			for {
 				select {
 				case event, ok := <-resultChan:
 					if !ok {
-						return nil
+						return
 					}
 					err := w.processEvent(w.ctx, event)
 					if err != nil {
 						w.logger.Warn("failed to process event", zap.Error(err))
 					}
 				case <-w.ctx.Done():
-					return nil
+					return
 				}
 			}
-		}()
+		}(i)
 	}
 
-	for {
-		select {
-		case <-w.ctx.Done():
-			watcher.Stop()
-			return nil
-		}
-	}
+	<-w.ctx.Done()
+	watcher.Stop()
+	return nil
 }
 
 func (w *runtimeWatcherWorker) Stop(_ context.Context) {


### PR DESCRIPTION
### What?
Improves k8s usage caching instances to reduce load on kube API.
### Why?
Maestro behavior is bad when it need to manage too many rooms, since they produce too many events and all those events are fetching kube api.