### PR TITLE
Improvement/create pending operations chan for worker

### DIFF
--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -169,10 +169,10 @@ func (mr *MockOperationManagerMockRecorder) ListSchedulerPendingOperations(ctx, 
 }
 
 // PendingOperationsChan mocks base method.
-func (m *MockOperationManager) PendingOperationsChan(ctx context.Context, schedulerName string) <-chan *ports.OperationComposition {
+func (m *MockOperationManager) PendingOperationsChan(ctx context.Context, schedulerName string) <-chan string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PendingOperationsChan", ctx, schedulerName)
-	ret0, _ := ret[0].(<-chan *ports.OperationComposition)
+	ret0, _ := ret[0].(<-chan string)
 	return ret0
 }
 

--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -168,20 +168,18 @@ func (mr *MockOperationManagerMockRecorder) ListSchedulerPendingOperations(ctx, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSchedulerPendingOperations", reflect.TypeOf((*MockOperationManager)(nil).ListSchedulerPendingOperations), ctx, schedulerName)
 }
 
-// NextSchedulerOperation mocks base method.
-func (m *MockOperationManager) NextSchedulerOperation(ctx context.Context, schedulerName string) (*operation.Operation, operations.Definition, error) {
+// PendingOperationsChan mocks base method.
+func (m *MockOperationManager) PendingOperationsChan(ctx context.Context, schedulerName string) <-chan *ports.OperationComposition {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NextSchedulerOperation", ctx, schedulerName)
-	ret0, _ := ret[0].(*operation.Operation)
-	ret1, _ := ret[1].(operations.Definition)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "PendingOperationsChan", ctx, schedulerName)
+	ret0, _ := ret[0].(<-chan *ports.OperationComposition)
+	return ret0
 }
 
-// NextSchedulerOperation indicates an expected call of NextSchedulerOperation.
-func (mr *MockOperationManagerMockRecorder) NextSchedulerOperation(ctx, schedulerName interface{}) *gomock.Call {
+// PendingOperationsChan indicates an expected call of PendingOperationsChan.
+func (mr *MockOperationManagerMockRecorder) PendingOperationsChan(ctx, schedulerName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextSchedulerOperation", reflect.TypeOf((*MockOperationManager)(nil).NextSchedulerOperation), ctx, schedulerName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PendingOperationsChan", reflect.TypeOf((*MockOperationManager)(nil).PendingOperationsChan), ctx, schedulerName)
 }
 
 // RevokeLease mocks base method.

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -39,7 +39,7 @@ type OperationManager interface {
 	// GetOperation retrieves the operation and its definition.
 	GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, operations.Definition, error)
 	// PendingOperationsChan returns a read-only channel of pending operations.
-	PendingOperationsChan(ctx context.Context, schedulerName string) (pendingOpsChan <-chan *OperationComposition)
+	PendingOperationsChan(ctx context.Context, schedulerName string) (pendingOpsChan <-chan string)
 	// StartOperation used when an operation will start executing.
 	StartOperation(ctx context.Context, op *operation.Operation, cancelFunction context.CancelFunc) error
 	// FinishOperation used when an operation has finished executing, with error or not.
@@ -114,9 +114,4 @@ type OperationLeaseStorage interface {
 type OperationCancellationRequest struct {
 	SchedulerName string `json:"schedulerName"`
 	OperationID   string `json:"operationID"`
-}
-
-type OperationComposition struct {
-	Operation  *operation.Operation
-	Definition operations.Definition
 }

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -38,8 +38,8 @@ type OperationManager interface {
 	CreateOperation(ctx context.Context, schedulerName string, definition operations.Definition) (*operation.Operation, error)
 	// GetOperation retrieves the operation and its definition.
 	GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, operations.Definition, error)
-	// NextSchedulerOperation returns the next scheduler operation to be processed.
-	NextSchedulerOperation(ctx context.Context, schedulerName string) (*operation.Operation, operations.Definition, error)
+	// PendingOperationsChan returns a read-only channel of pending operations.
+	PendingOperationsChan(ctx context.Context, schedulerName string) (pendingOpsChan <-chan *OperationComposition)
 	// StartOperation used when an operation will start executing.
 	StartOperation(ctx context.Context, op *operation.Operation, cancelFunction context.CancelFunc) error
 	// FinishOperation used when an operation has finished executing, with error or not.
@@ -114,4 +114,9 @@ type OperationLeaseStorage interface {
 type OperationCancellationRequest struct {
 	SchedulerName string `json:"schedulerName"`
 	OperationID   string `json:"operationID"`
+}
+
+type OperationComposition struct {
+	Operation  *operation.Operation
+	Definition operations.Definition
 }

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -113,10 +113,10 @@ func (om *OperationManager) GetOperation(ctx context.Context, schedulerName, ope
 	return op, definition, nil
 }
 
-func (om *OperationManager) PendingOperationsChan(ctx context.Context, schedulerName string) (pendingOpsChan <-chan *ports.OperationComposition) {
-	pendingOperationsChan := make(chan *ports.OperationComposition)
+func (om *OperationManager) PendingOperationsChan(ctx context.Context, schedulerName string) (pendingOpsChan <-chan string) {
+	pendingOperationsChan := make(chan string)
 
-	go func(opsChan chan *ports.OperationComposition) {
+	go func(opsChan chan string) {
 		defer close(opsChan)
 
 		for {
@@ -125,12 +125,7 @@ func (om *OperationManager) PendingOperationsChan(ctx context.Context, scheduler
 				return
 			}
 
-			op, def, err := om.GetOperation(ctx, schedulerName, operationID)
-			if err != nil {
-				return
-			}
-
-			opsChan <- &ports.OperationComposition{Operation: op, Definition: def}
+			opsChan <- operationID
 		}
 
 	}(pendingOperationsChan)

--- a/pkg/api/v1/messages.pb.go
+++ b/pkg/api/v1/messages.pb.go
@@ -982,7 +982,7 @@ type SchedulerWithoutSpec struct {
 	CreatedAt *timestamp.Timestamp `protobuf:"bytes,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// Max surge of rooms
 	MaxSurge string `protobuf:"bytes,7,opt,name=max_surge,json=maxSurge,proto3" json:"max_surge,omitempty"`
-	// Rooms Replicas is the desired number that a Scheduler should have rooms
+	// Rooms Replicas is the desired number that a Scheduler maintains.
 	RoomsReplicas int32 `protobuf:"varint,8,opt,name=rooms_replicas,json=roomsReplicas,proto3" json:"rooms_replicas,omitempty"`
 }
 

--- a/proto/apidocs.swagger.json
+++ b/proto/apidocs.swagger.json
@@ -1575,7 +1575,7 @@
         "roomsReplicas": {
           "type": "integer",
           "format": "int32",
-          "title": "Rooms Replicas is the desired number that a Scheduler should have rooms"
+          "description": "Rooms Replicas is the desired number that a Scheduler maintains."
         }
       },
       "title": "Scheduler message used in the \"ListScheduler version\" definition. The \"spec\" is not implemented\non this message since it's unnecessary for the list function"


### PR DESCRIPTION
## What❓
Update operation execution worker logic to receive pending operations from a channel instead of directly calling for the next operation in a for loop. This includes the creation of a new method **PendingOperationsChan** in **OperationsManager**.

## Why 🤔 
With the future health controller feature, the operation execution worker will have to coordinate an extra behavior instead of just keeping getting and processing pending operations of a queue. It will also need to periodically run a health check logic to maintain the scheduler's desired state. For this to happen, we need to start receiving pending operations from a channel.

## Obs ⚠️ 
With this initial solution, we always pop an operation from the queue before actually executing it. If the worker component goes down in the meantime, these operations will no longer be in the queue and will remain in pending operation forever without lease data. Another PR will be opened to implement an **reliable queue** pattern to prevent this from happening.