### PR TITLE
implements InsertPriorityOperationID on operation flow redis adapter

### DIFF
--- a/internal/adapters/operation/operation_flow_redis.go
+++ b/internal/adapters/operation/operation_flow_redis.go
@@ -65,6 +65,19 @@ func (r *redisOperationFlow) InsertOperationID(ctx context.Context, schedulerNam
 	return nil
 }
 
+// InsertPriorityOperationID inserts the operationID on the top of pending operations list.
+func (r *redisOperationFlow) InsertPriorityOperationID(ctx context.Context, schedulerName string, operationID string) (err error) {
+	metrics.RunWithMetrics(operationFlowStorageMetricLabel, func() error {
+		err = r.client.LPush(ctx, r.buildSchedulerPendingOperationsKey(schedulerName), operationID).Err()
+		return err
+	})
+	if err != nil {
+		return errors.NewErrUnexpected("failed to insert operation ID on redis").WithError(err)
+	}
+
+	return nil
+}
+
 // NextOperationID fetches the next scheduler operation ID from the
 // pending_operations list.
 func (r *redisOperationFlow) NextOperationID(ctx context.Context, schedulerName string) (opId string, err error) {

--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -289,6 +289,20 @@ func (mr *MockOperationFlowMockRecorder) InsertOperationID(ctx, schedulerName, o
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertOperationID", reflect.TypeOf((*MockOperationFlow)(nil).InsertOperationID), ctx, schedulerName, operationID)
 }
 
+// InsertPriorityOperationID mocks base method.
+func (m *MockOperationFlow) InsertPriorityOperationID(ctx context.Context, schedulerName, operationID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertPriorityOperationID", ctx, schedulerName, operationID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertPriorityOperationID indicates an expected call of InsertPriorityOperationID.
+func (mr *MockOperationFlowMockRecorder) InsertPriorityOperationID(ctx, schedulerName, operationID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertPriorityOperationID", reflect.TypeOf((*MockOperationFlow)(nil).InsertPriorityOperationID), ctx, schedulerName, operationID)
+}
+
 // ListSchedulerPendingOperationIDs mocks base method.
 func (m *MockOperationFlow) ListSchedulerPendingOperationIDs(ctx context.Context, schedulerName string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -67,7 +67,11 @@ type OperationManager interface {
 // Secondary ports (output, driven ports)
 
 type OperationFlow interface {
+	// InsertOperationID pushes the operation ID to the scheduler pending
+	// operations list.
 	InsertOperationID(ctx context.Context, schedulerName, operationID string) error
+	// InsertPriorityOperationID inserts the operationID on the top of pending operations list.
+	InsertPriorityOperationID(ctx context.Context, schedulerName, operationID string) error
 	// NextOperationID fetches the next scheduler operation to be
 	// processed and return its ID.
 	NextOperationID(ctx context.Context, schedulerName string) (string, error)

--- a/pkg/api/v1/messages.pb.go
+++ b/pkg/api/v1/messages.pb.go
@@ -982,7 +982,7 @@ type SchedulerWithoutSpec struct {
 	CreatedAt *timestamp.Timestamp `protobuf:"bytes,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// Max surge of rooms
 	MaxSurge string `protobuf:"bytes,7,opt,name=max_surge,json=maxSurge,proto3" json:"max_surge,omitempty"`
-	// Rooms Replicas is the desired number that a Scheduler should have rooms
+	// Rooms Replicas is the desired number that a Scheduler maintains.
 	RoomsReplicas int32 `protobuf:"varint,8,opt,name=rooms_replicas,json=roomsReplicas,proto3" json:"rooms_replicas,omitempty"`
 }
 

--- a/proto/apidocs.swagger.json
+++ b/proto/apidocs.swagger.json
@@ -1575,7 +1575,7 @@
         "roomsReplicas": {
           "type": "integer",
           "format": "int32",
-          "title": "Rooms Replicas is the desired number that a Scheduler should have rooms"
+          "description": "Rooms Replicas is the desired number that a Scheduler maintains."
         }
       },
       "title": "Scheduler message used in the \"ListScheduler version\" definition. The \"spec\" is not implemented\non this message since it's unnecessary for the list function"


### PR DESCRIPTION
### What?
- Implement `InsertPriorityOperationID` method into operation flow redis adapter.
### Why?
- So we are able to add high-priority operations to the pending operations list (inserted at the top of the list).
### Refactor contained
- Running `make generate` updates swagger docs from a previous commit where this command hasn't been executed again after some upgrades.