### PR TITLE
Feature/create priority operation operation manager

### DIFF
--- a/internal/adapters/operation/operation_flow_redis.go
+++ b/internal/adapters/operation/operation_flow_redis.go
@@ -65,6 +65,19 @@ func (r *redisOperationFlow) InsertOperationID(ctx context.Context, schedulerNam
 	return nil
 }
 
+// InsertPriorityOperationID inserts the operationID on the top of pending operations list.
+func (r *redisOperationFlow) InsertPriorityOperationID(ctx context.Context, schedulerName string, operationID string) (err error) {
+	metrics.RunWithMetrics(operationFlowStorageMetricLabel, func() error {
+		err = r.client.LPush(ctx, r.buildSchedulerPendingOperationsKey(schedulerName), operationID).Err()
+		return err
+	})
+	if err != nil {
+		return errors.NewErrUnexpected("failed to insert operation ID on redis").WithError(err)
+	}
+
+	return nil
+}
+
 // NextOperationID fetches the next scheduler operation ID from the
 // pending_operations list.
 func (r *redisOperationFlow) NextOperationID(ctx context.Context, schedulerName string) (opId string, err error) {

--- a/internal/core/entities/operation/operation.go
+++ b/internal/core/entities/operation/operation.go
@@ -24,6 +24,7 @@ package operation
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	"time"
 )
 
@@ -83,4 +84,21 @@ func (s Status) String() (string, error) {
 	}
 
 	return "", fmt.Errorf("status could not be mapped to string: %d", s)
+}
+
+func New(schedulerName, definitionName string, definitionInput []byte) *Operation {
+	return &Operation{
+		ID:             uuid.NewString(),
+		Status:         StatusPending,
+		DefinitionName: definitionName,
+		SchedulerName:  schedulerName,
+		CreatedAt:      time.Now(),
+		Input:          definitionInput,
+		ExecutionHistory: []OperationEvent{
+			{
+				CreatedAt: time.Now().UTC(),
+				Event:     "Created",
+			},
+		},
+	}
 }

--- a/internal/core/entities/operation/operation_test.go
+++ b/internal/core/entities/operation/operation_test.go
@@ -1,0 +1,95 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build unit
+// +build unit
+
+package operation_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"testing"
+)
+
+func TestNewOperation(t *testing.T) {
+	type Input struct {
+		SchedulerName string
+		DefinitionName string
+		DefinitionInput []byte
+	}
+
+	type Output struct {
+		Operation *operation.Operation
+	}
+
+	genericString := "some-value"
+
+	testCases := []struct {
+		Title string
+		Input
+		Output
+	}{
+		{
+			Title:  "Creates operation successfully",
+			Input:  Input{
+				SchedulerName:   genericString,
+				DefinitionName:  genericString,
+				DefinitionInput: []byte("test"),
+			},
+			Output: Output{
+				Operation: &operation.Operation{
+					Status:           operation.StatusPending,
+					DefinitionName:   genericString,
+					SchedulerName:    genericString,
+					Input:            []byte("test"),
+					ExecutionHistory: []operation.OperationEvent{
+						{
+							Event:     "Created",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			in := testCase.Input
+			out := testCase.Output.Operation
+			op := operation.New(in.SchedulerName, in.DefinitionName, in.DefinitionInput)
+
+			assert.Equal(t, op.SchedulerName, out.SchedulerName)
+			assert.Equal(t, op.Input, out.Input)
+			assert.Equal(t, op.ExecutionHistory[0].Event, out.ExecutionHistory[0].Event)
+			assert.Equal(t, op.Status, out.Status)
+			assert.Equal(t, op.DefinitionName, out.DefinitionName)
+
+			assert.NotEqual(t, "",op.ID)
+
+			assert.NotNil(t, op.CreatedAt)
+			assert.NotNil(t, op.ExecutionHistory[0].CreatedAt)
+
+			assert.Nil(t, op.Lease)
+		})
+	}
+}

--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -289,6 +289,20 @@ func (mr *MockOperationFlowMockRecorder) InsertOperationID(ctx, schedulerName, o
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertOperationID", reflect.TypeOf((*MockOperationFlow)(nil).InsertOperationID), ctx, schedulerName, operationID)
 }
 
+// InsertPriorityOperationID mocks base method.
+func (m *MockOperationFlow) InsertPriorityOperationID(ctx context.Context, schedulerName, operationID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertPriorityOperationID", ctx, schedulerName, operationID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertPriorityOperationID indicates an expected call of InsertPriorityOperationID.
+func (mr *MockOperationFlowMockRecorder) InsertPriorityOperationID(ctx, schedulerName, operationID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertPriorityOperationID", reflect.TypeOf((*MockOperationFlow)(nil).InsertPriorityOperationID), ctx, schedulerName, operationID)
+}
+
 // ListSchedulerPendingOperationIDs mocks base method.
 func (m *MockOperationFlow) ListSchedulerPendingOperationIDs(ctx context.Context, schedulerName string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -65,6 +65,21 @@ func (mr *MockOperationManagerMockRecorder) CreateOperation(ctx, schedulerName, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOperation", reflect.TypeOf((*MockOperationManager)(nil).CreateOperation), ctx, schedulerName, definition)
 }
 
+// CreatePriorityOperation mocks base method.
+func (m *MockOperationManager) CreatePriorityOperation(ctx context.Context, schedulerName string, definition operations.Definition) (*operation.Operation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePriorityOperation", ctx, schedulerName, definition)
+	ret0, _ := ret[0].(*operation.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreatePriorityOperation indicates an expected call of CreatePriorityOperation.
+func (mr *MockOperationManagerMockRecorder) CreatePriorityOperation(ctx, schedulerName, definition interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePriorityOperation", reflect.TypeOf((*MockOperationManager)(nil).CreatePriorityOperation), ctx, schedulerName, definition)
+}
+
 // EnqueueOperationCancellationRequest mocks base method.
 func (m *MockOperationManager) EnqueueOperationCancellationRequest(ctx context.Context, schedulerName, operationID string) error {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -36,6 +36,9 @@ import (
 type OperationManager interface {
 	// CreateOperation creates a new operation for the given scheduler and includes it in the execution process.
 	CreateOperation(ctx context.Context, schedulerName string, definition operations.Definition) (*operation.Operation, error)
+	// CreatePriorityOperation creates a new priority operation (it'll run before other enqueued operation)
+	//for the given scheduler and includes it in the execution process.
+	CreatePriorityOperation(ctx context.Context, schedulerName string, definition operations.Definition) (*operation.Operation, error)
 	// GetOperation retrieves the operation and its definition.
 	GetOperation(ctx context.Context, schedulerName, operationID string) (*operation.Operation, operations.Definition, error)
 	// NextSchedulerOperation returns the next scheduler operation to be processed.

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -67,7 +67,11 @@ type OperationManager interface {
 // Secondary ports (output, driven ports)
 
 type OperationFlow interface {
+	// InsertOperationID pushes the operation ID to the scheduler pending
+	// operations list.
 	InsertOperationID(ctx context.Context, schedulerName, operationID string) error
+	// InsertPriorityOperationID inserts the operationID on the top of pending operations list.
+	InsertPriorityOperationID(ctx context.Context, schedulerName, operationID string) error
 	// NextOperationID fetches the next scheduler operation to be
 	// processed and return its ID.
 	NextOperationID(ctx context.Context, schedulerName string) (string, error)

--- a/pkg/api/v1/messages.pb.go
+++ b/pkg/api/v1/messages.pb.go
@@ -982,7 +982,7 @@ type SchedulerWithoutSpec struct {
 	CreatedAt *timestamp.Timestamp `protobuf:"bytes,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// Max surge of rooms
 	MaxSurge string `protobuf:"bytes,7,opt,name=max_surge,json=maxSurge,proto3" json:"max_surge,omitempty"`
-	// Rooms Replicas is the desired number that a Scheduler should have rooms
+	// Rooms Replicas is the desired number that a Scheduler maintains.
 	RoomsReplicas int32 `protobuf:"varint,8,opt,name=rooms_replicas,json=roomsReplicas,proto3" json:"rooms_replicas,omitempty"`
 }
 

--- a/proto/apidocs.swagger.json
+++ b/proto/apidocs.swagger.json
@@ -1575,7 +1575,7 @@
         "roomsReplicas": {
           "type": "integer",
           "format": "int32",
-          "title": "Rooms Replicas is the desired number that a Scheduler should have rooms"
+          "description": "Rooms Replicas is the desired number that a Scheduler maintains."
         }
       },
       "title": "Scheduler message used in the \"ListScheduler version\" definition. The \"spec\" is not implemented\non this message since it's unnecessary for the list function"


### PR DESCRIPTION
### What?
- Implements CreatePriorityOperation Method in operationManager
### Why?
- To be able to add high-priority operations in the queue (should be executed before all others)

### Refactors included
Since `CreateOperation` and `CreatePriorityOperation` both creates operation, a constructor was added to the entity, so it won't repeat itself. Also, added simple creation test for this little guy (to prevent further alteration that might change the way it's supposed to work