### PR TITLE
Add operations tests flags to be executed when make call them

### DIFF
--- a/internal/core/operations/add_rooms/add_rooms_executor_test.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor_test.go
@@ -20,6 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//go:build unit
+// +build unit
+
 package add_rooms
 
 import (

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -20,6 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//go:build unit
+// +build unit
+
 package newschedulerversion_test
 
 import (

--- a/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
@@ -20,6 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//go:build unit
+// +build unit
+
 package switch_active_version_test
 
 import (


### PR DESCRIPTION
### Why
Operations tests are not being executed because there is no flag to them.

### What
Add unit flags to operations tests files.