### PR TITLE
Integrate health_controller with execution worker

### DIFF
--- a/cmd/worker/wire.go
+++ b/cmd/worker/wire.go
@@ -50,6 +50,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 		service.NewPortAllocatorRandom,
 		service.NewRoomStorageRedis,
 		service.NewGameRoomInstanceStorageRedis,
+		service.NewWorkersConfig,
 		service.NewRoomManagerConfig,
 		service.NewRoomManager,
 		service.NewOperationManagerConfig,

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -78,7 +78,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	roomManager := service.NewRoomManager(clock, portAllocator, roomStorage, gameRoomInstanceStorage, runtime, eventsService, roomManagerConfig)
 	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager, roomStorage, schedulerManager, gameRoomInstanceStorage, operationManager, roomManagerConfig)
-	workerOptions := workers.ProvideWorkerOptions(operationManager, v2, roomManager, runtime)
+	workerOptions := workers.ProvideWorkerOptions(c, operationManager, v2, roomManager, runtime)
 	workersManager := workers_manager.NewWorkersManager(builder, c, schedulerStorage, workerOptions)
 	return workersManager, nil
 }

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -23,6 +23,10 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	if err != nil {
 		return nil, err
 	}
+	configuration, err := service.NewWorkersConfig(c)
+	if err != nil {
+		return nil, err
+	}
 	operationFlow, err := service.NewOperationFlowRedis(c)
 	if err != nil {
 		return nil, err
@@ -78,7 +82,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	roomManager := service.NewRoomManager(clock, portAllocator, roomStorage, gameRoomInstanceStorage, runtime, eventsService, roomManagerConfig)
 	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager, roomStorage, schedulerManager, gameRoomInstanceStorage, operationManager, roomManagerConfig)
-	workerOptions := workers.ProvideWorkerOptions(c, operationManager, v2, roomManager, runtime)
+	workerOptions := workers.ProvideWorkerOptions(operationManager, v2, roomManager, runtime, configuration)
 	workersManager := workers_manager.NewWorkersManager(builder, c, schedulerStorage, workerOptions)
 	return workersManager, nil
 }

--- a/config/worker.local.yaml
+++ b/config/worker.local.yaml
@@ -38,6 +38,8 @@ adapters:
 workers:
   syncInterval: 10s
   stopTimeoutDuration: 1m
+  operationExecution:
+    healthControllerInterval: 1m
 services:
   roomManager:
     roomPingTimeoutMillis: 90000

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -81,6 +81,7 @@ func (w *OperationExecutionWorker) Start(ctx context.Context) error {
 	pendingOpsChan := w.operationManager.PendingOperationsChan(w.workerContext, w.scheduler.Name)
 
 	healthControllerTicker := time.NewTicker(w.config.GetDuration(healthControllerExecutionIntervalConfigPath))
+	defer healthControllerTicker.Stop()
 
 	for {
 		select {

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -37,16 +37,24 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	mockconfig "github.com/topfreegames/maestro/internal/config/mock"
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/operations"
+	"github.com/topfreegames/maestro/internal/core/operations/healthcontroller"
 	mockoperation "github.com/topfreegames/maestro/internal/core/operations/mock"
 	"github.com/topfreegames/maestro/internal/core/workers"
 )
 
 func TestSchedulerOperationsExecutionLoop(t *testing.T) {
+	duration, err := time.ParseDuration("10m")
+	require.NoError(t, err)
+
 	t.Run("successfully runs a single operation", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
+
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
 
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
@@ -69,7 +77,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -104,6 +112,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 	t.Run("execute Rollback when a Execute fails", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
+
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -125,7 +136,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -165,6 +176,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 	t.Run("execute Rollback when a Execute was canceled", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
+
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -186,7 +200,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -228,6 +242,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
+
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationDefinition.EXPECT().Name().Return(operationName).AnyTimes()
@@ -245,7 +262,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		}
 
 		executors := map[string]operations.Executor{}
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -269,6 +286,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
+
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -289,7 +309,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -315,6 +335,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
+
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -335,7 +358,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
 
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
 		pendingOpsChan := make(chan string)
@@ -366,6 +389,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
+
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -386,7 +412,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -416,6 +442,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
+
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -437,7 +466,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
 
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), expectedOperation.SchedulerName).Return(pendingOpsChan)
@@ -452,6 +481,9 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 	t.Run("no error getting next operation should stop execution of operation", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
+
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
 
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
@@ -474,7 +506,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(nil, nil, errors.New("some error"))
@@ -488,6 +520,97 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		}()
 
 		err := workerService.Start(context.Background())
+		require.NoError(t, err)
+	})
+
+	t.Run("when healthcontroller ticks, call operation manager creating a new health_controller operation", func(t *testing.T) {
+		duration, err := time.ParseDuration("1ms")
+		require.NoError(t, err)
+
+		mockCtrl := gomock.NewController(t)
+
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
+
+		operationName := "test_operation"
+		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
+		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
+		operationManager := mock.NewMockOperationManager(mockCtrl)
+
+		defFunc := func() operations.Definition { return operationDefinition }
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[operationName] = defFunc
+
+		scheduler := &entities.Scheduler{Name: "random-scheduler"}
+
+		executors := map[string]operations.Executor{}
+		executors[operationName] = operationExecutor
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		pendingOpsChan := make(chan string)
+
+		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), gomock.Any()).Return(pendingOpsChan)
+		operationManager.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(_ context.Context, schedulerName string, op operations.Definition) {
+			require.Equal(t, scheduler.Name, schedulerName)
+			require.IsType(t, &healthcontroller.SchedulerHealthControllerDefinition{}, op)
+		}).Return(&operation.Operation{}, nil).AnyTimes()
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func() {
+			time.Sleep(5 * time.Millisecond)
+			cancel()
+		}()
+
+		err = workerService.Start(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("when healthcontroller ticks and CreateOperation return in error, continue the execution normally", func(t *testing.T) {
+		duration, err := time.ParseDuration("1ms")
+		require.NoError(t, err)
+
+		mockCtrl := gomock.NewController(t)
+
+		config := mockconfig.NewMockConfig(mockCtrl)
+		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
+
+		operationName := "test_operation"
+		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
+		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
+		operationManager := mock.NewMockOperationManager(mockCtrl)
+
+		defFunc := func() operations.Definition { return operationDefinition }
+		definitionConstructors := operations.NewDefinitionConstructors()
+		definitionConstructors[operationName] = defFunc
+
+		scheduler := &entities.Scheduler{Name: "random-scheduler"}
+
+		executors := map[string]operations.Executor{}
+		executors[operationName] = operationExecutor
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		pendingOpsChan := make(chan string)
+
+		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), gomock.Any()).Return(pendingOpsChan)
+		executionCount := 0
+		operationManager.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, schedulerName string, op operations.Definition) (*operation.Operation, error) {
+			require.Equal(t, scheduler.Name, schedulerName)
+			require.IsType(t, &healthcontroller.SchedulerHealthControllerDefinition{}, op)
+
+			if executionCount == 0 {
+				return nil, fmt.Errorf("Error on creating operation")
+			}
+
+			return &operation.Operation{}, nil
+		}).AnyTimes()
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func() {
+			time.Sleep(5 * time.Millisecond)
+			cancel()
+		}()
+
+		err = workerService.Start(ctx)
 		require.NoError(t, err)
 	})
 }

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	mockconfig "github.com/topfreegames/maestro/internal/config/mock"
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/operations"
@@ -52,9 +51,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 	t.Run("successfully runs a single operation", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
-
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
 
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
@@ -77,7 +73,10 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -112,9 +111,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 	t.Run("execute Rollback when a Execute fails", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
-
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -136,7 +132,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
+
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -176,9 +176,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 	t.Run("execute Rollback when a Execute was canceled", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
-
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -200,7 +197,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
+
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -242,9 +243,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
-
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationDefinition.EXPECT().Name().Return(operationName).AnyTimes()
@@ -262,7 +260,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		}
 
 		executors := map[string]operations.Executor{}
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
+
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -286,9 +288,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
-
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -309,7 +308,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
+
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -335,9 +338,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
-
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -358,7 +358,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
+
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
 		pendingOpsChan := make(chan string)
@@ -389,9 +393,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
-
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -412,7 +413,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
+
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
@@ -442,9 +447,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		operationManager := mock.NewMockOperationManager(mockCtrl)
 
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
-
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -465,8 +467,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
 
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), expectedOperation.SchedulerName).Return(pendingOpsChan)
@@ -481,9 +486,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 	t.Run("no error getting next operation should stop execution of operation", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
-
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
 
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
@@ -506,7 +508,11 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
+
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(nil, nil, errors.New("some error"))
@@ -529,9 +535,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		mockCtrl := gomock.NewController(t)
 
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
-
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -545,14 +548,15 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
+
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), gomock.Any()).Return(pendingOpsChan)
-		operationManager.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(_ context.Context, schedulerName string, op operations.Definition) {
-			require.Equal(t, scheduler.Name, schedulerName)
-			require.IsType(t, &healthcontroller.SchedulerHealthControllerDefinition{}, op)
-		}).Return(&operation.Operation{}, nil).AnyTimes()
+		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, &healthcontroller.SchedulerHealthControllerDefinition{}).Return(&operation.Operation{}, nil).MaxTimes(5)
 
 		ctx, cancel := context.WithCancel(context.Background())
 
@@ -571,9 +575,6 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		mockCtrl := gomock.NewController(t)
 
-		config := mockconfig.NewMockConfig(mockCtrl)
-		config.EXPECT().GetDuration(gomock.Any()).Return(duration)
-
 		operationName := "test_operation"
 		operationDefinition := mockoperation.NewMockDefinition(mockCtrl)
 		operationExecutor := mockoperation.NewMockExecutor(mockCtrl)
@@ -587,21 +588,15 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 
 		executors := map[string]operations.Executor{}
 		executors[operationName] = operationExecutor
-		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(config, operationManager, executors, nil, nil))
+		config := workers.Configuration{
+			HealthControllerExecutionInterval: duration,
+		}
+
+		workerService := NewOperationExecutionWorker(scheduler, workers.ProvideWorkerOptions(operationManager, executors, nil, nil, config))
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), gomock.Any()).Return(pendingOpsChan)
-		executionCount := 0
-		operationManager.EXPECT().CreateOperation(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, schedulerName string, op operations.Definition) (*operation.Operation, error) {
-			require.Equal(t, scheduler.Name, schedulerName)
-			require.IsType(t, &healthcontroller.SchedulerHealthControllerDefinition{}, op)
-
-			if executionCount == 0 {
-				return nil, fmt.Errorf("Error on creating operation")
-			}
-
-			return &operation.Operation{}, nil
-		}).AnyTimes()
+		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, &healthcontroller.SchedulerHealthControllerDefinition{}).Return(nil, fmt.Errorf("Error on creating operation")).MaxTimes(5)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/internal/core/workers/worker.go
+++ b/internal/core/workers/worker.go
@@ -24,8 +24,8 @@ package workers
 
 import (
 	"context"
+	"time"
 
-	maestroConfig "github.com/topfreegames/maestro/internal/config"
 	"github.com/topfreegames/maestro/internal/core/workers/config"
 
 	"github.com/topfreegames/maestro/internal/core/entities"
@@ -47,7 +47,7 @@ type Worker interface {
 // its construction. This struct is going to be used to inject the worker
 // dependencies like ports.
 type WorkerOptions struct {
-	Config                maestroConfig.Config
+	Configuration         Configuration
 	OperationManager      ports.OperationManager
 	OperationExecutors    map[string]operations.Executor
 	RoomManager           ports.RoomManager
@@ -57,16 +57,21 @@ type WorkerOptions struct {
 	MetricsReporterConfig *config.MetricsReporterConfig
 }
 
+// Configuration holds all worker configuration parameters.
+type Configuration struct {
+	HealthControllerExecutionInterval time.Duration
+}
+
 // ProvideWorkerOptions instantiate an WorkerOptions structure.
 func ProvideWorkerOptions(
-	appConfig maestroConfig.Config,
 	operationManager ports.OperationManager,
 	operationExecutors map[string]operations.Executor,
 	roomManager ports.RoomManager,
 	runtime ports.Runtime,
+	configuration Configuration,
 ) *WorkerOptions {
 	return &WorkerOptions{
-		Config:             appConfig,
+		Configuration:      configuration,
 		OperationManager:   operationManager,
 		OperationExecutors: operationExecutors,
 		RoomManager:        roomManager,

--- a/internal/core/workers/worker.go
+++ b/internal/core/workers/worker.go
@@ -25,6 +25,7 @@ package workers
 import (
 	"context"
 
+	maestroConfig "github.com/topfreegames/maestro/internal/config"
 	"github.com/topfreegames/maestro/internal/core/workers/config"
 
 	"github.com/topfreegames/maestro/internal/core/entities"
@@ -46,6 +47,7 @@ type Worker interface {
 // its construction. This struct is going to be used to inject the worker
 // dependencies like ports.
 type WorkerOptions struct {
+	Config                maestroConfig.Config
 	OperationManager      ports.OperationManager
 	OperationExecutors    map[string]operations.Executor
 	RoomManager           ports.RoomManager
@@ -55,13 +57,16 @@ type WorkerOptions struct {
 	MetricsReporterConfig *config.MetricsReporterConfig
 }
 
+// ProvideWorkerOptions instantiate an WorkerOptions structure.
 func ProvideWorkerOptions(
+	appConfig maestroConfig.Config,
 	operationManager ports.OperationManager,
 	operationExecutors map[string]operations.Executor,
 	roomManager ports.RoomManager,
 	runtime ports.Runtime,
 ) *WorkerOptions {
 	return &WorkerOptions{
+		Config:             appConfig,
 		OperationManager:   operationManager,
 		OperationExecutors: operationExecutors,
 		RoomManager:        roomManager,

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -26,12 +26,16 @@ import (
 	"time"
 
 	"github.com/topfreegames/maestro/internal/core/services/events_forwarder"
+	"github.com/topfreegames/maestro/internal/core/workers"
 
 	"github.com/topfreegames/maestro/internal/config"
 	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
 	"github.com/topfreegames/maestro/internal/core/services/room_manager"
 )
 
+const healthControllerExecutionIntervalConfigPath = "workers.operationExecution.healthControllerInterval"
+
+// NewRoomManagerConfig instantiate a new RoomManagerConfig to be used by the RoomManager to customize its configuration.
 func NewRoomManagerConfig(c config.Config) (room_manager.RoomManagerConfig, error) {
 	pingTimeout := time.Duration(c.GetInt("services.roomManager.roomPingTimeoutMillis")) * time.Millisecond
 	initializationTimeout := time.Duration(c.GetInt("services.roomManager.roomInitializationTimeoutMillis")) * time.Millisecond
@@ -46,28 +50,40 @@ func NewRoomManagerConfig(c config.Config) (room_manager.RoomManagerConfig, erro
 	return roomManagerConfig, nil
 }
 
+// NewWorkersConfig instantiate a new workers Config stucture to be used by the workers to customize them from the config package.
+func NewWorkersConfig(c config.Config) (workers.Configuration, error) {
+	healthControllerExecutionInterval := c.GetDuration(healthControllerExecutionIntervalConfigPath)
+	config := workers.Configuration{
+		HealthControllerExecutionInterval: healthControllerExecutionInterval,
+	}
+
+	return config, nil
+}
+
+// NewOperationManagerConfig instantiate a new OperationManagerConfig to be used by the OperationManager to customize its configuration.
 func NewOperationManagerConfig(c config.Config) (operation_manager.OperationManagerConfig, error) {
-	operationLeaseTtl := time.Duration(c.GetInt("services.operationManager.operationLeaseTtlMillis")) * time.Millisecond
+	operationLeaseTTL := time.Duration(c.GetInt("services.operationManager.operationLeaseTtlMillis")) * time.Millisecond
 
 	operationManagerConfig := operation_manager.OperationManagerConfig{
-		OperationLeaseTtl: operationLeaseTtl,
+		OperationLeaseTtl: operationLeaseTTL,
 	}
 
 	return operationManagerConfig, nil
 }
 
+// NewEventsForwarderServiceConfig instantiate a new EventsForwarderConfig to be used by the EventsForwarder to customize its configuration.
 func NewEventsForwarderServiceConfig(c config.Config) (events_forwarder.EventsForwarderConfig, error) {
-	var schedulerCacheTtl time.Duration
-	defaultSchedulerCacheTtl := time.Hour * 24
+	var schedulerCacheTTL time.Duration
+	defaultSchedulerCacheTTL := time.Hour * 24
 
-	if configuredSchedulerCacheTtlInt := c.GetInt("services.eventsForwarder.schedulerCacheTtlMillis"); configuredSchedulerCacheTtlInt > 0 {
-		schedulerCacheTtl = time.Duration(configuredSchedulerCacheTtlInt) * time.Millisecond
+	if configuredSchedulerCacheTTLInt := c.GetInt("services.eventsForwarder.schedulerCacheTtlMillis"); configuredSchedulerCacheTTLInt > 0 {
+		schedulerCacheTTL = time.Duration(configuredSchedulerCacheTTLInt) * time.Millisecond
 	} else {
-		schedulerCacheTtl = defaultSchedulerCacheTtl
+		schedulerCacheTTL = defaultSchedulerCacheTTL
 	}
 
 	eventsForwarderConfig := events_forwarder.EventsForwarderConfig{
-		SchedulerCacheTtl: schedulerCacheTtl,
+		SchedulerCacheTtl: schedulerCacheTTL,
 	}
 
 	return eventsForwarderConfig, nil


### PR DESCRIPTION
### Why
Currently `health_controller` isn't being triggered to execute.

### What
- Add a ticker to control when `health_controller` executes
- Integrate `health_controller` in the `operation_execution_worker`