### PR TITLE
remove rooms do not fails when room is not found

### DIFF
--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -159,6 +159,8 @@ func (m *RoomManager) DeleteRoomAndWaitForRoomTerminating(ctx context.Context, g
 	err = m.Runtime.DeleteGameRoomInstance(ctx, instance)
 	if err != nil {
 		if errors.Is(err, porterrors.ErrNotFound) {
+			_ = m.RoomStorage.DeleteRoom(ctx, gameRoom.SchedulerID, gameRoom.ID)
+			_ = m.InstanceStorage.DeleteInstance(ctx, gameRoom.SchedulerID, gameRoom.ID)
 			return nil
 		}
 		return fmt.Errorf("failed to delete instance on the runtime: %w", err)

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -149,13 +149,17 @@ func (m *RoomManager) populateSpecWithHostPort(scheduler entities.Scheduler) (*g
 func (m *RoomManager) DeleteRoomAndWaitForRoomTerminating(ctx context.Context, gameRoom *game_room.GameRoom) error {
 	instance, err := m.InstanceStorage.GetInstance(ctx, gameRoom.SchedulerID, gameRoom.ID)
 	if err != nil {
-		// TODO(gabriel.corado): deal better with instance not found.
+		if errors.Is(err, porterrors.ErrNotFound) {
+			return nil
+		}
 		return fmt.Errorf("unable to fetch game room instance from storage: %w", err)
 	}
 
 	err = m.Runtime.DeleteGameRoomInstance(ctx, instance)
 	if err != nil {
-		// TODO(gabriel.corado): deal better with instance not found.
+		if errors.Is(err, porterrors.ErrNotFound) {
+			return nil
+		}
 		return fmt.Errorf("failed to delete instance on the runtime: %w", err)
 	}
 

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -150,6 +150,7 @@ func (m *RoomManager) DeleteRoomAndWaitForRoomTerminating(ctx context.Context, g
 	instance, err := m.InstanceStorage.GetInstance(ctx, gameRoom.SchedulerID, gameRoom.ID)
 	if err != nil {
 		if errors.Is(err, porterrors.ErrNotFound) {
+			_ = m.RoomStorage.DeleteRoom(ctx, gameRoom.SchedulerID, gameRoom.ID)
 			return nil
 		}
 		return fmt.Errorf("unable to fetch game room instance from storage: %w", err)

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -331,11 +331,12 @@ func TestRoomManager_DeleteRoomAndWaitForRoomTerminating(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("when room instance is not found on storage do not return error", func(t *testing.T) {
-		roomManager, _, _, instanceStorage, _, _, _ := testSetup(t)
+	t.Run("when room instance is not found on storage, try to delete game room, do not return error", func(t *testing.T) {
+		roomManager, _, roomStorage, instanceStorage, _, _, _ := testSetup(t)
 
 		gameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusTerminating}
 		instanceStorage.EXPECT().GetInstance(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(nil, porterrors.NewErrNotFound("error"))
+		roomStorage.EXPECT().DeleteRoom(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(nil)
 
 		err := roomManager.DeleteRoomAndWaitForRoomTerminating(context.Background(), gameRoom)
 		require.NoError(t, err)

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -343,12 +343,14 @@ func TestRoomManager_DeleteRoomAndWaitForRoomTerminating(t *testing.T) {
 	})
 
 	t.Run("when room instance is not found on runtime do not return error", func(t *testing.T) {
-		roomManager, _, _, instanceStorage, runtime, _, _ := testSetup(t)
+		roomManager, _, roomStorage, instanceStorage, runtime, _, _ := testSetup(t)
 
 		gameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusTerminating}
 		instance := &game_room.Instance{ID: "test-instance"}
 		instanceStorage.EXPECT().GetInstance(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(instance, nil)
 		runtime.EXPECT().DeleteGameRoomInstance(context.Background(), instance).Return(porterrors.NewErrNotFound("error"))
+		roomStorage.EXPECT().DeleteRoom(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(nil)
+		instanceStorage.EXPECT().DeleteInstance(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(nil)
 
 		err := roomManager.DeleteRoomAndWaitForRoomTerminating(context.Background(), gameRoom)
 		require.NoError(t, err)


### PR DESCRIPTION
### What?
Fix behavior for when removing rooms try to remove a room that does not exist
### Why?
Remove rooms should not break entirely when the room is not found (we suppose it is already deleted). Also, we try to delete the room from the storage too, since probably it is a inconsistency.