### PR TITLE
Feature/add ttl to operations

### DIFF
--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -23,10 +23,6 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	if err != nil {
 		return nil, err
 	}
-	configuration, err := service.NewWorkersConfig(c)
-	if err != nil {
-		return nil, err
-	}
 	operationFlow, err := service.NewOperationFlowRedis(c)
 	if err != nil {
 		return nil, err
@@ -82,6 +78,10 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	roomManager := service.NewRoomManager(clock, portAllocator, roomStorage, gameRoomInstanceStorage, runtime, eventsService, roomManagerConfig)
 	schedulerManager := scheduler_manager.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager, roomStorage, schedulerManager, gameRoomInstanceStorage, operationManager, roomManagerConfig)
+	configuration, err := service.NewWorkersConfig(c)
+	if err != nil {
+		return nil, err
+	}
 	workerOptions := workers.ProvideWorkerOptions(operationManager, v2, roomManager, runtime, configuration)
 	workersManager := workers_manager.NewWorkersManager(builder, c, schedulerStorage, workerOptions)
 	return workersManager, nil

--- a/config/management-api.local.yaml
+++ b/config/management-api.local.yaml
@@ -18,6 +18,8 @@ adapters:
   operationStorage:
     redis:
       url: "redis://localhost:6379/0"
+      operationsTtl:
+        healthController: 24h
   operationLeaseStorage:
     redis:
       url: "redis://localhost:6379/0"

--- a/config/runtime-watcher.local.yaml
+++ b/config/runtime-watcher.local.yaml
@@ -15,6 +15,8 @@ adapters:
   operationStorage:
     redis:
       url: "redis://localhost:6379/0"
+      operationsTtl:
+        healthController: 24h
   operationLeaseStorage:
     redis:
       url: "redis://localhost:6379/0"

--- a/config/worker.local.yaml
+++ b/config/worker.local.yaml
@@ -15,6 +15,8 @@ adapters:
   operationStorage:
     redis:
       url: "redis://localhost:6379/0"
+      operationsTtl:
+        healthController: 24h
   operationLeaseStorage:
     redis:
       url: "redis://localhost:6379/0"

--- a/internal/adapters/operation/operation_storage_redis_test.go
+++ b/internal/adapters/operation/operation_storage_redis_test.go
@@ -117,24 +117,8 @@ func TestCreateOperation(t *testing.T) {
 		err := storage.CreateOperation(context.Background(), op)
 		require.NoError(t, err)
 
-		executionHistoryJson, err := json.Marshal(op.ExecutionHistory)
-		require.NoError(t, err)
-
-		operationStored, err := client.HGetAll(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID)).Result()
-		require.NoError(t, err)
-		require.Equal(t, op.ID, operationStored[idRedisKey])
-		require.Equal(t, op.SchedulerName, operationStored[schedulerNameRedisKey])
-		require.Equal(t, op.DefinitionName, operationStored[definitionNameRedisKey])
-		require.Equal(t, createdAtString, operationStored[createdAtRedisKey])
-		require.EqualValues(t, op.Input, operationStored[definitionContentsRedisKey])
-		require.EqualValues(t, executionHistoryJson, operationStored[executionHistoryRedisKey])
-
-		intStatus, err := strconv.Atoi(operationStored[statusRedisKey])
-		require.NoError(t, err)
-		require.Equal(t, op.Status, operation.Status(intStatus))
-
-		time.Sleep(time.Second)
-		operationStored, _ = client.HGetAll(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID)).Result()
+		time.Sleep(time.Second * 2)
+		operationStored, _ := client.HGetAll(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID)).Result()
 		require.True(t, len(operationStored) == 0)
 	})
 

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -24,8 +24,9 @@ package service
 
 import (
 	"fmt"
-	"github.com/topfreegames/maestro/internal/core/operations/healthcontroller"
 	"time"
+
+	"github.com/topfreegames/maestro/internal/core/operations/healthcontroller"
 
 	operationadapters "github.com/topfreegames/maestro/internal/adapters/operation"
 

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -24,6 +24,8 @@ package service
 
 import (
 	"fmt"
+	"github.com/topfreegames/maestro/internal/core/operations/healthcontroller"
+	"time"
 
 	operationadapters "github.com/topfreegames/maestro/internal/adapters/operation"
 
@@ -71,6 +73,8 @@ const (
 	schedulerStoragePostgresUrlPath = "adapters.schedulerStorage.postgres.url"
 	// Redis operation flow
 	operationFlowRedisUrlPath = "adapters.operationFlow.redis.url"
+	// Health Controller operation TTL
+	healthControllerOperationTTL = "adapters.operationStorage.redis.operationsTtl.healthController"
 )
 
 func NewOperationManager(flow ports.OperationFlow, storage ports.OperationStorage, operationDefinitionConstructors map[string]operations.DefinitionConstructor, leaseStorage ports.OperationLeaseStorage, config operation_manager.OperationManagerConfig, schedulerStorage ports.SchedulerStorage) ports.OperationManager {
@@ -110,7 +114,11 @@ func NewOperationStorageRedis(clock ports.Clock, c config.Config) (ports.Operati
 		return nil, fmt.Errorf("failed to initialize Redis operation storage: %w", err)
 	}
 
-	return operationadapters.NewRedisOperationStorage(client, clock), nil
+	operationsTTlMap := map[operationadapters.Definition]time.Duration{
+		healthcontroller.OperationName: c.GetDuration(healthControllerOperationTTL),
+	}
+
+	return operationadapters.NewRedisOperationStorage(client, clock, operationsTTlMap), nil
 }
 
 func NewOperationLeaseStorageRedis(clock ports.Clock, c config.Config) (ports.OperationLeaseStorage, error) {

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/orlangure/gnomock"
@@ -60,6 +61,7 @@ func TestOperationStorageRedis(t *testing.T) {
 		config := configmock.NewMockConfig(mockCtrl)
 
 		config.EXPECT().GetString(operationStorageRedisUrlPath).Return(getRedisUrl(t))
+		config.EXPECT().GetDuration(healthControllerOperationTTL).Return(time.Minute)
 		opStorage, err := NewOperationStorageRedis(clock, config)
 		require.NoError(t, err)
 
@@ -74,6 +76,7 @@ func TestOperationStorageRedis(t *testing.T) {
 		config := configmock.NewMockConfig(mockCtrl)
 
 		config.EXPECT().GetString(operationStorageRedisUrlPath).Return("redis://somewhere-in-the-world:6379")
+		config.EXPECT().GetDuration(healthControllerOperationTTL).Return(time.Minute)
 		opStorage, err := NewOperationStorageRedis(clock, config)
 		require.NoError(t, err)
 


### PR DESCRIPTION
### What?
Adds TTL to operation health controller
### Why?
Because this operation is going to accumulate and become a huge list of operations if it does not expire