### PR TITLE
Fix list scheduler active operations to not return error when an oper…

### DIFF
--- a/internal/adapters/operation/operation_storage_redis.go
+++ b/internal/adapters/operation/operation_storage_redis.go
@@ -190,7 +190,7 @@ func (r *redisOperationStorage) ListSchedulerActiveOperations(ctx context.Contex
 	})
 
 	if err != nil {
-		return nil, errors.NewErrUnexpected("failed execute pipe for retrieving schedulers").WithError(err)
+		return nil, errors.NewErrUnexpected("failed execute pipe for retrieving operations").WithError(err)
 	}
 	operations = make([]*operation.Operation, 0, len(operationsIDs))
 	for _, cmder := range cmders {

--- a/internal/adapters/operation/operation_storage_redis.go
+++ b/internal/adapters/operation/operation_storage_redis.go
@@ -177,14 +177,37 @@ func (r *redisOperationStorage) ListSchedulerActiveOperations(ctx context.Contex
 		return nil, errors.NewErrUnexpected("failed to list active operations for \"%s\"", schedulerName).WithError(err)
 	}
 
-	operations = make([]*operation.Operation, len(operationsIDs))
-	for i, operationID := range operationsIDs {
-		op, err := r.GetOperation(ctx, schedulerName, operationID)
-		if err != nil {
-			return nil, err
+	pipe := r.client.Pipeline()
+
+	for _, operationID := range operationsIDs {
+		pipe.HGetAll(ctx, fmt.Sprintf("operations:%s:%s", schedulerName, operationID))
+	}
+
+	var cmders []redis.Cmder
+	metrics.RunWithMetrics(operationStorageMetricLabel, func() error {
+		cmders, err = pipe.Exec(ctx)
+		return err
+	})
+
+	if err != nil {
+		return nil, errors.NewErrUnexpected("failed execute pipe for retrieving schedulers").WithError(err)
+	}
+	operations = make([]*operation.Operation, 0, len(operationsIDs))
+	for _, cmder := range cmders {
+		res, err := cmder.(*redis.StringStringMapCmd).Result()
+		if err != nil && err != redis.Nil {
+			return nil, errors.NewErrUnexpected("failed to fetch operation").WithError(err)
 		}
 
-		operations[i] = op
+		if len(res) == 0 {
+			continue
+		}
+
+		op, err := buildOperationFromMap(res)
+		if err != nil {
+			return nil, errors.NewErrUnexpected("failed to build operation from the hash").WithError(err)
+		}
+		operations = append(operations, op)
 	}
 
 	return operations, nil

--- a/internal/adapters/operation/operation_storage_redis_test.go
+++ b/internal/adapters/operation/operation_storage_redis_test.go
@@ -658,7 +658,7 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		}
 	})
 
-	t.Run("failed to fetch a operation inside the list", func(t *testing.T) {
+	t.Run("fetching an operation that doesnt exists in the list, return without them", func(t *testing.T) {
 		client := test.GetRedisConnection(t, redisAddress)
 		now := time.Now()
 		operationsTTlMap := map[Definition]time.Duration{}
@@ -685,8 +685,8 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		}).Err()
 		require.NoError(t, err)
 
-		_, err = storage.ListSchedulerActiveOperations(context.Background(), schedulerName)
-		require.Error(t, err)
-		require.ErrorIs(t, errors.ErrNotFound, err)
+		resultOperations, err := storage.ListSchedulerActiveOperations(context.Background(), schedulerName)
+		require.NoError(t, err)
+		require.Len(t, resultOperations, len(activeOperations))
 	})
 }

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -187,7 +187,6 @@ func (om *OperationManager) ListSchedulerActiveOperations(ctx context.Context, s
 }
 
 func (om *OperationManager) ListSchedulerFinishedOperations(ctx context.Context, schedulerName string) ([]*operation.Operation, error) {
-
 	return om.Storage.ListSchedulerFinishedOperations(ctx, schedulerName)
 }
 


### PR DESCRIPTION
### WHY
`ListSchedulerActiveOperations` in the Redis adapter returned an error when an operation was expired. This PR proposes to avoid errors when it is `redis.Nil`.
### WHAT
- Change the Redis operation storage adapter to avoid returning an error when it is `redis.Nil`
- Use the Redis pipeline to avoid multiple calls to the Redis and improve latency.