### PR TITLE
Fix/clear nonexistent operations from history

### DIFF
--- a/internal/adapters/operation/operation_storage_redis.go
+++ b/internal/adapters/operation/operation_storage_redis.go
@@ -29,6 +29,8 @@ import (
 	"strconv"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/topfreegames/maestro/internal/adapters/metrics"
 
 	"github.com/go-redis/redis/v8"
@@ -269,6 +271,7 @@ func (r *redisOperationStorage) removeNonExistentOperationFromHistory(ctx contex
 		}
 		metrics.RunWithMetrics(operationStorageMetricLabel, func() error {
 			_, err := pipe.Exec(ctx)
+			zap.L().Error("failed to remove non-existent operations from history", zap.Error(err))
 			return err
 		})
 	}()


### PR DESCRIPTION
## What ❓ 
Delete nonexistent operations from history when listing active operations.

## Why 🤔 
When expiring certain types of operations, we are not removing them from the operation history sorted set, which causes the maestro to make unnecessary queries for nonexistent operations.