### PR TITLE
Fix/produce event for killed rooms

### DIFF
--- a/internal/adapters/runtime/kubernetes/game_room_watcher.go
+++ b/internal/adapters/runtime/kubernetes/game_room_watcher.go
@@ -213,7 +213,6 @@ func (kw *kubernetesWatcher) updateFunc(obj interface{}, newObj interface{}) {
 }
 
 func (kw *kubernetesWatcher) deleteFunc(obj interface{}) {
-	kw.logger.Info("POD DELETED")
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		return

--- a/internal/adapters/runtime/kubernetes/game_room_watcher.go
+++ b/internal/adapters/runtime/kubernetes/game_room_watcher.go
@@ -213,6 +213,7 @@ func (kw *kubernetesWatcher) updateFunc(obj interface{}, newObj interface{}) {
 }
 
 func (kw *kubernetesWatcher) deleteFunc(obj interface{}) {
+	kw.logger.Info("POD DELETED")
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		return

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -234,8 +234,8 @@ func (m *RoomManager) CleanRoomState(ctx context.Context, schedulerName, roomId 
 	}
 
 	m.forwardStatusTerminatingEvent(ctx, &game_room.GameRoom{
-		ID:               roomId,
-		SchedulerID:      schedulerName,
+		ID:          roomId,
+		SchedulerID: schedulerName,
 	})
 
 	m.Logger.Info("cleaning room success")
@@ -364,8 +364,8 @@ func (m *RoomManager) UpdateGameRoomStatus(ctx context.Context, schedulerId, gam
 
 	if instance.Status.Type == game_room.InstanceTerminating {
 		m.forwardStatusTerminatingEvent(ctx, &game_room.GameRoom{
-			ID:               gameRoomId,
-			SchedulerID:      schedulerId,
+			ID:          gameRoomId,
+			SchedulerID: schedulerId,
 		})
 	}
 

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -233,6 +233,11 @@ func (m *RoomManager) CleanRoomState(ctx context.Context, schedulerName, roomId 
 		return fmt.Errorf("failed to delete room state: %w", err)
 	}
 
+	m.forwardStatusTerminatingEvent(ctx, &game_room.GameRoom{
+		ID:               roomId,
+		SchedulerID:      schedulerName,
+	})
+
 	m.Logger.Info("cleaning room success")
 	return nil
 }
@@ -355,6 +360,13 @@ func (m *RoomManager) UpdateGameRoomStatus(ctx context.Context, schedulerId, gam
 	err = m.RoomStorage.UpdateRoomStatus(ctx, schedulerId, gameRoomId, newStatus)
 	if err != nil {
 		return fmt.Errorf("failed to update game room status: %w", err)
+	}
+
+	if instance.Status.Type == game_room.InstanceTerminating {
+		m.forwardStatusTerminatingEvent(ctx, &game_room.GameRoom{
+			ID:               gameRoomId,
+			SchedulerID:      schedulerId,
+		})
 	}
 
 	return nil


### PR DESCRIPTION
### What?
Produce events room terminating when room terminated
### Why?
Rooms killed without graceful shutdown were not having events being produced with this information.