### PR TITLE
Add CreateRoom method in RoomManager port and adapter

### DIFF
--- a/internal/core/ports/mock/rooms_ports_mock.go
+++ b/internal/core/ports/mock/rooms_ports_mock.go
@@ -53,6 +53,22 @@ func (mr *MockRoomManagerMockRecorder) CleanRoomState(ctx, schedulerName, roomId
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanRoomState", reflect.TypeOf((*MockRoomManager)(nil).CleanRoomState), ctx, schedulerName, roomId)
 }
 
+// CreateRoom mocks base method.
+func (m *MockRoomManager) CreateRoom(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRoom", ctx, scheduler, isValidationRoom)
+	ret0, _ := ret[0].(*game_room.GameRoom)
+	ret1, _ := ret[1].(*game_room.Instance)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateRoom indicates an expected call of CreateRoom.
+func (mr *MockRoomManagerMockRecorder) CreateRoom(ctx, scheduler, isValidationRoom interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoom", reflect.TypeOf((*MockRoomManager)(nil).CreateRoom), ctx, scheduler, isValidationRoom)
+}
+
 // CreateRoomAndWaitForReadiness mocks base method.
 func (m *MockRoomManager) CreateRoomAndWaitForReadiness(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error) {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/room_ports.go
+++ b/internal/core/ports/room_ports.go
@@ -71,6 +71,8 @@ type RoomManager interface {
 	// If the room is created and don't succeed on sending a ping to maestro, it will try to delete the room, and return
 	// an error. The "isValidationRoom" parameter must be passed "true" if we want to create a room that won't be forwarded
 	CreateRoomAndWaitForReadiness(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error)
+	// CreateRoom creates a game room in maestro runtime and storages without waiting the room to reach ready status.
+	CreateRoom(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error)
 	// UpdateGameRoomStatus updates the game based on the ping and runtime status.
 	UpdateGameRoomStatus(ctx context.Context, schedulerId, gameRoomId string) error
 	// WaitRoomStatus blocks the caller until the context is canceled, an error


### PR DESCRIPTION
## What ❓ 
Add **CreateRoom** method in RoomManager port and adapter, including unitary tests.

## Why 🤔 
The add rooms operation uses the CreateRoomAndWaitForReadiness method for creating rooms, this method, as the name suggests, creates the game room and blocks the execution, waiting for the room to reach the ready state (when the room sends the ping). This behavior can make add rooms operations take a lot of time if this waiting period reach the roomInitializationTimeout period. For a scheduler with health checker or autoscaling enabled, having add rooms operation as a blocking operation can create scenarios in which the maestro will take too long to reach the desired state.