### PR TITLE
Update add rooms operation to not wait for rooms readiness

### DIFF
--- a/internal/core/operations/add_rooms/add_rooms_executor_test.go
+++ b/internal/core/operations/add_rooms/add_rooms_executor_test.go
@@ -28,6 +28,9 @@ package add_rooms
 import (
 	"time"
 
+	"github.com/topfreegames/maestro/internal/core/logs"
+	"go.uber.org/zap"
+
 	"github.com/topfreegames/maestro/internal/core/operations"
 
 	"context"
@@ -40,8 +43,6 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
-	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
-
 	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
 )
 
@@ -100,7 +101,7 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 		roomsManager := mockports.NewMockRoomManager(mockCtrl)
 
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), op.SchedulerName).Return(&scheduler, nil)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(10)
+		roomsManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(10)
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
@@ -116,32 +117,14 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 		gameRoomReady := gameRoom
 		gameRoomReady.Status = game_room.GameStatusReady
 
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, porterrors.NewErrUnexpected("error"))
+		roomsManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
+		roomsManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), false).Return(nil, nil, porterrors.NewErrUnexpected("error"))
 
 		executor := NewExecutor(roomsManager, schedulerStorage)
 		err := executor.Execute(context.Background(), &op, &definition)
 
 		require.NotNil(t, err)
 		require.Equal(t, err.Kind(), operations.ErrKindUnexpected)
-	})
-
-	t.Run("should fail - some room creation fail with timeout => returns timeout error", func(t *testing.T) {
-		roomsManager := mockports.NewMockRoomManager(mockCtrl)
-
-		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
-
-		gameRoomReady := gameRoom
-		gameRoomReady.Status = game_room.GameStatusReady
-
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, serviceerrors.NewErrGameRoomStatusWaitingTimeout("context deadline exceeded"))
-
-		executor := NewExecutor(roomsManager, schedulerStorage)
-		err := executor.Execute(context.Background(), &op, &definition)
-
-		require.NotNil(t, err)
-		require.Equal(t, err.Kind(), operations.ErrKindReadyPingTimeout)
 	})
 
 	t.Run("should fail - no scheduler found => returns error", func(t *testing.T) {
@@ -158,46 +141,9 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 func TestAddRoomsExecutor_Rollback(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
-	clockMock := clock_mock.NewFakeClock(time.Now())
 	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 
 	definition := AddRoomsDefinition{Amount: 10}
-
-	container1 := game_room.Container{
-		Name: "container1",
-		Ports: []game_room.ContainerPort{
-			{Protocol: "tcp"},
-		},
-	}
-
-	container2 := game_room.Container{
-		Name: "container2",
-		Ports: []game_room.ContainerPort{
-			{Protocol: "udp"},
-		},
-	}
-
-	scheduler := entities.Scheduler{
-		Name: "zooba_blue:1.0.0",
-		Spec: game_room.Spec{
-			Version:    "1.0.0",
-			Containers: []game_room.Container{container1, container2},
-		},
-		PortRange: nil,
-	}
-
-	gameRoom := game_room.GameRoom{
-		ID:          "game-1",
-		SchedulerID: "zooba_blue:1.0.0",
-		Version:     "1.0.0",
-		Status:      game_room.GameStatusPending,
-		LastPingAt:  clockMock.Now(),
-	}
-
-	gameRoomInstance := game_room.Instance{
-		ID:          "game-1",
-		SchedulerID: "game",
-	}
 
 	op := operation.Operation{
 		ID:             "some-op-id",
@@ -206,41 +152,17 @@ func TestAddRoomsExecutor_Rollback(t *testing.T) {
 		DefinitionName: "zooba_blue:1.0.0",
 	}
 
-	t.Run("when no error occurs it deletes previously created rooms and return without error", func(t *testing.T) {
+	t.Run("does nothing and return nil", func(t *testing.T) {
 		roomsManager := mockports.NewMockRoomManager(mockCtrl)
 
-		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
+		executor := &AddRoomsExecutor{
+			roomManager: roomsManager,
+			storage:     schedulerStorage,
+			logger:      zap.L().With(zap.String(logs.LogFieldServiceName, "worker")),
+		}
 
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, porterrors.NewErrUnexpected("error"))
-
-		executor := NewExecutor(roomsManager, schedulerStorage)
-		err := executor.Execute(context.Background(), &op, &definition)
-
-		require.NotNil(t, err)
-
-		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil).Times(9)
 		rollbackErr := executor.Rollback(context.Background(), &op, &definition, nil)
 		require.NoError(t, rollbackErr)
-	})
-
-	t.Run("when some error occurs while deleting rooms it returns error", func(t *testing.T) {
-		roomsManager := mockports.NewMockRoomManager(mockCtrl)
-
-		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), op.SchedulerName).Return(&scheduler, nil)
-
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(9)
-		roomsManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), false).Return(nil, nil, porterrors.NewErrUnexpected("error"))
-
-		executor := NewExecutor(roomsManager, schedulerStorage)
-		err := executor.Execute(context.Background(), &op, &definition)
-
-		require.NotNil(t, err)
-
-		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(porterrors.NewErrUnexpected("error")).Times(1)
-
-		rollbackErr := executor.Rollback(context.Background(), &op, &definition, nil)
-		require.Error(t, rollbackErr)
 	})
 
 }

--- a/internal/core/ports/mock/rooms_ports_mock.go
+++ b/internal/core/ports/mock/rooms_ports_mock.go
@@ -53,6 +53,22 @@ func (mr *MockRoomManagerMockRecorder) CleanRoomState(ctx, schedulerName, roomId
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanRoomState", reflect.TypeOf((*MockRoomManager)(nil).CleanRoomState), ctx, schedulerName, roomId)
 }
 
+// CreateRoom mocks base method.
+func (m *MockRoomManager) CreateRoom(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRoom", ctx, scheduler, isValidationRoom)
+	ret0, _ := ret[0].(*game_room.GameRoom)
+	ret1, _ := ret[1].(*game_room.Instance)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateRoom indicates an expected call of CreateRoom.
+func (mr *MockRoomManagerMockRecorder) CreateRoom(ctx, scheduler, isValidationRoom interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoom", reflect.TypeOf((*MockRoomManager)(nil).CreateRoom), ctx, scheduler, isValidationRoom)
+}
+
 // CreateRoomAndWaitForReadiness mocks base method.
 func (m *MockRoomManager) CreateRoomAndWaitForReadiness(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error) {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/room_ports.go
+++ b/internal/core/ports/room_ports.go
@@ -71,6 +71,8 @@ type RoomManager interface {
 	// If the room is created and don't succeed on sending a ping to maestro, it will try to delete the room, and return
 	// an error. The "isValidationRoom" parameter must be passed "true" if we want to create a room that won't be forwarded
 	CreateRoomAndWaitForReadiness(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error)
+	// CreateRoom creates a game room in maestro runtime and storages without waiting the room to reach ready status.
+	CreateRoom(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error)
 	// UpdateGameRoomStatus updates the game based on the ping and runtime status.
 	UpdateGameRoomStatus(ctx context.Context, schedulerId, gameRoomId string) error
 	// WaitRoomStatus blocks the caller until the context is canceled, an error


### PR DESCRIPTION
## What ❓ 
Update add rooms operation to not wait for readiness and remove rollback logic

## Why 🤔 
The add rooms operation uses the CreateRoomAndWaitForReadiness method for creating rooms, this method, as the name suggests, creates the game room and blocks the execution, waiting for the room to reach the ready state (when the room sends the ping). This behavior can make add rooms operations take a lot of time if this waiting period reaches the roomInitializationTimout period. For a scheduler with a health checker or autoscaling enabled, having add rooms operation as a blocking operation can create scenarios in which the maestro will take too long to reach the desired state.

Besides all that, the current rollback logic of adding rooms consists in removing rooms that were created, this behavior also needs to be updated for a health-checker/autoscaling scenario. The rollback logic of add rooms should be empty, in a way that Maestro will keep rooms created successfully if some error occurs in the middle of add rooms process.