### PR TITLE
Fix/expired rooms event forwarding

### DIFF
--- a/internal/core/entities/events/player_event.go
+++ b/internal/core/entities/events/player_event.go
@@ -40,9 +40,9 @@ const (
 
 func ConvertToPlayerEventType(value string) (PlayerEventType, error) {
 	switch value {
-	case "playerLeft":
+	case string(PlayerLeft):
 		return PlayerLeft, nil
-	case "playerJoin":
+	case string(PlayerJoin):
 		return PlayerJoin, nil
 	default:
 		return "", fmt.Errorf("invalid PlayerEventType. Should be \"playerLeft\" or \"playerJoin\"")

--- a/internal/core/entities/events/room_event.go
+++ b/internal/core/entities/events/room_event.go
@@ -53,11 +53,11 @@ const (
 
 func ConvertToRoomEventType(value string) (RoomEventType, error) {
 	switch value {
-	case "resync":
+	case string(Ping):
 		return Ping, nil
-	case "roomEvent":
+	case string(Arbitrary):
 		return Arbitrary, nil
-	case "roomStatus":
+	case string(Status):
 		return Status, nil
 	default:
 		return "", fmt.Errorf("invalid RoomEventType. Should be \"resync\" or \"roomEvent\"")

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -431,8 +431,9 @@ func (m *RoomManager) forwardStatusTerminatingEvent(ctx context.Context, room *g
 	if room.Metadata == nil {
 		room.Metadata = map[string]interface{}{}
 	}
-	room.Metadata["eventType"] = events.FromRoomEventTypeToString(events.Arbitrary)
-	room.Metadata["roomEvent"] = game_room.GameStatusTerminating.String()
+	room.Metadata["eventType"] = events.FromRoomEventTypeToString(events.Status)
+	room.Metadata["pingType"] = game_room.GameRoomPingStatusTerminated.String()
+	room.Metadata["roomEvent"] = game_room.GameRoomPingStatusTerminated.String()
 
 	err := m.EventsService.ProduceEvent(ctx, events.NewRoomEvent(room.SchedulerID, room.ID, room.Metadata))
 	if err != nil {

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -402,8 +402,9 @@ func TestRoomManager_DeleteRoomAndWaitForRoomTerminating(t *testing.T) {
 			SchedulerID: gameRoom.SchedulerID,
 			RoomID:      gameRoom.ID,
 			Attributes: map[string]interface{}{
-				"eventType": "roomEvent",
-				"roomEvent": "terminating",
+				"eventType": "roomStatus",
+				"roomEvent": "terminated",
+				"pingType":  "terminated",
 			},
 		}
 
@@ -446,8 +447,9 @@ func TestRoomManager_DeleteRoomAndWaitForRoomTerminating(t *testing.T) {
 			SchedulerID: gameRoom.SchedulerID,
 			RoomID:      gameRoom.ID,
 			Attributes: map[string]interface{}{
-				"eventType": "roomEvent",
-				"roomEvent": "terminating",
+				"eventType": "roomStatus",
+				"roomEvent": "terminated",
+				"pingType":  "terminated",
 			},
 		}
 


### PR DESCRIPTION
## What ❓ 
Forward **RoomStatus** event instead of **RoomEvent** when deleting rooms.

## Why 🤔 
In maestro v9, the event type that maestro forward when deleting expired rooms is **RoomStatus** with **terminated** state