### PR TITLE
Fix/invalid event type mapping

### DIFF
--- a/internal/adapters/operation/operation_storage_redis.go
+++ b/internal/adapters/operation/operation_storage_redis.go
@@ -270,8 +270,10 @@ func (r *redisOperationStorage) removeNonExistentOperationFromHistory(ctx contex
 			pipe.ZRem(ctx, r.buildSchedulerHistoryOperationsKey(name), operationID)
 		}
 		metrics.RunWithMetrics(operationStorageMetricLabel, func() error {
-			_, err := pipe.Exec(ctx)
-			zap.L().Error("failed to remove non-existent operations from history", zap.Error(err))
+			_, err := pipe.Exec(context.Background())
+			if err != nil {
+				zap.L().Error("failed to remove non-existent operations from history", zap.Error(err))
+			}
 			return err
 		})
 	}()

--- a/internal/api/handlers/rooms_handler_test.go
+++ b/internal/api/handlers/rooms_handler_test.go
@@ -326,7 +326,7 @@ func TestRoomsHandler_UpdateRoomStatus(t *testing.T) {
 					SchedulerID: "scheduler-name",
 					RoomID:      "room-name",
 					Attributes: map[string]interface{}{
-						"eventType": "roomStatus",
+						"eventType": "status",
 						"pingType":  "ready",
 						"roomType":  "red",
 					},
@@ -365,7 +365,7 @@ func TestRoomsHandler_UpdateRoomStatus(t *testing.T) {
 					SchedulerID: "scheduler-name",
 					RoomID:      "room-name",
 					Attributes: map[string]interface{}{
-						"eventType": "roomStatus",
+						"eventType": "status",
 						"pingType":  "ready",
 						"roomType":  "red",
 					},

--- a/internal/core/entities/events/room_event.go
+++ b/internal/core/entities/events/room_event.go
@@ -60,7 +60,7 @@ func ConvertToRoomEventType(value string) (RoomEventType, error) {
 	case string(Status):
 		return Status, nil
 	default:
-		return "", fmt.Errorf(fmt.Sprintf("invalid RoomEventType. Should be %s, %s or %s", Ping, Arbitrary, Status))
+		return "", fmt.Errorf(fmt.Sprintf("invalid RoomEventType, should be %s, %s or %s", Ping, Arbitrary, Status))
 	}
 }
 

--- a/internal/core/entities/events/room_event.go
+++ b/internal/core/entities/events/room_event.go
@@ -60,18 +60,18 @@ func ConvertToRoomEventType(value string) (RoomEventType, error) {
 	case string(Status):
 		return Status, nil
 	default:
-		return "", fmt.Errorf("invalid RoomEventType. Should be \"resync\" or \"roomEvent\"")
+		return "", fmt.Errorf(fmt.Sprintf("invalid RoomEventType. Should be %s, %s or %s", Ping, Arbitrary, Status))
 	}
 }
 
 func FromRoomEventTypeToString(eventType RoomEventType) string {
 	switch eventType {
 	case Ping:
-		return "resync"
+		return string(Ping)
 	case Arbitrary:
-		return "roomEvent"
+		return string(Arbitrary)
 	case Status:
-		return "roomStatus"
+		return string(Status)
 	default:
 		return ""
 	}

--- a/internal/core/entities/events/room_event_test.go
+++ b/internal/core/entities/events/room_event_test.go
@@ -33,11 +33,15 @@ func TestRoomEvent(t *testing.T) {
 
 		converted, err := ConvertToRoomEventType("resync")
 		require.NoError(t, err)
-		require.IsType(t, RoomEventType("resync"), converted)
+		require.IsType(t, Ping, converted)
 
 		converted, err = ConvertToRoomEventType("roomEvent")
 		require.NoError(t, err)
-		require.IsType(t, RoomEventType("roomEvent"), converted)
+		require.IsType(t, Arbitrary, converted)
+
+		converted, err = ConvertToRoomEventType("status")
+		require.NoError(t, err)
+		require.IsType(t, Status, converted)
 	})
 
 	t.Run("with success when converting to RoomStatusType", func(t *testing.T) {
@@ -61,7 +65,7 @@ func TestRoomEvent(t *testing.T) {
 	t.Run("with error when converting to RoomEventType", func(t *testing.T) {
 
 		_, err := ConvertToRoomEventType("INVALID")
-		require.Error(t, err)
+		require.EqualError(t, err, "invalid RoomEventType, should be resync, roomEvent or status")
 	})
 
 	t.Run("with error when converting to RoomStatusType", func(t *testing.T) {

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -402,7 +402,7 @@ func TestRoomManager_DeleteRoomAndWaitForRoomTerminating(t *testing.T) {
 			SchedulerID: gameRoom.SchedulerID,
 			RoomID:      gameRoom.ID,
 			Attributes: map[string]interface{}{
-				"eventType": "roomStatus",
+				"eventType": "status",
 				"roomEvent": "terminated",
 				"pingType":  "terminated",
 			},
@@ -447,7 +447,7 @@ func TestRoomManager_DeleteRoomAndWaitForRoomTerminating(t *testing.T) {
 			SchedulerID: gameRoom.SchedulerID,
 			RoomID:      gameRoom.ID,
 			Attributes: map[string]interface{}{
-				"eventType": "roomStatus",
+				"eventType": "status",
 				"roomEvent": "terminated",
 				"pingType":  "terminated",
 			},


### PR DESCRIPTION
## What ❓ 
Fix event type conversion, we were not covering the `status` type in our unitary tests. Fix the wrong error log being generated every time in operations storage.
 