### PR TITLE
switch active version does not wait to create room

### DIFF
--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -222,7 +222,7 @@ func (ex *SwitchActiveVersionExecutor) replaceRoom(logger *zap.Logger, roomsChan
 			return err
 		}
 
-		logger.Sugar().Debugf("replaced room \"%s\" with \"%s\"", room.ID, gameRoom.ID)
+		logger.Sugar().Debugf("replaced room \"%s\"", room.ID)
 		ex.roomsBeingReplaced.Delete(room.ID)
 		ex.appendToNewCreatedRooms(scheduler.Name, gameRoom)
 	}

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -222,6 +222,10 @@ func (ex *SwitchActiveVersionExecutor) replaceRoom(logger *zap.Logger, roomsChan
 			return err
 		}
 
+		if gameRoom == nil {
+			return nil
+		}
+
 		logger.Sugar().Debugf("replaced room \"%s\"", room.ID)
 		ex.roomsBeingReplaced.Delete(room.ID)
 		ex.appendToNewCreatedRooms(scheduler.Name, gameRoom)

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -222,12 +222,12 @@ func (ex *SwitchActiveVersionExecutor) replaceRoom(logger *zap.Logger, roomsChan
 			return err
 		}
 
+		ex.roomsBeingReplaced.Delete(room.ID)
 		if gameRoom == nil {
 			return nil
 		}
 
 		logger.Sugar().Debugf("replaced room \"%s\" with \"%s\"", room.ID, gameRoom.ID)
-		ex.roomsBeingReplaced.Delete(room.ID)
 		ex.appendToNewCreatedRooms(scheduler.Name, gameRoom)
 	}
 }

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -210,11 +210,9 @@ func (ex *SwitchActiveVersionExecutor) replaceRoom(logger *zap.Logger, roomsChan
 			return nil
 		}
 
-		gameRoom, _, err := roomManager.CreateRoomAndWaitForReadiness(ctx, scheduler, false)
+		gameRoom, _, err := roomManager.CreateRoom(ctx, scheduler, false)
 		if err != nil {
 			logger.Error("error creating room", zap.Error(err))
-			ex.roomsBeingReplaced.Delete(room.ID)
-			return err
 		}
 
 		err = roomManager.DeleteRoomAndWaitForRoomTerminating(ctx, room)

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -226,7 +226,7 @@ func (ex *SwitchActiveVersionExecutor) replaceRoom(logger *zap.Logger, roomsChan
 			return nil
 		}
 
-		logger.Sugar().Debugf("replaced room \"%s\"", room.ID)
+		logger.Sugar().Debugf("replaced room \"%s\" with \"%s\"", room.ID, gameRoom.ID)
 		ex.roomsBeingReplaced.Delete(room.ID)
 		ex.appendToNewCreatedRooms(scheduler.Name, gameRoom)
 	}

--- a/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
@@ -428,7 +428,7 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 
 		allRooms := append(gameRoomListCycle1, gameRoomListCycle2...)
 		for i := range allRooms {
-			if i == len(allRooms) - 1 {
+			if i == len(allRooms)-1 {
 				mocks.roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("error"))
 				mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 				continue
@@ -444,7 +444,6 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)
 		}
 
-
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
 		op := &operation.Operation{
 			ID:             "op",
@@ -457,7 +456,7 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 
 		for i := range allRooms {
-			if i == len(allRooms) - 1 {
+			if i == len(allRooms)-1 {
 				continue
 			}
 			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)


### PR DESCRIPTION
### What?
Switch method used by switch active version operation from `CreateRoomAndWaitForReadiness` to `CreateRoom`
### Why?
Since we have a health controller in maestro now, switch active version does not need to wait for every room to be ready. This can lead to a bad experience when replacing hundreds of rooms.
