### PR TITLE
Add new autoscaling struct

### DIFF
--- a/internal/adapters/scheduler/db_scheduler.go
+++ b/internal/adapters/scheduler/db_scheduler.go
@@ -23,6 +23,7 @@
 package scheduler
 
 import (
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 	"time"
 
 	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
@@ -59,6 +60,7 @@ type schedulerInfo struct {
 	MaxSurge               string
 	RoomsReplicas          int
 	Forwarders             []*forwarder.Forwarder
+	Autoscaling            *autoscaling.Autoscaling
 }
 
 func NewDBScheduler(scheduler *entities.Scheduler) *Scheduler {
@@ -71,6 +73,7 @@ func NewDBScheduler(scheduler *entities.Scheduler) *Scheduler {
 		MaxSurge:               scheduler.MaxSurge,
 		RoomsReplicas:          scheduler.RoomsReplicas,
 		Forwarders:             scheduler.Forwarders,
+		Autoscaling:            scheduler.Autoscaling,
 	}
 	yamlBytes, _ := yaml.Marshal(info)
 	return &Scheduler{
@@ -106,5 +109,6 @@ func (s *Scheduler) ToScheduler() (*entities.Scheduler, error) {
 		MaxSurge:        info.MaxSurge,
 		RoomsReplicas:   info.RoomsReplicas,
 		Forwarders:      info.Forwarders,
+		Autoscaling:     info.Autoscaling,
 	}, nil
 }

--- a/internal/adapters/scheduler/db_scheduler.go
+++ b/internal/adapters/scheduler/db_scheduler.go
@@ -23,8 +23,9 @@
 package scheduler
 
 import (
-	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 	"time"
+
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 
 	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
 

--- a/internal/adapters/scheduler/db_scheduler_test.go
+++ b/internal/adapters/scheduler/db_scheduler_test.go
@@ -26,9 +26,10 @@
 package scheduler
 
 import (
-	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 	"testing"
 	"time"
+
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 
 	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
 

--- a/internal/adapters/scheduler/db_scheduler_test.go
+++ b/internal/adapters/scheduler/db_scheduler_test.go
@@ -26,6 +26,7 @@
 package scheduler
 
 import (
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 	"testing"
 	"time"
 
@@ -187,6 +188,19 @@ func TestScheduler_ToScheduler(t *testing.T) {
 					Affinity:               "affinity",
 				},
 				Forwarders: forwarders,
+				Autoscaling: &autoscaling.Autoscaling{
+					Enabled: true,
+					Min:     1,
+					Max:     3,
+					Policy: autoscaling.Policy{
+						Type: autoscaling.RoomOccupancy,
+						Parameters: autoscaling.PolicyParameters{
+							RoomOccupancy: &autoscaling.RoomOccupancyParams{
+								ReadyTarget: 0.1,
+							},
+						},
+					},
+				},
 			},
 		}
 

--- a/internal/core/entities/autoscaling/autoscaling.go
+++ b/internal/core/entities/autoscaling/autoscaling.go
@@ -1,23 +1,39 @@
 package autoscaling
 
+import "github.com/topfreegames/maestro/internal/validations"
+
 // Autoscaling represents the autoscaling configuration for a scheduler.
 type Autoscaling struct {
 	// Enabled indicates if autoscaling is enabled.
 	Enabled bool
 	// Min indicates the minimum number of replicas,
-	// it must be greater than 0 and lower than max.
-	Min int
+	// it must be greater than 1 and lower than max.
+	Min int `validate:"min=1,custom_lower_than=Max"`
 	// Max indicates the maximum number of replicas,
 	// it must be greater than or equal zero, or -1 to have no limit.
-	Max int
+	Max int `validate:"min=-1"`
 	// Policy indicates the autoscaling policy configuration.
 	Policy Policy
+}
+
+func (a *Autoscaling) Validate() error {
+	return validations.Validate.Struct(a)
+}
+
+func NewAutoscaling(enabled bool, min, max int, policy Policy) (*Autoscaling, error) {
+	autoscaling := &Autoscaling{
+		Enabled: enabled,
+		Min:     min,
+		Max:     max,
+		Policy:  policy,
+	}
+	return autoscaling, autoscaling.Validate()
 }
 
 // Policy represents the autoscaling policy configuration.
 type Policy struct {
 	// Type indicates the autoscaling policy type.
-	Type PolicyType
+	Type PolicyType `validate:"oneof=roomOccupancy"`
 	// Parameters indicates the autoscaling policy parameters.
 	Parameters PolicyParameters
 }
@@ -27,12 +43,12 @@ type Policy struct {
 type PolicyParameters struct {
 	// RoomOccupancy represents the parameters for RoomOccupancy policy type, it must be provided if Policy Type is RoomOccupancy.
 	// +optional
-	RoomOccupancy *RoomOccupancyParams
+	RoomOccupancy *RoomOccupancyParams `validate:"required_for_room_occupancy=Type"`
 }
 
 type RoomOccupancyParams struct {
 	// ReadyTarget indicates the target percentage of ready rooms a scheduler should maintain.
-	ReadyTarget string
+	ReadyTarget float64 `validate:"gt=0,lt=1"`
 }
 
 // PolicyType represents an enum of possible policy types/strategies a scheduler can have.

--- a/internal/core/entities/autoscaling/autoscaling.go
+++ b/internal/core/entities/autoscaling/autoscaling.go
@@ -1,0 +1,43 @@
+package autoscaling
+
+// Autoscaling represents the autoscaling configuration for a scheduler.
+type Autoscaling struct {
+	// Enabled indicates if autoscaling is enabled.
+	Enabled bool
+	// Min indicates the minimum number of replicas,
+	// it must be greater than 0 and lower than max.
+	Min int
+	// Max indicates the maximum number of replicas,
+	// it must be greater than or equal zero, or -1 to have no limit.
+	Max int
+	// Policy indicates the autoscaling policy configuration.
+	Policy Policy
+}
+
+// Policy represents the autoscaling policy configuration.
+type Policy struct {
+	// Type indicates the autoscaling policy type.
+	Type PolicyType
+	// Parameters indicates the autoscaling policy parameters.
+	Parameters PolicyParameters
+}
+
+// PolicyParameters represents the autoscaling policy parameters, its fields validations will
+// vary according to the policy type.
+type PolicyParameters struct {
+	// RoomOccupancy represents the parameters for RoomOccupancy policy type, it must be provided if Policy Type is RoomOccupancy.
+	// +optional
+	RoomOccupancy *RoomOccupancyParams
+}
+
+type RoomOccupancyParams struct {
+	// ReadyTarget indicates the target percentage of ready rooms a scheduler should maintain.
+	ReadyTarget string
+}
+
+// PolicyType represents an enum of possible policy types/strategies a scheduler can have.
+type PolicyType string
+
+const (
+	RoomOccupancy PolicyType = "roomOccupancy"
+)

--- a/internal/core/entities/autoscaling/autoscaling.go
+++ b/internal/core/entities/autoscaling/autoscaling.go
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package autoscaling
 
 import "github.com/topfreegames/maestro/internal/validations"

--- a/internal/core/entities/autoscaling/autoscaling_test.go
+++ b/internal/core/entities/autoscaling/autoscaling_test.go
@@ -1,0 +1,88 @@
+package autoscaling
+
+import (
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/topfreegames/maestro/internal/validations"
+)
+
+func TestNewAutoscaling(t *testing.T) {
+	err := validations.RegisterValidations()
+	if err != nil {
+		t.Errorf("unexpected error %d'", err)
+	}
+	translator := validations.GetDefaultTranslator()
+
+	validRoomOccupancyPolicy := Policy{
+		Type: RoomOccupancy,
+		Parameters: PolicyParameters{
+			RoomOccupancy: &RoomOccupancyParams{ReadyTarget: 0.2},
+		},
+	}
+
+	t.Run("invalid scenarios", func(t *testing.T) {
+		t.Run("fails when try to create autoscaling with invalid Min", func(t *testing.T) {
+			_, err := NewAutoscaling(true, -1, 10, validRoomOccupancyPolicy)
+			assert.Error(t, err)
+			validationErrs := err.(validator.ValidationErrors)
+			assert.Equal(t, "Min must be 1 or greater", validationErrs[0].Translate(translator))
+
+			_, err = NewAutoscaling(true, 0, 10, validRoomOccupancyPolicy)
+			assert.Error(t, err)
+			validationErrs = err.(validator.ValidationErrors)
+			assert.Equal(t, "Min must be 1 or greater", validationErrs[0].Translate(translator))
+
+			_, err = NewAutoscaling(true, 11, 10, validRoomOccupancyPolicy)
+			assert.Error(t, err)
+			validationErrs = err.(validator.ValidationErrors)
+			assert.Equal(t, "Min must be a number lower than Max", validationErrs[0].Translate(translator))
+
+		})
+		t.Run("fails when try to create autoscaling with invalid Max", func(t *testing.T) {
+			_, err := NewAutoscaling(true, 1, -2, validRoomOccupancyPolicy)
+			validationErrs := err.(validator.ValidationErrors)
+			assert.Equal(t, "Min must be a number lower than Max", validationErrs[0].Translate(translator))
+			assert.Equal(t, "Max must be -1 or greater", validationErrs[1].Translate(translator))
+
+		})
+
+		t.Run("fails when try to create autoscaling with invalid roomOccupancy Policy", func(t *testing.T) {
+			_, err := NewAutoscaling(true, 1, 10, Policy{})
+			validationErrs := err.(validator.ValidationErrors)
+			assert.Equal(t, "Type must be one of [roomOccupancy]", validationErrs[0].Translate(translator))
+
+			_, err = NewAutoscaling(true, 1, 10, Policy{Type: "invalid", Parameters: PolicyParameters{}})
+			validationErrs = err.(validator.ValidationErrors)
+			assert.Equal(t, "Type must be one of [roomOccupancy]", validationErrs[0].Translate(translator))
+
+			_, err = NewAutoscaling(true, 1, 10, Policy{Type: "roomOccupancy", Parameters: PolicyParameters{}})
+			validationErrs = err.(validator.ValidationErrors)
+			assert.Equal(t, "RoomOccupancy must not be nil for RoomOccupancy policy type", validationErrs[0].Translate(translator))
+
+			_, err = NewAutoscaling(true, 1, 10, Policy{Type: "roomOccupancy", Parameters: PolicyParameters{RoomOccupancy: &RoomOccupancyParams{ReadyTarget: 0.0}}})
+			validationErrs = err.(validator.ValidationErrors)
+			assert.Equal(t, "ReadyTarget must be greater than 0", validationErrs[0].Translate(translator))
+
+			_, err = NewAutoscaling(true, 1, 10, Policy{Type: "roomOccupancy", Parameters: PolicyParameters{RoomOccupancy: &RoomOccupancyParams{ReadyTarget: 1.0}}})
+			validationErrs = err.(validator.ValidationErrors)
+			assert.Equal(t, "ReadyTarget must be less than 1", validationErrs[0].Translate(translator))
+		})
+	})
+
+	t.Run("valid scenarios", func(t *testing.T) {
+		t.Run("success when try to create valid autoscaling with roomOccupancy type", func(t *testing.T) {
+			_, err := NewAutoscaling(true, 10, -1, validRoomOccupancyPolicy)
+			assert.NoError(t, err)
+
+			_, err = NewAutoscaling(false, 1, 1, validRoomOccupancyPolicy)
+			assert.NoError(t, err)
+
+			_, err = NewAutoscaling(false, 50, 100, validRoomOccupancyPolicy)
+			assert.NoError(t, err)
+		})
+	})
+
+}

--- a/internal/core/entities/autoscaling/autoscaling_test.go
+++ b/internal/core/entities/autoscaling/autoscaling_test.go
@@ -1,3 +1,28 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build unit
+// +build unit
+
 package autoscaling
 
 import (

--- a/internal/core/entities/autoscaling/autoscaling_test.go
+++ b/internal/core/entities/autoscaling/autoscaling_test.go
@@ -77,11 +77,11 @@ func TestNewAutoscaling(t *testing.T) {
 		t.Run("fails when try to create autoscaling with invalid roomOccupancy Policy", func(t *testing.T) {
 			_, err := NewAutoscaling(true, 1, 10, Policy{})
 			validationErrs := err.(validator.ValidationErrors)
-			assert.Equal(t, "Type must be one of [roomOccupancy]", validationErrs[0].Translate(translator))
+			assert.Contains(t, validationErrs[0].Translate(translator), "Type must be one of")
 
 			_, err = NewAutoscaling(true, 1, 10, Policy{Type: "invalid", Parameters: PolicyParameters{}})
 			validationErrs = err.(validator.ValidationErrors)
-			assert.Equal(t, "Type must be one of [roomOccupancy]", validationErrs[0].Translate(translator))
+			assert.Contains(t, validationErrs[0].Translate(translator), "Type must be one of")
 
 			_, err = NewAutoscaling(true, 1, 10, Policy{Type: "roomOccupancy", Parameters: PolicyParameters{}})
 			validationErrs = err.(validator.ValidationErrors)

--- a/internal/core/entities/scheduler.go
+++ b/internal/core/entities/scheduler.go
@@ -130,6 +130,7 @@ func (s *Scheduler) IsMajorVersion(newScheduler *Scheduler) bool {
 			"CreatedAt",
 			"MaxSurge",
 			"RoomsReplicas",
+			"Autoscaling",
 		),
 	)
 }

--- a/internal/core/entities/scheduler.go
+++ b/internal/core/entities/scheduler.go
@@ -25,6 +25,8 @@ package entities
 import (
 	"time"
 
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
@@ -55,6 +57,7 @@ type Scheduler struct {
 	State           string `validate:"required"`
 	RollbackVersion string
 	Spec            game_room.Spec
+	Autoscaling     *autoscaling.Autoscaling
 	PortRange       *PortRange
 	RoomsReplicas   int `validate:"min=0"`
 	CreatedAt       time.Time

--- a/internal/core/entities/scheduler_test.go
+++ b/internal/core/entities/scheduler_test.go
@@ -26,6 +26,7 @@
 package entities_test
 
 import (
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 	"testing"
 	"time"
 
@@ -281,6 +282,11 @@ func TestIsMajorVersion(t *testing.T) {
 		"roomsReplicas shouldn't be a major": {
 			currentScheduler: &entities.Scheduler{RoomsReplicas: 0},
 			newScheduler:     &entities.Scheduler{RoomsReplicas: 2},
+			expected:         false,
+		},
+		"Autoscaling shouldn't be a major": {
+			currentScheduler: &entities.Scheduler{Autoscaling: &autoscaling.Autoscaling{Enabled: false}},
+			newScheduler:     &entities.Scheduler{Autoscaling: &autoscaling.Autoscaling{Enabled: true}},
 			expected:         false,
 		},
 	}

--- a/internal/core/entities/scheduler_test.go
+++ b/internal/core/entities/scheduler_test.go
@@ -26,9 +26,10 @@
 package entities_test
 
 import (
-	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 	"testing"
 	"time"
+
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 
 	"github.com/stretchr/testify/require"
 	"github.com/topfreegames/maestro/internal/validations"

--- a/internal/core/validations/validations.go
+++ b/internal/core/validations/validations.go
@@ -32,6 +32,26 @@ import (
 	"github.com/Masterminds/semver"
 )
 
+func RequiredIfTypeRoomOccupancy(isParameterNil bool, policyType string) bool {
+	if policyType == "roomOccupancy" {
+		return isParameterNil
+	}
+	return true
+}
+
+func IsAutoscalingMinMaxValid(min int, max int) bool {
+	if max >= 0 && min > max {
+		return false
+	}
+	if min < 0 {
+		return false
+	}
+	if max < -1 {
+		return false
+	}
+	return true
+}
+
 //IsMaxSurgeValid check if MaxSurge is valid. A MaxSurge valid is a number greater than zero or a number greater than zero with suffix '%'
 func IsMaxSurgeValid(maxSurge string) bool {
 	if maxSurge == "" {

--- a/internal/core/validations/validations.go
+++ b/internal/core/validations/validations.go
@@ -34,7 +34,7 @@ import (
 
 func RequiredIfTypeRoomOccupancy(isParameterNil bool, policyType string) bool {
 	if policyType == "roomOccupancy" {
-		return isParameterNil
+		return !isParameterNil
 	}
 	return true
 }
@@ -43,7 +43,7 @@ func IsAutoscalingMinMaxValid(min int, max int) bool {
 	if max >= 0 && min > max {
 		return false
 	}
-	if min < 0 {
+	if min <= 0 {
 		return false
 	}
 	if max < -1 {

--- a/internal/core/validations/validations_test.go
+++ b/internal/core/validations/validations_test.go
@@ -141,3 +141,51 @@ func TestIsForwarderTypeSupported(t *testing.T) {
 		assert.False(t, supported)
 	})
 }
+
+func TestIsAutoscalingMinMaxValid(t *testing.T) {
+
+	t.Run("return false when min is bigger than max and max is not -1", func(t *testing.T) {
+		valid := IsAutoscalingMinMaxValid(10, 5)
+		assert.False(t, valid)
+	})
+	t.Run("return false when min is less than zero", func(t *testing.T) {
+		valid := IsAutoscalingMinMaxValid(0, 100)
+		assert.False(t, valid)
+
+		valid = IsAutoscalingMinMaxValid(-1, 100)
+		assert.False(t, valid)
+	})
+
+	t.Run("return false when max is less than -1", func(t *testing.T) {
+		valid := IsAutoscalingMinMaxValid(2, -2)
+		assert.False(t, valid)
+	})
+	t.Run("return true when min is less than max", func(t *testing.T) {
+		valid := IsAutoscalingMinMaxValid(1, 2)
+		assert.True(t, valid)
+	})
+	t.Run("return true when min is bigger than max and max is -1", func(t *testing.T) {
+		valid := IsAutoscalingMinMaxValid(10, -1)
+		assert.True(t, valid)
+	})
+}
+
+func TestRequiredIfTypeRoomOccupancy(t *testing.T) {
+
+	t.Run("return true when policy type is room occupancy and the parameter is not nil", func(t *testing.T) {
+		valid := RequiredIfTypeRoomOccupancy(false, "roomOccupancy")
+		assert.True(t, valid)
+	})
+	t.Run("return true when policy type is not roomOccupancy and parameter is nil", func(t *testing.T) {
+		valid := RequiredIfTypeRoomOccupancy(false, "otherPolicy")
+		assert.True(t, valid)
+	})
+	t.Run("return true when policy type is not roomOccupancy and parameter is not nil", func(t *testing.T) {
+		valid := RequiredIfTypeRoomOccupancy(false, "otherPolicy")
+		assert.True(t, valid)
+	})
+	t.Run("return false when policy type is room occupancy and the parameter is nil", func(t *testing.T) {
+		valid := RequiredIfTypeRoomOccupancy(true, "roomOccupancy")
+		assert.False(t, valid)
+	})
+}

--- a/internal/core/validations/validations_test.go
+++ b/internal/core/validations/validations_test.go
@@ -20,6 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//go:build unit
+// +build unit
+
 package validations
 
 import (

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -75,12 +75,6 @@ func RegisterValidations() error {
 	}
 	addTranslation(Validate, "required_for_room_occupancy", "{0} must not be nil for RoomOccupancy policy type")
 
-	err = Validate.RegisterValidation("required_for_room_occupancy", roomOccupancyParameterValidate)
-	if err != nil {
-		return errors.New("could not register roomOccupancyParameterValidate")
-	}
-	addTranslation(Validate, "required_for_room_occupancy", "{0} must not be nil for RoomOccupancy policy type")
-
 	err = Validate.RegisterValidation("max_surge", maxSurgeValidate)
 	if err != nil {
 		return errors.New("could not register maxSurgeValidate")

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -63,6 +63,24 @@ func RegisterValidations() error {
 	}
 	addTranslation(Validate, "ports_protocol", "{0} must be one of the following options: tcp, udp, sctp")
 
+	err = Validate.RegisterValidation("custom_lower_than", autoscalingMinMaxValidate)
+	if err != nil {
+		return errors.New("could not register autoscalingMinMaxValidate")
+	}
+	addTranslation(Validate, "custom_lower_than", "{0} must be a number lower than {1}")
+
+	err = Validate.RegisterValidation("required_for_room_occupancy", roomOccupancyParameterValidate)
+	if err != nil {
+		return errors.New("could not register roomOccupancyParameterValidate")
+	}
+	addTranslation(Validate, "required_for_room_occupancy", "{0} must not be nil for RoomOccupancy policy type")
+
+	err = Validate.RegisterValidation("required_for_room_occupancy", roomOccupancyParameterValidate)
+	if err != nil {
+		return errors.New("could not register roomOccupancyParameterValidate")
+	}
+	addTranslation(Validate, "required_for_room_occupancy", "{0} must not be nil for RoomOccupancy policy type")
+
 	err = Validate.RegisterValidation("max_surge", maxSurgeValidate)
 	if err != nil {
 		return errors.New("could not register maxSurgeValidate")
@@ -98,6 +116,30 @@ func imagePullPolicyValidate(fl validator.FieldLevel) bool {
 
 func portsProtocolValidate(fl validator.FieldLevel) bool {
 	return validations.IsProtocolSupported(fl.Field().String())
+}
+
+func autoscalingMinMaxValidate(fl validator.FieldLevel) bool {
+	field := fl.Field()
+	kind := field.Kind()
+
+	topField, topKind, _, ok := fl.GetStructFieldOK2()
+	if !ok || topKind != kind {
+		return false
+	}
+
+	return validations.IsAutoscalingMinMaxValid(int(field.Int()), int(topField.Int()))
+}
+
+func roomOccupancyParameterValidate(fl validator.FieldLevel) bool {
+	field := fl.Field()
+	kind := field.Kind()
+
+	topField, topKind, _, ok := fl.GetStructFieldOK2()
+	if !ok || topKind != kind {
+		return false
+	}
+
+	return validations.RequiredIfTypeRoomOccupancy(field.IsNil(), topField.String())
 }
 
 func maxSurgeValidate(fl validator.FieldLevel) bool {


### PR DESCRIPTION
### What ❓
Create new structs types to represent autoscaling, add validation for new types and fields, update entity-db mapper to include autoscaling info.

### Why 🤔
With the new autoscaling feature we need to represent its configuration including it in the scheduler struct.