### PR TITLE
Chore/create autoscaler service

### DIFF
--- a/internal/core/entities/autoscaling/autoscaling.go
+++ b/internal/core/entities/autoscaling/autoscaling.go
@@ -29,7 +29,7 @@ type PolicyType string
 
 const (
 	// RoomOccupancy is an implemented policy in maestro autoscaler,
-	// it uses the number of occupied rooms to calculate the desired number of rooms in a scheduler.
+	// it uses the number of occupied rooms and a ready rooms target percentage to calculate the desired number of rooms in a scheduler.
 	RoomOccupancy PolicyType = "roomOccupancy"
 )
 

--- a/internal/core/entities/autoscaling/autoscaling.go
+++ b/internal/core/entities/autoscaling/autoscaling.go
@@ -47,7 +47,7 @@ type Autoscaling struct {
 	Policy Policy
 }
 
-// Validate check if an Autoscaling struct is well formated.
+// Validate check if an Autoscaling struct is well formatted and contains valid values.
 func (a *Autoscaling) Validate() error {
 	return validations.Validate.Struct(a)
 }

--- a/internal/core/entities/autoscaling/autoscaling.go
+++ b/internal/core/entities/autoscaling/autoscaling.go
@@ -24,6 +24,15 @@ package autoscaling
 
 import "github.com/topfreegames/maestro/internal/validations"
 
+// PolicyType represents an enum of possible policy types/strategies a scheduler can have.
+type PolicyType string
+
+const (
+	// RoomOccupancy is an implemented policy in maestro autoscaler,
+	// it uses the number of occupied rooms to calculate the desired number of rooms in a scheduler.
+	RoomOccupancy PolicyType = "roomOccupancy"
+)
+
 // Autoscaling represents the autoscaling configuration for a scheduler.
 type Autoscaling struct {
 	// Enabled indicates if autoscaling is enabled.
@@ -38,10 +47,12 @@ type Autoscaling struct {
 	Policy Policy
 }
 
+// Validate check if an Autoscaling struct is well formated.
 func (a *Autoscaling) Validate() error {
 	return validations.Validate.Struct(a)
 }
 
+// NewAutoscaling instantiates a new autoscaling struct based on its parameters.
 func NewAutoscaling(enabled bool, min, max int, policy Policy) (*Autoscaling, error) {
 	autoscaling := &Autoscaling{
 		Enabled: enabled,
@@ -68,14 +79,8 @@ type PolicyParameters struct {
 	RoomOccupancy *RoomOccupancyParams `validate:"required_for_room_occupancy=Type"`
 }
 
+// RoomOccupancyParams represents the parameters accepted by rooms occupancy autoscaling properties.
 type RoomOccupancyParams struct {
 	// ReadyTarget indicates the target percentage of ready rooms a scheduler should maintain.
 	ReadyTarget float64 `validate:"gt=0,lt=1"`
 }
-
-// PolicyType represents an enum of possible policy types/strategies a scheduler can have.
-type PolicyType string
-
-const (
-	RoomOccupancy PolicyType = "roomOccupancy"
-)

--- a/internal/core/services/autoscaler/autoscaler.go
+++ b/internal/core/services/autoscaler/autoscaler.go
@@ -52,23 +52,23 @@ func NewAutoscaler(policyMap PolicyMap) *Autoscaler {
 // CalculateDesiredNumberOfRooms return the number of rooms that a Scheduler should have based on its policy or error if it can calculate.
 func (a *Autoscaler) CalculateDesiredNumberOfRooms(ctx context.Context, scheduler *entities.Scheduler) (int, error) {
 	if scheduler.Autoscaling == nil {
-		return -1, errors.New("Scheduler does not have autoscaling struct")
+		return -1, errors.New("scheduler does not have autoscaling struct")
 	}
 
 	if _, ok := a.policyMap[scheduler.Autoscaling.Policy.Type]; !ok {
-		return -1, fmt.Errorf("Error finding policy to scheduler %s", scheduler.Name)
+		return -1, fmt.Errorf("error finding policy to scheduler %s", scheduler.Name)
 	}
 
 	policy := a.policyMap[scheduler.Autoscaling.Policy.Type]
 
 	currentState, err := policy.CurrentStateBuilder(ctx, scheduler)
 	if err != nil {
-		return -1, fmt.Errorf("Error fetching current state to scheduler %s: %w", scheduler.Name, err)
+		return -1, fmt.Errorf("error fetching current state to scheduler %s: %w", scheduler.Name, err)
 	}
 
 	desiredNumberOfRooms, err := policy.CalculateDesiredNumberOfRooms(scheduler.Autoscaling.Policy.Parameters, currentState)
 	if err != nil {
-		return -1, fmt.Errorf("Error calculating the desired number of rooms to scheduler %s: %w", scheduler.Name, err)
+		return -1, fmt.Errorf("error calculating the desired number of rooms to scheduler %s: %w", scheduler.Name, err)
 	}
 
 	desiredNumberOfRooms = ensureDesiredNumberIsBetweenMinAndMax(scheduler.Autoscaling, desiredNumberOfRooms)

--- a/internal/core/services/autoscaler/autoscaler.go
+++ b/internal/core/services/autoscaler/autoscaler.go
@@ -32,18 +32,18 @@ import (
 	autoscalerPorts "github.com/topfreegames/maestro/internal/core/ports/autoscaler"
 )
 
-// PolicyFactory is a type that corelates a policy type with an autoscaling policy.
-type PolicyFactory map[autoscaling.PolicyType]autoscalerPorts.Policy
+// PolicyMap is a type that corelates a policy type with an autoscaling policy.
+type PolicyMap map[autoscaling.PolicyType]autoscalerPorts.Policy
 
 // Autoscaler is a service that holds dependencies to execute autoscaling feature.
 type Autoscaler struct {
-	policyFactory PolicyFactory
+	policyMap PolicyMap
 }
 
 // NewAutoscaler returns a new instance of autoscaler.
-func NewAutoscaler(policyFactory PolicyFactory) *Autoscaler {
+func NewAutoscaler(policyMap PolicyMap) *Autoscaler {
 	autoscaler := &Autoscaler{
-		policyFactory: policyFactory,
+		policyMap: policyMap,
 	}
 
 	return autoscaler
@@ -55,11 +55,11 @@ func (a *Autoscaler) CalculateDesiredNumberOfRooms(ctx context.Context, schedule
 		return -1, errors.New("Scheduler does not have autoscaling struct")
 	}
 
-	if _, ok := a.policyFactory[scheduler.Autoscaling.Policy.Type]; !ok {
+	if _, ok := a.policyMap[scheduler.Autoscaling.Policy.Type]; !ok {
 		return -1, fmt.Errorf("Error finding policy to scheduler %s", scheduler.Name)
 	}
 
-	policy := a.policyFactory[scheduler.Autoscaling.Policy.Type]
+	policy := a.policyMap[scheduler.Autoscaling.Policy.Type]
 
 	currentState, err := policy.CurrentStateBuilder(ctx, scheduler)
 	if err != nil {

--- a/internal/core/services/autoscaler/autoscaler.go
+++ b/internal/core/services/autoscaler/autoscaler.go
@@ -1,0 +1,87 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package autoscaler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/topfreegames/maestro/internal/core/entities"
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
+	autoscalerPorts "github.com/topfreegames/maestro/internal/core/ports/autoscaler"
+)
+
+// PolicyFactory is a type that corelates a policy type with an autoscaling policy.
+type PolicyFactory map[autoscaling.PolicyType]autoscalerPorts.Policy
+
+// Autoscaler is a service that holds dependencies to execute autoscaling feature.
+type Autoscaler struct {
+	policyFactory PolicyFactory
+}
+
+// NewAutoscaler returns a new instance of autoscaler.
+func NewAutoscaler(policyFactory PolicyFactory) *Autoscaler {
+	autoscaler := &Autoscaler{
+		policyFactory: policyFactory,
+	}
+
+	return autoscaler
+}
+
+// CalculateDesiredNumberOfRooms return the number of rooms that a Scheduler should have based on its policy or error if it can calculate.
+func (a *Autoscaler) CalculateDesiredNumberOfRooms(ctx context.Context, scheduler *entities.Scheduler) (int, error) {
+	if scheduler.Autoscaling == nil {
+		return -1, errors.New("Scheduler does not have autoscaling struct")
+	}
+
+	if _, ok := a.policyFactory[scheduler.Autoscaling.Policy.Type]; !ok {
+		return -1, fmt.Errorf("Error finding policy to scheduler %s", scheduler.Name)
+	}
+
+	policy := a.policyFactory[scheduler.Autoscaling.Policy.Type]
+
+	currentState, err := policy.CurrentStateBuilder(ctx, scheduler)
+	if err != nil {
+		return -1, fmt.Errorf("Error fetching current state to scheduler %s: %w", scheduler.Name, err)
+	}
+
+	desiredNumberOfRooms, err := policy.CalculateDesiredNumberOfRooms(scheduler.Autoscaling.Policy.Parameters, currentState)
+	if err != nil {
+		return -1, fmt.Errorf("Error calculating the desired number of rooms to scheduler %s: %w", scheduler.Name, err)
+	}
+
+	desiredNumberOfRooms = ensureDesiredNumberIsBetweenMinAndMax(scheduler.Autoscaling, desiredNumberOfRooms)
+
+	return desiredNumberOfRooms, nil
+}
+
+func ensureDesiredNumberIsBetweenMinAndMax(autoscaling *autoscaling.Autoscaling, desiredNumberOfRooms int) int {
+	if desiredNumberOfRooms < autoscaling.Min {
+		desiredNumberOfRooms = autoscaling.Min
+	} else if desiredNumberOfRooms > autoscaling.Max {
+		desiredNumberOfRooms = autoscaling.Max
+	}
+
+	return desiredNumberOfRooms
+}

--- a/internal/core/services/autoscaler/autoscaler_test.go
+++ b/internal/core/services/autoscaler/autoscaler_test.go
@@ -70,7 +70,7 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			mockPolicy.EXPECT().CurrentStateBuilder(gomock.Any(), scheduler).Return(currentState, nil)
 			mockPolicy.EXPECT().CalculateDesiredNumberOfRooms(scheduler.Autoscaling.Policy.Parameters, currentState).Return(expectedDesiredNumberOfRooms, nil)
 
-			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyFactory{policyType: mockPolicy})
+			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyMap{policyType: mockPolicy})
 
 			desiredNumberOfRoom, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
 			assert.NoError(t, err)
@@ -86,7 +86,7 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			mockPolicy.EXPECT().CurrentStateBuilder(gomock.Any(), scheduler).Return(currentState, nil)
 			mockPolicy.EXPECT().CalculateDesiredNumberOfRooms(scheduler.Autoscaling.Policy.Parameters, currentState).Return(minimumNumberOfRooms-1, nil)
 
-			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyFactory{policyType: mockPolicy})
+			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyMap{policyType: mockPolicy})
 
 			desiredNumberOfRoom, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
 			assert.NoError(t, err)
@@ -102,7 +102,7 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			mockPolicy.EXPECT().CurrentStateBuilder(gomock.Any(), scheduler).Return(currentState, nil)
 			mockPolicy.EXPECT().CalculateDesiredNumberOfRooms(scheduler.Autoscaling.Policy.Parameters, currentState).Return(maximumNumberOfRooms+1, nil)
 
-			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyFactory{policyType: mockPolicy})
+			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyMap{policyType: mockPolicy})
 
 			desiredNumberOfRoom, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
 			assert.NoError(t, err)
@@ -123,8 +123,8 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			assert.ErrorContains(t, err, "Scheduler does not have autoscaling struct")
 		})
 
-		t.Run("When policyFactory does not have policy retun in error", func(t *testing.T) {
-			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyFactory{})
+		t.Run("When policyMap does not have policy retun in error", func(t *testing.T) {
+			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyMap{})
 
 			_, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
 			assert.ErrorContains(t, err, "Error finding policy to scheduler")
@@ -135,7 +135,7 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 
 			mockPolicy.EXPECT().CurrentStateBuilder(gomock.Any(), scheduler).Return(nil, errors.New("Error getting current state"))
 
-			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyFactory{policyType: mockPolicy})
+			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyMap{policyType: mockPolicy})
 
 			_, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
 			assert.ErrorContains(t, err, "Error fetching current state to scheduler")
@@ -149,7 +149,7 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			mockPolicy.EXPECT().CurrentStateBuilder(gomock.Any(), scheduler).Return(currentState, nil)
 			mockPolicy.EXPECT().CalculateDesiredNumberOfRooms(scheduler.Autoscaling.Policy.Parameters, currentState).Return(-1, errors.New("Error calculating desired number of rooms"))
 
-			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyFactory{policyType: mockPolicy})
+			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyMap{policyType: mockPolicy})
 
 			_, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
 			assert.ErrorContains(t, err, "Error calculating the desired number of rooms to scheduler")

--- a/internal/core/services/autoscaler/autoscaler_test.go
+++ b/internal/core/services/autoscaler/autoscaler_test.go
@@ -85,7 +85,7 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			assert.ErrorContains(t, err, "Error building policy to scheduler")
 		})
 
-		t.Run("When CurrentStateBuilder returns in error", func(t *testing.T) {
+		t.Run("When CurrentStateBuilder returns error", func(t *testing.T) {
 			mockPolicy := policyMock.NewMockPolicy(ctrl)
 
 			mockPolicy.EXPECT().CurrentStateBuilder(gomock.Any(), scheduler).Return(nil, errors.New("Error getting current state"))

--- a/internal/core/services/autoscaler/autoscaler_test.go
+++ b/internal/core/services/autoscaler/autoscaler_test.go
@@ -120,14 +120,14 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			}
 
 			_, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
-			assert.ErrorContains(t, err, "Scheduler does not have autoscaling struct")
+			assert.ErrorContains(t, err, "scheduler does not have autoscaling struct")
 		})
 
 		t.Run("When policyMap does not have policy retun in error", func(t *testing.T) {
 			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyMap{})
 
 			_, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
-			assert.ErrorContains(t, err, "Error finding policy to scheduler")
+			assert.ErrorContains(t, err, "error finding policy to scheduler")
 		})
 
 		t.Run("When CurrentStateBuilder returns error", func(t *testing.T) {
@@ -138,7 +138,7 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyMap{policyType: mockPolicy})
 
 			_, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
-			assert.ErrorContains(t, err, "Error fetching current state to scheduler")
+			assert.ErrorContains(t, err, "error fetching current state to scheduler")
 		})
 
 		t.Run("When CalculateDesiredNumberOfRooms returns error", func(t *testing.T) {
@@ -152,7 +152,7 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			autoscaler := autoscaler.NewAutoscaler(autoscaler.PolicyMap{policyType: mockPolicy})
 
 			_, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
-			assert.ErrorContains(t, err, "Error calculating the desired number of rooms to scheduler")
+			assert.ErrorContains(t, err, "error calculating the desired number of rooms to scheduler")
 		})
 	})
 }

--- a/internal/core/services/autoscaler/autoscaler_test.go
+++ b/internal/core/services/autoscaler/autoscaler_test.go
@@ -100,7 +100,7 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			assert.ErrorContains(t, err, "Error fetching current state to scheduler")
 		})
 
-		t.Run("When CalculateDesiredNumberOfRooms returns in error", func(t *testing.T) {
+		t.Run("When CalculateDesiredNumberOfRooms returns error", func(t *testing.T) {
 			mockPolicy := policyMock.NewMockPolicy(ctrl)
 
 			currentState := policies.CurrentState{}

--- a/internal/core/services/autoscaler/autoscaler_test.go
+++ b/internal/core/services/autoscaler/autoscaler_test.go
@@ -1,0 +1,145 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build unit
+// +build unit
+
+package autoscaler_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/topfreegames/maestro/internal/core/entities"
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
+	autoscalerPorts "github.com/topfreegames/maestro/internal/core/ports/autoscaler"
+	"github.com/topfreegames/maestro/internal/core/ports/mock"
+	"github.com/topfreegames/maestro/internal/core/services/autoscaler"
+	"github.com/topfreegames/maestro/internal/core/services/autoscaler/policies"
+	policyMock "github.com/topfreegames/maestro/internal/core/services/autoscaler/policies/mock"
+	"github.com/topfreegames/maestro/internal/core/services/autoscaler/policies/roomoccupancy"
+)
+
+func TestCalculateDesiredNumberOfRooms(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	expectedDesiredNumberOfRooms := 4
+
+	scheduler := &entities.Scheduler{
+		Name:        "some-name",
+		Autoscaling: &autoscaling.Autoscaling{},
+	}
+
+	t.Run("Success case", func(t *testing.T) {
+		mockPolicy := policyMock.NewMockPolicy(ctrl)
+
+		currentState := policies.CurrentState{}
+
+		mockPolicy.EXPECT().CurrentStateBuilder(gomock.Any(), scheduler).Return(currentState, nil)
+		mockPolicy.EXPECT().CalculateDesiredNumberOfRooms(currentState).Return(expectedDesiredNumberOfRooms, nil)
+
+		autoscaler := autoscaler.Autoscaler{
+			PolicyFactory: func(autoscaling.PolicyType) (autoscalerPorts.Policy, error) {
+				return mockPolicy, nil
+			},
+		}
+
+		desiredNumberOfRoom, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedDesiredNumberOfRooms, desiredNumberOfRoom)
+	})
+
+	t.Run("Error cases", func(t *testing.T) {
+		t.Run("When policy factory retun in error", func(t *testing.T) {
+			autoscaler := autoscaler.Autoscaler{
+				PolicyFactory: func(autoscaling.PolicyType) (autoscalerPorts.Policy, error) {
+					return nil, errors.New("Error getting policy to policyType")
+				},
+			}
+
+			_, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
+			assert.ErrorContains(t, err, "Error building policy to scheduler")
+		})
+
+		t.Run("When CurrentStateBuilder returns in error", func(t *testing.T) {
+			mockPolicy := policyMock.NewMockPolicy(ctrl)
+
+			mockPolicy.EXPECT().CurrentStateBuilder(gomock.Any(), scheduler).Return(nil, errors.New("Error getting current state"))
+
+			autoscaler := autoscaler.Autoscaler{
+				PolicyFactory: func(autoscaling.PolicyType) (autoscalerPorts.Policy, error) {
+					return mockPolicy, nil
+				},
+			}
+
+			_, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
+			assert.ErrorContains(t, err, "Error fetching current state to scheduler")
+		})
+
+		t.Run("When CalculateDesiredNumberOfRooms returns in error", func(t *testing.T) {
+			mockPolicy := policyMock.NewMockPolicy(ctrl)
+
+			currentState := policies.CurrentState{}
+
+			mockPolicy.EXPECT().CurrentStateBuilder(gomock.Any(), scheduler).Return(currentState, nil)
+			mockPolicy.EXPECT().CalculateDesiredNumberOfRooms(currentState).Return(-1, errors.New("Error calculating desired number of rooms"))
+
+			autoscaler := autoscaler.Autoscaler{
+				PolicyFactory: func(autoscaling.PolicyType) (autoscalerPorts.Policy, error) {
+					return mockPolicy, nil
+				},
+			}
+
+			_, err := autoscaler.CalculateDesiredNumberOfRooms(context.Background(), scheduler)
+			assert.ErrorContains(t, err, "Error calculating the desired number of rooms to scheduler")
+		})
+	})
+}
+
+func TestDefaultPolicyFactory(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("Success case", func(t *testing.T) {
+		roomStorageMock := mock.NewMockRoomStorage(ctrl)
+
+		autoscaler := autoscaler.NewAutoscaler(roomStorageMock)
+
+		policy, err := autoscaler.DefaultPolicyFactory(autoscaling.RoomOccupancy)
+		assert.NoError(t, err)
+
+		assert.IsType(t, &roomoccupancy.Policy{}, policy)
+	})
+
+	t.Run("Error case", func(t *testing.T) {
+		roomStorageMock := mock.NewMockRoomStorage(ctrl)
+
+		autoscaler := autoscaler.NewAutoscaler(roomStorageMock)
+		_, err := autoscaler.DefaultPolicyFactory(autoscaling.PolicyType("unknown-policy-type"))
+		assert.ErrorContains(t, err, "Autoscaling policy not found")
+	})
+}

--- a/internal/core/services/autoscaler/policies/mock/mock.go
+++ b/internal/core/services/autoscaler/policies/mock/mock.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	entities "github.com/topfreegames/maestro/internal/core/entities"
+	autoscaling "github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 	policies "github.com/topfreegames/maestro/internal/core/services/autoscaler/policies"
 )
 
@@ -37,18 +38,18 @@ func (m *MockPolicy) EXPECT() *MockPolicyMockRecorder {
 }
 
 // CalculateDesiredNumberOfRooms mocks base method.
-func (m *MockPolicy) CalculateDesiredNumberOfRooms(currentState policies.CurrentState) (int, error) {
+func (m *MockPolicy) CalculateDesiredNumberOfRooms(policyParameters autoscaling.PolicyParameters, currentState policies.CurrentState) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CalculateDesiredNumberOfRooms", currentState)
+	ret := m.ctrl.Call(m, "CalculateDesiredNumberOfRooms", policyParameters, currentState)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CalculateDesiredNumberOfRooms indicates an expected call of CalculateDesiredNumberOfRooms.
-func (mr *MockPolicyMockRecorder) CalculateDesiredNumberOfRooms(currentState interface{}) *gomock.Call {
+func (mr *MockPolicyMockRecorder) CalculateDesiredNumberOfRooms(policyParameters, currentState interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalculateDesiredNumberOfRooms", reflect.TypeOf((*MockPolicy)(nil).CalculateDesiredNumberOfRooms), currentState)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalculateDesiredNumberOfRooms", reflect.TypeOf((*MockPolicy)(nil).CalculateDesiredNumberOfRooms), policyParameters, currentState)
 }
 
 // CurrentStateBuilder mocks base method.

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -196,8 +196,8 @@ func createRedisClient(url string) (*redis.Client, error) {
 	return redis.NewClient(opts), nil
 }
 
-func NewPolicyFactory(roomStorage ports.RoomStorage) autoscaler.PolicyFactory {
-	return autoscaler.PolicyFactory{
+func NewPolicyMap(roomStorage ports.RoomStorage) autoscaler.PolicyMap {
+	return autoscaler.PolicyMap{
 		autoscaling.RoomOccupancy: roomoccupancy.NewPolicy(roomStorage),
 	}
 }

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 	"github.com/topfreegames/maestro/internal/core/operations/healthcontroller"
 
 	operationadapters "github.com/topfreegames/maestro/internal/adapters/operation"
@@ -35,6 +36,8 @@ import (
 	scheduleradapters "github.com/topfreegames/maestro/internal/adapters/scheduler"
 
 	"github.com/topfreegames/maestro/internal/core/operations"
+	"github.com/topfreegames/maestro/internal/core/services/autoscaler"
+	"github.com/topfreegames/maestro/internal/core/services/autoscaler/policies/roomoccupancy"
 	"github.com/topfreegames/maestro/internal/core/services/operation_manager"
 	"github.com/topfreegames/maestro/internal/core/services/room_manager"
 
@@ -191,6 +194,12 @@ func createRedisClient(url string) (*redis.Client, error) {
 	}
 
 	return redis.NewClient(opts), nil
+}
+
+func NewPolicyFactory(roomStorage ports.RoomStorage) autoscaler.PolicyFactory {
+	return autoscaler.PolicyFactory{
+		autoscaling.RoomOccupancy: roomoccupancy.NewPolicy(roomStorage),
+	}
 }
 
 func NewOperationFlowRedis(c config.Config) (ports.OperationFlow, error) {

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -34,9 +34,13 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/orlangure/gnomock"
 	predis "github.com/orlangure/gnomock/preset/redis"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	configmock "github.com/topfreegames/maestro/internal/config/mock"
+	"github.com/topfreegames/maestro/internal/core/entities/autoscaling"
 	"github.com/topfreegames/maestro/internal/core/ports/errors"
+	"github.com/topfreegames/maestro/internal/core/ports/mock"
+	"github.com/topfreegames/maestro/internal/core/services/autoscaler/policies/roomoccupancy"
 )
 
 func getRedisUrl(t *testing.T) string {
@@ -280,5 +284,16 @@ func TestOperationFlowRedis(t *testing.T) {
 		config.EXPECT().GetString(operationFlowRedisUrlPath).Return("")
 		_, err := NewOperationFlowRedis(config)
 		require.Error(t, err)
+	})
+}
+
+func TestNewPolicyFactory(t *testing.T) {
+	t.Run("Should return RoomOccupancy policy", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		roomStorageMock := mock.NewMockRoomStorage(mockCtrl)
+
+		policyFactory := NewPolicyFactory(roomStorageMock)
+		assert.IsType(t, policyFactory[autoscaling.RoomOccupancy], &roomoccupancy.Policy{})
 	})
 }

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -287,13 +287,13 @@ func TestOperationFlowRedis(t *testing.T) {
 	})
 }
 
-func TestNewPolicyFactory(t *testing.T) {
+func TestNewPolicyMap(t *testing.T) {
 	t.Run("Should return RoomOccupancy policy", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		roomStorageMock := mock.NewMockRoomStorage(mockCtrl)
 
-		policyFactory := NewPolicyFactory(roomStorageMock)
-		assert.IsType(t, policyFactory[autoscaling.RoomOccupancy], &roomoccupancy.Policy{})
+		policyMap := NewPolicyMap(roomStorageMock)
+		assert.IsType(t, policyMap[autoscaling.RoomOccupancy], &roomoccupancy.Policy{})
 	})
 }


### PR DESCRIPTION
### Why

To autoscaling execute it needs a service that is responsible for injecting its dependency into the `healthcontroller` and executing its logic.

### What

Create a package called `autoscaler` with `Autoscaler` struct that executes the logic to calculate the desired number of rooms in the scheduler.