### PR TITLE
Fix/expired pending rooms

### DIFF
--- a/internal/adapters/room_storage/redis/redis.go
+++ b/internal/adapters/room_storage/redis/redis.go
@@ -45,10 +45,11 @@ const (
 	maxRoomStatusEvents = 100
 
 	// Room hash keys.
-	metadataKey      = "metadata"
-	pingStatusKey    = "ping_status"
-	versionKey       = "version"
-	isValidationRoom = "is_validation_room"
+	metadataKey         = "metadata"
+	pingStatusKey       = "ping_status"
+	versionKey          = "version"
+	isValidationRoomKey = "is_validation_room"
+	createdAtKey        = "created_at"
 )
 
 type redisStateStorage struct {
@@ -96,11 +97,17 @@ func (r redisStateStorage) GetRoom(ctx context.Context, scheduler, roomID string
 		return nil, errors.NewErrEncoding("failed to parse operation status").WithError(err)
 	}
 
-	boolIsValidationRoom, _ := strconv.ParseBool(roomHashCmd.Val()[isValidationRoom])
+	boolIsValidationRoom, _ := strconv.ParseBool(roomHashCmd.Val()[isValidationRoomKey])
 	room.IsValidationRoom = boolIsValidationRoom
 
 	room.PingStatus = game_room.GameRoomPingStatus(pingStatusInt)
 	room.Version = roomHashCmd.Val()[versionKey]
+	createdAt, err := strconv.ParseInt(roomHashCmd.Val()[createdAtKey], 10, 64)
+	if err != nil {
+		return nil, errors.NewErrEncoding("error parsing room %s createdAtKey", roomID).WithError(err)
+	}
+
+	room.CreatedAt = time.Unix(createdAt, 0)
 	return room, nil
 }
 
@@ -112,10 +119,11 @@ func (r *redisStateStorage) CreateRoom(ctx context.Context, room *game_room.Game
 
 	p := r.client.TxPipeline()
 	p.HSet(ctx, getRoomRedisKey(room.SchedulerID, room.ID), map[string]interface{}{
-		versionKey:       room.Version,
-		metadataKey:      metadataJson,
-		pingStatusKey:    strconv.Itoa(int(room.PingStatus)),
-		isValidationRoom: room.IsValidationRoom,
+		versionKey:          room.Version,
+		metadataKey:         metadataJson,
+		pingStatusKey:       strconv.Itoa(int(room.PingStatus)),
+		isValidationRoomKey: room.IsValidationRoom,
+		createdAtKey:        time.Now().Unix(),
 	})
 
 	statusCmd := p.ZAddNX(ctx, getRoomStatusSetRedisKey(room.SchedulerID), &redis.Z{

--- a/internal/adapters/room_storage/redis/redis_test.go
+++ b/internal/adapters/room_storage/redis/redis_test.go
@@ -290,7 +290,7 @@ func TestRedisStateStorage_GetRoom(t *testing.T) {
 			Score:  float64(expectedRoom.LastPingAt.Unix()),
 		})
 
-		p.Exec(ctx)
+		_, _ = p.Exec(ctx)
 
 		actualRoom, err := storage.GetRoom(ctx, expectedRoom.SchedulerID, expectedRoom.ID)
 		require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestRedisStateStorage_GetRoom(t *testing.T) {
 			Member: expectedRoom.ID,
 			Score:  float64(expectedRoom.LastPingAt.Unix()),
 		})
-		p.Exec(ctx)
+		_, _ = p.Exec(ctx)
 
 		actualRoom, err := storage.GetRoom(ctx, expectedRoom.SchedulerID, expectedRoom.ID)
 		require.NoError(t, err)

--- a/internal/core/entities/game_room/game_room.go
+++ b/internal/core/entities/game_room/game_room.go
@@ -123,8 +123,9 @@ type GameRoom struct {
 	Status           GameRoomStatus
 	PingStatus       GameRoomPingStatus
 	Metadata         map[string]interface{}
-	LastPingAt       time.Time
 	IsValidationRoom bool
+	LastPingAt       time.Time
+	CreatedAt        time.Time
 }
 
 // validStatusTransitions this map has all possible status changes for a game

--- a/internal/core/operations/healthcontroller/health_controller_executor.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor.go
@@ -200,9 +200,7 @@ func (ex *SchedulerHealthControllerExecutor) findAvailableAndExpiredRooms(ctx co
 		}
 
 		switch {
-		case ex.isRoomStatus(room, game_room.GameStatusUnready):
-			availableRoomsIDs = append(availableRoomsIDs, gameRoomID)
-		case ex.isPendingRoomExpired(room):
+		case ex.isInitializingRoomExpired(room):
 			expiredRoomsIDs = append(expiredRoomsIDs, gameRoomID)
 		case ex.isRoomPingExpired(room):
 			expiredRoomsIDs = append(expiredRoomsIDs, gameRoomID)
@@ -218,9 +216,10 @@ func (ex *SchedulerHealthControllerExecutor) findAvailableAndExpiredRooms(ctx co
 	return availableRoomsIDs, expiredRoomsIDs
 }
 
-func (ex *SchedulerHealthControllerExecutor) isPendingRoomExpired(room *game_room.GameRoom) bool {
+func (ex *SchedulerHealthControllerExecutor) isInitializingRoomExpired(room *game_room.GameRoom) bool {
 	timeDurationInPendingState := time.Since(room.CreatedAt)
-	return ex.isRoomStatus(room, game_room.GameStatusPending) && timeDurationInPendingState > ex.roomManagerConfig.RoomInitializationTimeout
+	return (ex.isRoomStatus(room, game_room.GameStatusPending) || ex.isRoomStatus(room, game_room.GameStatusUnready)) &&
+		timeDurationInPendingState > ex.roomManagerConfig.RoomInitializationTimeout
 }
 
 func (ex *SchedulerHealthControllerExecutor) isRoomPingExpired(room *game_room.GameRoom) bool {

--- a/internal/core/operations/healthcontroller/health_controller_executor.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor.go
@@ -200,7 +200,6 @@ func (ex *SchedulerHealthControllerExecutor) findAvailableAndExpiredRooms(ctx co
 		}
 
 		switch {
-
 		case ex.isRoomStatus(room, game_room.GameStatusUnready):
 			availableRoomsIDs = append(availableRoomsIDs, gameRoomID)
 		case ex.isPendingRoomExpired(room):

--- a/internal/core/operations/healthcontroller/health_controller_executor.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor.go
@@ -200,12 +200,13 @@ func (ex *SchedulerHealthControllerExecutor) findAvailableAndExpiredRooms(ctx co
 		}
 
 		switch {
-		case ex.isRoomStatus(room, game_room.GameStatusPending):
-			availableRoomsIDs = append(availableRoomsIDs, gameRoomID)
+
 		case ex.isRoomStatus(room, game_room.GameStatusUnready):
 			availableRoomsIDs = append(availableRoomsIDs, gameRoomID)
-		case ex.isRoomExpired(room):
-			expiredRoomsIDs = append(expiredRoomsIDs, room.ID)
+		case ex.isPendingRoomExpired(room):
+			expiredRoomsIDs = append(expiredRoomsIDs, gameRoomID)
+		case ex.isRoomPingExpired(room):
+			expiredRoomsIDs = append(expiredRoomsIDs, gameRoomID)
 		case ex.isRoomStatus(room, game_room.GameStatusTerminating):
 			continue
 		case ex.isRoomStatus(room, game_room.GameStatusError):
@@ -218,9 +219,14 @@ func (ex *SchedulerHealthControllerExecutor) findAvailableAndExpiredRooms(ctx co
 	return availableRoomsIDs, expiredRoomsIDs
 }
 
-func (ex *SchedulerHealthControllerExecutor) isRoomExpired(room *game_room.GameRoom) bool {
+func (ex *SchedulerHealthControllerExecutor) isPendingRoomExpired(room *game_room.GameRoom) bool {
+	timeDurationInPendingState := time.Since(room.CreatedAt)
+	return ex.isRoomStatus(room, game_room.GameStatusPending) && timeDurationInPendingState > ex.roomManagerConfig.RoomInitializationTimeout
+}
+
+func (ex *SchedulerHealthControllerExecutor) isRoomPingExpired(room *game_room.GameRoom) bool {
 	timeDurationWithoutPing := time.Since(room.LastPingAt)
-	return timeDurationWithoutPing > ex.roomManagerConfig.RoomPingTimeout
+	return !ex.isRoomStatus(room, game_room.GameStatusPending) && timeDurationWithoutPing > ex.roomManagerConfig.RoomPingTimeout
 }
 
 func (ex *SchedulerHealthControllerExecutor) isRoomStatus(room *game_room.GameRoom, status game_room.GameRoomStatus) bool {

--- a/internal/core/operations/healthcontroller/health_controller_executor_test.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor_test.go
@@ -81,7 +81,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "game room status pending found, considered available, so nothing to do, no operations enqueued",
+			title: "game room status pending with no initialization timeout found, considered available, so nothing to do, no operations enqueued",
 			executionPlan: executionPlan{
 				planMocks: func(
 					roomStorage *mockports.MockRoomStorage,
@@ -110,8 +110,55 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 						SchedulerID: genericScheduler.Name,
 						Status:      game_room.GameStatusPending,
 						LastPingAt:  time.Now(),
+						CreatedAt:   time.Now(),
 					}
 					roomStorage.EXPECT().GetRoom(gomock.Any(), genericScheduler.Name, gameRoomIDs[1]).Return(gameRoomPending, nil)
+
+					genericScheduler.RoomsReplicas = 2
+				},
+			},
+		},
+		{
+			title: "game room status pending with initialization timeout found, considered expired, remove room operation enqueued",
+			executionPlan: executionPlan{
+				planMocks: func(
+					roomStorage *mockports.MockRoomStorage,
+					instanceStorage *ismock.MockGameRoomInstanceStorage,
+					schedulerStorage *mockports.MockSchedulerStorage,
+					operationManager *mockports.MockOperationManager,
+				) {
+					gameRoomIDs := []string{"existent-1", "existent-pending-2"}
+					instances := []*game_room.Instance{{ID: "existent-1"}, {ID: "existent-pending-2"}}
+					// load
+					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
+					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
+					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(genericScheduler, nil)
+
+					// Find game room
+					gameRoom := &game_room.GameRoom{
+						ID:          gameRoomIDs[0],
+						SchedulerID: genericScheduler.Name,
+						Status:      game_room.GameStatusReady,
+						LastPingAt:  time.Now(),
+					}
+					roomStorage.EXPECT().GetRoom(gomock.Any(), genericScheduler.Name, gameRoomIDs[0]).Return(gameRoom, nil)
+
+					expiredCreatedAt := time.Now().Add(5 * -time.Minute)
+					gameRoomPending := &game_room.GameRoom{
+						ID:          gameRoomIDs[0],
+						SchedulerID: genericScheduler.Name,
+						Status:      game_room.GameStatusPending,
+						LastPingAt:  time.Now(),
+						CreatedAt:   expiredCreatedAt,
+					}
+					roomStorage.EXPECT().GetRoom(gomock.Any(), genericScheduler.Name, gameRoomIDs[1]).Return(gameRoomPending, nil)
+
+					op := operation.New(genericScheduler.Name, genericDefinition.Name(), nil)
+					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericScheduler.Name, &remove_rooms.RemoveRoomsDefinition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(op, nil)
+
+					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericScheduler.Name, &add_rooms.AddRoomsDefinition{Amount: 1}).Return(op, nil)
 
 					genericScheduler.RoomsReplicas = 2
 				},
@@ -605,7 +652,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 			operationManager := mockports.NewMockOperationManager(mockCtrl)
 			config := room_manager.RoomManagerConfig{
-				RoomPingTimeout: 900000,
+				RoomPingTimeout:           2 * time.Minute,
+				RoomInitializationTimeout: 4 * time.Minute,
 			}
 			executor := healthcontroller.NewExecutor(roomsStorage, instanceStorage, schedulerStorage, operationManager, config)
 


### PR DESCRIPTION
## What ❓ 
Add CreatedAt field in GameRoom struct, update room storage db adapter to populate and retrieve this new field.

Update health controller operation logic to check for pending rooms with age bigger than **roomInitializationTimeout** to consider them as expired.

## Why 🤔 
Since add rooms operation doesn't wait for rooms to reach ready state anymore, we can have scenarios of game rooms stuck in `pending` state. We have to update our health controller to be able to identify and remove those rooms.

