### PR TITLE
Prevent creation of dangerous ready target

### DIFF
--- a/internal/core/entities/autoscaling/autoscaling.go
+++ b/internal/core/entities/autoscaling/autoscaling.go
@@ -82,5 +82,5 @@ type PolicyParameters struct {
 // RoomOccupancyParams represents the parameters accepted by rooms occupancy autoscaling properties.
 type RoomOccupancyParams struct {
 	// ReadyTarget indicates the target percentage of ready rooms a scheduler should maintain.
-	ReadyTarget float64 `validate:"gt=0,lt=1"`
+	ReadyTarget float64 `validate:"gt=0,lte=0.9"`
 }

--- a/internal/core/entities/autoscaling/autoscaling_test.go
+++ b/internal/core/entities/autoscaling/autoscaling_test.go
@@ -91,9 +91,9 @@ func TestNewAutoscaling(t *testing.T) {
 			validationErrs = err.(validator.ValidationErrors)
 			assert.Equal(t, "ReadyTarget must be greater than 0", validationErrs[0].Translate(translator))
 
-			_, err = NewAutoscaling(true, 1, 10, Policy{Type: "roomOccupancy", Parameters: PolicyParameters{RoomOccupancy: &RoomOccupancyParams{ReadyTarget: 1.0}}})
+			_, err = NewAutoscaling(true, 1, 10, Policy{Type: "roomOccupancy", Parameters: PolicyParameters{RoomOccupancy: &RoomOccupancyParams{ReadyTarget: 0.91}}})
 			validationErrs = err.(validator.ValidationErrors)
-			assert.Equal(t, "ReadyTarget must be less than 1", validationErrs[0].Translate(translator))
+			assert.Equal(t, "ReadyTarget must be 0.9 or less", validationErrs[0].Translate(translator))
 		})
 	})
 


### PR DESCRIPTION
### Why

`ReadyTarget` in the `roomOccupancy` autoscaling policy greater than `0.9` presents a huge security problem that could create a very big number of game rooms when there is no limit to the maximum number of rooms.

### What

This PR proposes to limit the `ReadyTarget` to a maximum of `0.9`

