### PR TITLE
Ensure operation context is canceled after execution to fix memory leak

### DIFF
--- a/internal/core/workers/metricsreporter/metrics_reporter_worker.go
+++ b/internal/core/workers/metricsreporter/metrics_reporter_worker.go
@@ -64,6 +64,7 @@ func NewMetricsReporterWorker(scheduler *entities.Scheduler, opts *workers.Worke
 // Start is responsible for starting a loop that will
 // periodically report metrics for scheduler pods and game rooms.
 func (w *MetricsReporterWorker) Start(ctx context.Context) error {
+	defer w.Stop(ctx)
 	w.workerContext, w.cancelWorkerContext = context.WithCancel(ctx)
 	ticker := time.NewTicker(time.Millisecond * w.config.MetricsReporterIntervalMillis)
 	defer ticker.Stop()


### PR DESCRIPTION
## What ❓ 
- Ensure operation context is canceled after execution to fix memory leak
- Use worker context when granting and renewing lease in operation execution worker
- Ensure worker Stop is called on metrics reporter

## Why 🤔 
We have identified a memory leak on operation execution worker, after profiling the application we discovered that the worker was spamming operation contexts and not canceling them after the operation execution, this was causing resources to be allocated for this context indefinitely, causing the memory leak.

## Heap profiling:

Using 500 schedulers static schedulers locally.

### Before the fix
##### First snapshot -> ~33MB
![profile001](https://user-images.githubusercontent.com/33766735/172604014-1599c9ae-a227-468f-be85-f14e56209766.png)
##### Last snapshot (after 40 minutes of running application) -> ~90MB
![profile006](https://user-images.githubusercontent.com/33766735/172604150-8818ea83-f7a6-4fb9-8403-db3126af0b7b.png)

### After the fix
##### First snapshot ~27MB
![profile001](https://user-images.githubusercontent.com/33766735/172604251-24ad0278-ff68-4999-8e40-26ee5cea9283.png)
##### Last snapshot (after 40 minutes of running application) -> ~27MB
![profile005](https://user-images.githubusercontent.com/33766735/172604283-d6ff9c1d-2fe6-4198-893b-c534c93b50d4.png)




