### PR TITLE
add fix for watcher stopping when convert instance fails

### DIFF
--- a/internal/adapters/runtime/kubernetes/metrics.go
+++ b/internal/adapters/runtime/kubernetes/metrics.go
@@ -1,0 +1,19 @@
+package kubernetes
+
+import "github.com/topfreegames/maestro/internal/core/monitoring"
+
+var (
+	watcherInstanceConversionFailCounterMetric = monitoring.CreateCounterMetric(&monitoring.MetricOpts{
+		Namespace: monitoring.Namespace,
+		Subsystem: monitoring.SubsystemWorker,
+		Name:      "workers_sync",
+		Help:      "Times of the workers sync processes",
+		Labels: []string{
+			monitoring.LabelScheduler,
+		},
+	})
+)
+
+func reportInstanceConversionFailed(schedulerName string) {
+	watcherInstanceConversionFailCounterMetric.WithLabelValues(schedulerName).Inc()
+}

--- a/internal/adapters/runtime/kubernetes/metrics.go
+++ b/internal/adapters/runtime/kubernetes/metrics.go
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package kubernetes
 
 import "github.com/topfreegames/maestro/internal/core/monitoring"

--- a/internal/adapters/runtime/kubernetes/metrics.go
+++ b/internal/adapters/runtime/kubernetes/metrics.go
@@ -6,8 +6,8 @@ var (
 	watcherInstanceConversionFailCounterMetric = monitoring.CreateCounterMetric(&monitoring.MetricOpts{
 		Namespace: monitoring.Namespace,
 		Subsystem: monitoring.SubsystemWorker,
-		Name:      "workers_sync",
-		Help:      "Times of the workers sync processes",
+		Name:      "failed_instance_conversion",
+		Help:      "Amount of instances conversions failed",
 		Labels: []string{
 			monitoring.LabelScheduler,
 		},

--- a/internal/adapters/runtime/kubernetes/metrics.go
+++ b/internal/adapters/runtime/kubernetes/metrics.go
@@ -5,7 +5,7 @@ import "github.com/topfreegames/maestro/internal/core/monitoring"
 var (
 	watcherInstanceConversionFailCounterMetric = monitoring.CreateCounterMetric(&monitoring.MetricOpts{
 		Namespace: monitoring.Namespace,
-		Subsystem: monitoring.SubsystemWorker,
+		Subsystem: monitoring.SubsystemWatcher,
 		Name:      "failed_instance_conversion",
 		Help:      "Amount of instances conversions failed",
 		Labels: []string{

--- a/internal/core/monitoring/constants.go
+++ b/internal/core/monitoring/constants.go
@@ -23,9 +23,10 @@
 package monitoring
 
 const (
-	Namespace       = "maestro"
-	SubsystemApi    = "api"
-	SubsystemWorker = "worker"
+	Namespace        = "maestro"
+	SubsystemApi     = "api"
+	SubsystemWorker  = "worker"
+	SubsystemWatcher = "watcher"
 )
 
 const (


### PR DESCRIPTION
### What?
When `convertInstance` method fails under watcher, it does not stop the worker anymore. Instead, it produces a metric

### Why?
We don't want the watcher to stop if an instance cannot be converted. Although this is bad, it shouldn't stop the whole thing.
