### PR TITLE
fix cannot change status from pending to occupied

### DIFF
--- a/internal/core/entities/game_room/game_room.go
+++ b/internal/core/entities/game_room/game_room.go
@@ -136,6 +136,7 @@ var validStatusTransitions = map[GameRoomStatus]map[GameRoomStatus]struct{}{
 		GameStatusTerminating: struct{}{},
 		GameStatusUnready:     struct{}{},
 		GameStatusError:       struct{}{},
+		GameStatusOccupied:    struct{}{},
 	},
 	GameStatusReady: {
 		GameStatusOccupied:    struct{}{},


### PR DESCRIPTION
### Why?
Sometimes the watcher takes some time to process the event of pod ready (even though the ping is forwarded and the game room is stable). Because of that, the room enters an invalid state to maestro since transiting the instance from pending to occupied is forbidden right now