### PR TITLE
changes delete method to not wait for watcher confirmation

### DIFF
--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -120,7 +120,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Rollback(ctx context.Context, op *o
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 	if gameRoom, ok := ex.validationRoomIdsMap[op.SchedulerName]; ok {
-		err := ex.roomManager.DeleteRoomAndWaitForRoomTerminating(ctx, gameRoom)
+		err := ex.roomManager.DeleteRoom(ctx, gameRoom)
 		if err != nil {
 			logger.Error("error deleting new game room created for validation", zap.Error(err))
 			return fmt.Errorf("error in Rollback function execution: %w", err)
@@ -141,7 +141,7 @@ func (ex *CreateNewSchedulerVersionExecutor) validateGameRoomCreation(ctx contex
 		return err
 	}
 	ex.AddValidationRoomId(scheduler.Name, gameRoom)
-	err = ex.roomManager.DeleteRoomAndWaitForRoomTerminating(ctx, gameRoom)
+	err = ex.roomManager.DeleteRoom(ctx, gameRoom)
 	if err != nil {
 		logger.Error("error deleting new game room created for validation", zap.Error(err))
 	}

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -76,7 +76,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		schedulerVersions := []*entities.SchedulerVersion{{Version: "v1.0.0"}, {Version: "v1.1.0"}, {Version: "v1.2.0"}}
 
 		roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), true).Return(&game_room.GameRoom{ID: "id-1"}, nil, nil)
-		roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)
+		roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 
 		schedulerManager.
 			EXPECT().
@@ -118,7 +118,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		schedulerVersions := []*entities.SchedulerVersion{{Version: "v2.0.0"}, {Version: "v3.1.0"}, {Version: "v1.2.0"}}
 
 		roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), true).Return(&game_room.GameRoom{ID: "id-1"}, nil, nil)
-		roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)
+		roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 
 		schedulerManager.
 			EXPECT().
@@ -160,7 +160,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		schedulerVersions := []*entities.SchedulerVersion{{Version: "v1.1.0"}, {Version: "v1.2.0"}, {Version: "v1.3.0"}}
 
 		roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), true).Return(&game_room.GameRoom{ID: "id-1"}, nil, nil)
-		roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)
+		roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 
 		schedulerManager.
 			EXPECT().
@@ -202,7 +202,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		schedulerVersions := []*entities.SchedulerVersion{{Version: "v1.1.0"}, {Version: "v1.2.0"}, {Version: "v1.3.0"}}
 
 		roomManager.EXPECT().CreateRoomAndWaitForReadiness(gomock.Any(), gomock.Any(), true).Return(&game_room.GameRoom{ID: "id-1"}, nil, nil)
-		roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("some_error"))
+		roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("some_error"))
 
 		schedulerManager.
 			EXPECT().
@@ -665,7 +665,7 @@ func TestCreateNewSchedulerVersionExecutor_Rollback(t *testing.T) {
 
 		executor := newschedulerversion.NewExecutor(roomManager, schedulerManager, operationsManager)
 		executor.AddValidationRoomId(newScheduler.Name, &game_room.GameRoom{ID: "room1"})
-		roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)
+		roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 		result := executor.Rollback(context.Background(), op, operationDef, nil)
 
 		require.Nil(t, result)
@@ -688,7 +688,7 @@ func TestCreateNewSchedulerVersionExecutor_Rollback(t *testing.T) {
 
 		executor := newschedulerversion.NewExecutor(roomManager, schedulerManager, operationsManager)
 		executor.AddValidationRoomId(newScheduler.Name, &game_room.GameRoom{ID: "room1"})
-		roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("some error"))
+		roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("some error"))
 		result := executor.Rollback(context.Background(), op, operationDef, nil)
 
 		require.EqualError(t, result, "error in Rollback function execution: some error")

--- a/internal/core/operations/remove_rooms/remove_rooms_executor.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor.go
@@ -134,7 +134,7 @@ func (e *RemoveRoomsExecutor) removeRoomsByAmount(ctx context.Context, scheduler
 func (e *RemoveRoomsExecutor) deleteRooms(ctx context.Context, rooms []*game_room.GameRoom) error {
 	var err error
 	for _, room := range rooms {
-		err = e.roomManager.DeleteRoomAndWaitForRoomTerminating(ctx, room)
+		err = e.roomManager.DeleteRoom(ctx, room)
 		if err != nil {
 			return err
 		}

--- a/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
+++ b/internal/core/operations/remove_rooms/remove_rooms_executor_test.go
@@ -74,7 +74,7 @@ func TestExecute(t *testing.T) {
 				{ID: "second-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
 			}
 			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
-			roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 			err := executor.Execute(ctx, operation, definition)
 
 			require.Nil(t, err)
@@ -93,7 +93,7 @@ func TestExecute(t *testing.T) {
 			}
 
 			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
-			roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(errors.New("failed to remove instance on the runtime: some error"))
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(errors.New("failed to remove instance on the runtime: some error"))
 
 			err := executor.Execute(context.Background(), operation, definition)
 			require.Equal(t, operations.ErrKindUnexpected, err.Kind())
@@ -113,7 +113,7 @@ func TestExecute(t *testing.T) {
 			}
 
 			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
-			roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(serviceerrors.NewErrGameRoomStatusWaitingTimeout("some error"))
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(serviceerrors.NewErrGameRoomStatusWaitingTimeout("some error"))
 
 			err := executor.Execute(context.Background(), operation, definition)
 			require.Equal(t, operations.ErrKindTerminatingPingTimeout, err.Kind())
@@ -175,8 +175,8 @@ func TestExecute(t *testing.T) {
 			}
 			roomsStorage.EXPECT().GetRoom(gomock.Any(), schedulerName, firstRoomID).Return(room, nil)
 			roomsStorage.EXPECT().GetRoom(gomock.Any(), schedulerName, secondRoomID).Return(secondRoom, nil)
-			roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), room).Return(nil)
-			roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), secondRoom).Return(nil)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), room).Return(nil)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), secondRoom).Return(nil)
 			err := executor.Execute(ctx, operation, definition)
 			require.Nil(t, err)
 		})
@@ -229,8 +229,8 @@ func TestExecute(t *testing.T) {
 			}
 			roomsStorage.EXPECT().GetRoom(gomock.Any(), schedulerName, firstRoomID).Return(room, nil)
 			roomsStorage.EXPECT().GetRoom(gomock.Any(), schedulerName, secondRoomID).Return(secondRoom, nil)
-			roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), room).Return(nil)
-			roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), secondRoom).Return(fmt.Errorf("Error on remove room"))
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), room).Return(nil)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), secondRoom).Return(fmt.Errorf("Error on remove room"))
 			err := executor.Execute(ctx, operation, definition)
 			require.Equal(t, operations.ErrKindUnexpected, err.Kind())
 			require.ErrorContains(t, err.Error(), "failed to remove room by ids:")
@@ -259,8 +259,8 @@ func TestExecute(t *testing.T) {
 			}
 			roomsStorage.EXPECT().GetRoom(gomock.Any(), schedulerName, firstRoomID).Return(room, nil)
 			roomsStorage.EXPECT().GetRoom(gomock.Any(), schedulerName, secondRoomID).Return(secondRoom, nil)
-			roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), room).Return(nil)
-			roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), secondRoom).Return(serviceerrors.NewErrGameRoomStatusWaitingTimeout("some error"))
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), room).Return(nil)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), secondRoom).Return(serviceerrors.NewErrGameRoomStatusWaitingTimeout("some error"))
 
 			err := executor.Execute(ctx, operation, definition)
 
@@ -321,12 +321,12 @@ func TestExecute(t *testing.T) {
 		}
 		roomsStorage.EXPECT().GetRoom(gomock.Any(), schedulerName, firstRoomID).Return(room, nil)
 		roomsStorage.EXPECT().GetRoom(gomock.Any(), schedulerName, secondRoomID).Return(secondRoom, nil)
-		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), room).Return(nil)
-		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), secondRoom).Return(nil)
+		roomsManager.EXPECT().DeleteRoom(gomock.Any(), room).Return(nil)
+		roomsManager.EXPECT().DeleteRoom(gomock.Any(), secondRoom).Return(nil)
 
 		availableRooms := []*game_room.GameRoom{thirdRoom, fourthRoom}
 		roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
-		roomsManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+		roomsManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 		err := executor.Execute(ctx, operation, definition)
 		require.Nil(t, err)
 	})

--- a/internal/core/operations/switch_active_version/switch_active_version_executor.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor.go
@@ -144,7 +144,7 @@ func (ex *SwitchActiveVersionExecutor) Name() string {
 func (ex *SwitchActiveVersionExecutor) deleteNewCreatedRooms(ctx context.Context, logger *zap.Logger, schedulerName string) error {
 	logger.Info("deleting created rooms since switching active version had error - start")
 	for _, room := range ex.newCreatedRooms[schedulerName] {
-		err := ex.roomManager.DeleteRoomAndWaitForRoomTerminating(ctx, room)
+		err := ex.roomManager.DeleteRoom(ctx, room)
 		if err != nil {
 			logger.Error("failed to deleted recent created room", zap.Error(err))
 			return err
@@ -215,7 +215,7 @@ func (ex *SwitchActiveVersionExecutor) replaceRoom(logger *zap.Logger, roomsChan
 			logger.Error("error creating room", zap.Error(err))
 		}
 
-		err = roomManager.DeleteRoomAndWaitForRoomTerminating(ctx, room)
+		err = roomManager.DeleteRoom(ctx, room)
 		if err != nil {
 			logger.Warn("failed to delete room", zap.Error(err))
 			ex.roomsBeingReplaced.Delete(room.ID)

--- a/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
+++ b/internal/core/operations/switch_active_version/switch_active_version_executor_test.go
@@ -128,7 +128,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 			}
 			mocks.roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoom, nil, nil)
 		}
-		mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(len(append(gameRoomListCycle1, gameRoomListCycle2...)))
+		mocks.roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(len(append(gameRoomListCycle1, gameRoomListCycle2...)))
 
 		mocks.schedulerManager.EXPECT().UpdateScheduler(gomock.Any(), newMajorScheduler).Return(nil)
 
@@ -191,7 +191,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.roomManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*game_room.GameRoom{}, nil).MaxTimes(1)
 
 		mocks.roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("error")).MaxTimes(maxSurge)
-		mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(maxSurge)
+		mocks.roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(maxSurge)
 
 		mocks.schedulerManager.EXPECT().UpdateScheduler(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -237,7 +237,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 		mocks.roomManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]*game_room.GameRoom{}, nil).MaxTimes(1)
 
 		mocks.roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil).MaxTimes(maxSurge)
-		mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(errors.New("error")).MaxTimes(maxSurge)
+		mocks.roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(errors.New("error")).MaxTimes(maxSurge)
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
 		execErr := executor.Execute(context.Background(), &operation.Operation{SchedulerName: newMajorScheduler.Name}, definition)
@@ -371,7 +371,7 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 				LastPingAt:  time.Now(),
 			}
 			mocks.roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoom, nil, nil)
-			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)
+			mocks.roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 		}
 
 		mocks.schedulerManager.EXPECT().UpdateScheduler(gomock.Any(), gomock.Any()).Return(errors.New("error"))
@@ -388,7 +388,7 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 
 		for range append(gameRoomListCycle1, gameRoomListCycle2...) {
-			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)
+			mocks.roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 		}
 
 		err = executor.Rollback(context.Background(), op, definition, nil)
@@ -430,7 +430,7 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 		for i := range allRooms {
 			if i == len(allRooms)-1 {
 				mocks.roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("error"))
-				mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(errors.New("error"))
+				mocks.roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 				continue
 			}
 			gameRoom := &game_room.GameRoom{
@@ -441,7 +441,7 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 				LastPingAt:  time.Now(),
 			}
 			mocks.roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoom, nil, nil)
-			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)
+			mocks.roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 		}
 
 		executor := switch_active_version.NewExecutor(mocks.roomManager, mocks.schedulerManager)
@@ -459,7 +459,7 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 			if i == len(allRooms)-1 {
 				continue
 			}
-			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)
+			mocks.roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 		}
 
 		err = executor.Rollback(context.Background(), op, definition, nil)
@@ -505,7 +505,7 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 				LastPingAt:  time.Now(),
 			}
 			mocks.roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(gameRoom, nil, nil)
-			mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(nil)
+			mocks.roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 		}
 
 		mocks.schedulerManager.EXPECT().UpdateScheduler(gomock.Any(), gomock.Any()).Return(errors.New("error"))
@@ -521,7 +521,7 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 		require.NotNil(t, execErr)
 		require.Equal(t, operations.ErrKindUnexpected, execErr.Kind())
 
-		mocks.roomManager.EXPECT().DeleteRoomAndWaitForRoomTerminating(gomock.Any(), gomock.Any()).Return(errors.New("error"))
+		mocks.roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 
 		err = executor.Rollback(context.Background(), op, definition, nil)
 		require.Error(t, err)

--- a/internal/core/ports/mock/rooms_ports_mock.go
+++ b/internal/core/ports/mock/rooms_ports_mock.go
@@ -85,18 +85,18 @@ func (mr *MockRoomManagerMockRecorder) CreateRoomAndWaitForReadiness(ctx, schedu
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoomAndWaitForReadiness", reflect.TypeOf((*MockRoomManager)(nil).CreateRoomAndWaitForReadiness), ctx, scheduler, isValidationRoom)
 }
 
-// DeleteRoomAndWaitForRoomTerminating mocks base method.
-func (m *MockRoomManager) DeleteRoomAndWaitForRoomTerminating(ctx context.Context, gameRoom *game_room.GameRoom) error {
+// DeleteRoom mocks base method.
+func (m *MockRoomManager) DeleteRoom(ctx context.Context, gameRoom *game_room.GameRoom) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRoomAndWaitForRoomTerminating", ctx, gameRoom)
+	ret := m.ctrl.Call(m, "DeleteRoom", ctx, gameRoom)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteRoomAndWaitForRoomTerminating indicates an expected call of DeleteRoomAndWaitForRoomTerminating.
-func (mr *MockRoomManagerMockRecorder) DeleteRoomAndWaitForRoomTerminating(ctx, gameRoom interface{}) *gomock.Call {
+// DeleteRoom indicates an expected call of DeleteRoom.
+func (mr *MockRoomManagerMockRecorder) DeleteRoom(ctx, gameRoom interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoomAndWaitForRoomTerminating", reflect.TypeOf((*MockRoomManager)(nil).DeleteRoomAndWaitForRoomTerminating), ctx, gameRoom)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoom", reflect.TypeOf((*MockRoomManager)(nil).DeleteRoom), ctx, gameRoom)
 }
 
 // GetRoomInstance mocks base method.

--- a/internal/core/ports/room_ports.go
+++ b/internal/core/ports/room_ports.go
@@ -35,10 +35,9 @@ import (
 
 // RoomManager is an interface for working with rooms in a high level way
 type RoomManager interface {
-	// DeleteRoomAndWaitForRoomTerminating receives a room to be deleted, and only finish execution when the
-	// room reach terminating status. If the room cannot be terminated by any means, it will return an error
-	// specifying why
-	DeleteRoomAndWaitForRoomTerminating(ctx context.Context, gameRoom *game_room.GameRoom) error
+	// DeleteRoom receives a room to be deleted, and updates the status of the game room to terminating
+	// If the room cannot be terminated by any means, it will return an error specifying why
+	DeleteRoom(ctx context.Context, gameRoom *game_room.GameRoom) error
 	// SchedulerMaxSurge calculates the current scheduler max surge based on
 	// the number of rooms the scheduler has.
 	SchedulerMaxSurge(ctx context.Context, scheduler *entities.Scheduler) (int, error)
@@ -58,7 +57,7 @@ type RoomManager interface {
 	// enough rooms on the scheduler.
 	ListRoomsWithDeletionPriority(ctx context.Context, schedulerName, ignoredVersion string, amount int, roomsBeingReplaced *sync.Map) ([]*game_room.GameRoom, error)
 	// CleanRoomState cleans the remaining state of a room. This function is
-	// intended to be used after a `DeleteRoomAndWaitForRoomTerminating`, where the room instance is
+	// intended to be used after a `DeleteRoom`, where the room instance is
 	// signaled to terminate.
 	//
 	// It wouldn't return an error if the room was already cleaned.


### PR DESCRIPTION
### What?
Changes `DeleteRoomAndWaitForRoomTerminated` method to `DeleteRoom`.

### Why?
Waiting for the room to be terminated is not needed since Kubernetes guarantees that the room is marked to be terminated if kube-api succeeds. 
For reference, see: https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-deletion