### PR TITLE
Cache node address to optimize kubernetes api usage

### DIFF
--- a/internal/adapters/runtime/kubernetes/game_room.go
+++ b/internal/adapters/runtime/kubernetes/game_room.go
@@ -48,7 +48,7 @@ func (k *kubernetes) CreateGameRoomInstance(ctx context.Context, schedulerID str
 
 	// when pod is created, we cannot have its node, so we're "forcing" node to
 	// be nil here.
-	instance, err := convertPod(pod, nil)
+	instance, err := convertPod(pod, "")
 	if err != nil {
 		return nil, errors.NewErrUnexpected("failed to convert game room instance: %s", err)
 	}

--- a/internal/adapters/runtime/kubernetes/game_room_convert.go
+++ b/internal/adapters/runtime/kubernetes/game_room_convert.go
@@ -355,12 +355,7 @@ func convertPodPorts(pod *v1.Pod) []game_room.Port {
 	return ports
 }
 
-func convertPod(pod *v1.Pod, node *v1.Node) (*game_room.Instance, error) {
-	nodeAddress, err := convertNodeAddress(node)
-	if err != nil {
-		return nil, err
-	}
-
+func convertPod(pod *v1.Pod, nodeAddress string) (*game_room.Instance, error) {
 	var address *game_room.Address
 	if nodeAddress != "" {
 		address = &game_room.Address{

--- a/internal/adapters/runtime/kubernetes/game_room_convert_test.go
+++ b/internal/adapters/runtime/kubernetes/game_room_convert_test.go
@@ -609,7 +609,7 @@ func TestConvertPodStatus(t *testing.T) {
 func TestConvertPod(t *testing.T) {
 	cases := map[string]struct {
 		pod              *v1.Pod
-		node             *v1.Node
+		nodeAddress      string
 		expectedInstance game_room.Instance
 		expectedError    bool
 	}{
@@ -633,20 +633,11 @@ func TestConvertPod(t *testing.T) {
 				SchedulerID: "some-scheduler",
 			},
 		},
-		"pod address error": {
-			node: &v1.Node{},
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pod-id",
-				},
-			},
-			expectedError: true,
-		},
 	}
 
 	for name, test := range cases {
 		t.Run(name, func(t *testing.T) {
-			res, err := convertPod(test.pod, test.node)
+			res, err := convertPod(test.pod, test.nodeAddress)
 			if test.expectedError {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
## What ❓ 
Cache node adresses to optimize kubernetes api usage. Also, use a filter when creating pods informer to ensure maestro only watches for pods that it created.

## Why 🤔 
Currently, for every new pod that maestro starts watching, it makes a **get node** request for fetching the node address, and since this request can delay the event processing in a throttling scenario, we should optimize kube API usage using a cache.

