### PR TITLE
Ensure to only forward events if the forwarder is enabled

### DIFF
--- a/internal/core/services/events_forwarder/events_forwarder_service.go
+++ b/internal/core/services/events_forwarder/events_forwarder_service.go
@@ -85,19 +85,20 @@ func (es *EventsForwarderService) ProduceEvent(ctx context.Context, event *event
 		return err
 	}
 
-	forwarderList := scheduler.Forwarders
-	if len(forwarderList) > 0 {
+	if forwarderList := scheduler.Forwarders; len(forwarderList) > 0 {
 		for _, _forwarder := range forwarderList {
-			switch event.Name {
-			case events.RoomEvent:
-				err = es.forwardRoomEvent(ctx, event, eventType, scheduler, _forwarder)
-				if err != nil {
-					return err
-				}
-			case events.PlayerEvent:
-				err = es.forwardPlayerEvent(ctx, event, eventType, scheduler, _forwarder)
-				if err != nil {
-					return err
+			if _forwarder.Enabled {
+				switch event.Name {
+				case events.RoomEvent:
+					err = es.forwardRoomEvent(ctx, event, eventType, scheduler, _forwarder)
+					if err != nil {
+						return err
+					}
+				case events.PlayerEvent:
+					err = es.forwardPlayerEvent(ctx, event, eventType, scheduler, _forwarder)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## What ❓
Check if the forwarder is enabled before producing events for it, also create a new test case covering the scenario for the disabled forwarder.

## Why 🤔 
Currently, the events service does not check if the forwarder is enabled before producing the event, this is not the expected behavior.
