### PR TITLE
Feature/enable transaction in delete scheduler method

### DIFF
--- a/internal/adapters/scheduler/scheduler_storage_pg_test.go
+++ b/internal/adapters/scheduler/scheduler_storage_pg_test.go
@@ -452,24 +452,70 @@ func TestSchedulerStorage_UpdateScheduler(t *testing.T) {
 }
 
 func TestSchedulerStorage_DeleteScheduler(t *testing.T) {
-	t.Run("scheduler exists", func(t *testing.T) {
+	t.Run("delete scheduler and its versions if it exists without transaction", func(t *testing.T) {
 		db := getPostgresDB(t)
 		storage := NewSchedulerStorage(db.Options())
+		dbScheduler := NewDBScheduler(expectedScheduler)
 
-		require.NoError(t, storage.CreateScheduler(context.Background(), expectedScheduler))
+		// Create scheduler
+		_, err := db.Exec(queryInsertScheduler, dbScheduler)
+		require.NoError(t, err)
+		_, err = db.Exec(queryInsertVersion, dbScheduler.Name, dbScheduler.Version, dbScheduler.Yaml, dbScheduler.RollbackVersion)
 
-		err := storage.DeleteScheduler(context.Background(), expectedScheduler)
+		err = storage.DeleteScheduler(context.Background(), "", expectedScheduler)
 		require.NoError(t, err)
 
-		dbScheduler, _ := getDBSchedulerAndVersions(t, db, expectedScheduler.Name)
-		require.Nil(t, dbScheduler)
+		dbSchedulerResult, _ := getDBSchedulerAndVersions(t, db, expectedScheduler.Name)
+		require.Nil(t, dbSchedulerResult)
 	})
 
-	t.Run("scheduler does not exist", func(t *testing.T) {
+	t.Run("delete scheduler and its versions if scheduler exists with successful transaction", func(t *testing.T) {
+		db := getPostgresDB(t)
+
+		storage := NewSchedulerStorage(db.Options())
+		dbScheduler := NewDBScheduler(expectedScheduler)
+
+		// Create scheduler
+		_, err := db.Exec(queryInsertScheduler, dbScheduler)
+		require.NoError(t, err)
+		_, err = db.Exec(queryInsertVersion, dbScheduler.Name, dbScheduler.Version, dbScheduler.Yaml, dbScheduler.RollbackVersion)
+
+		err = storage.RunWithTransaction(context.Background(), func(transactionID ports.TransactionID) error {
+			err = storage.DeleteScheduler(context.Background(), transactionID, expectedScheduler)
+			return err
+		})
+		require.NoError(t, err)
+
+		dbSchedulerResult, _ := getDBSchedulerAndVersions(t, db, expectedScheduler.Name)
+		require.Nil(t, dbSchedulerResult)
+	})
+
+	t.Run("does not delete scheduler if scheduler exists with failed transaction", func(t *testing.T) {
+		db := getPostgresDB(t)
+
+		storage := NewSchedulerStorage(db.Options())
+		dbScheduler := NewDBScheduler(expectedScheduler)
+
+		// Create scheduler
+		_, err := db.Exec(queryInsertScheduler, dbScheduler)
+		require.NoError(t, err)
+		_, err = db.Exec(queryInsertVersion, dbScheduler.Name, dbScheduler.Version, dbScheduler.Yaml, dbScheduler.RollbackVersion)
+
+		err = storage.RunWithTransaction(context.Background(), func(transactionID ports.TransactionID) error {
+			err = storage.DeleteScheduler(context.Background(), transactionID, expectedScheduler)
+			return errors.NewErrUnexpected("some error")
+		})
+		require.Error(t, err)
+
+		dbSchedulerResult, _ := getDBSchedulerAndVersions(t, db, expectedScheduler.Name)
+		require.NotNil(t, dbSchedulerResult)
+	})
+
+	t.Run("does nothing and return error if scheduler does not exist without transaction", func(t *testing.T) {
 		db := getPostgresDB(t)
 		storage := NewSchedulerStorage(db.Options())
 
-		err := storage.DeleteScheduler(context.Background(), expectedScheduler)
+		err := storage.DeleteScheduler(context.Background(), "", expectedScheduler)
 		require.Error(t, err)
 		require.ErrorIs(t, errors.ErrNotFound, err)
 	})

--- a/internal/core/logs/logs.go
+++ b/internal/core/logs/logs.go
@@ -33,4 +33,5 @@ const (
 	LogFieldServiceName         = "service_name"
 	LogFieldExecutorName        = "executor_name"
 	LogFieldHandlerName         = "handler_name"
+	LogFieldOperationPhase      = "operation_phase"
 )

--- a/internal/core/operations/create_scheduler/create_scheduler_executor.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor.go
@@ -52,7 +52,7 @@ func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op *operation.Ope
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "Execute"),
+		zap.String(logs.LogFieldOperationPhase, "Execute"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 
@@ -70,7 +70,7 @@ func (e *CreateSchedulerExecutor) Rollback(ctx context.Context, op *operation.Op
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "Rollback"),
+		zap.String(logs.LogFieldOperationPhase, "Rollback"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 

--- a/internal/core/operations/deletescheduler/delete_scheduler_definition.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_definition.go
@@ -1,0 +1,69 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deletescheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"go.uber.org/zap"
+)
+
+const OperationName = "delete_scheduler"
+
+type DeleteSchedulerDefinition struct {
+	SchedulerName string `json:"schedulerName"`
+}
+
+// ShouldExecute always return true, we're going to always perform the scheduler deletion when requested.
+func (d *DeleteSchedulerDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
+	return true
+}
+
+// Name returns the scheduler name.
+func (d *DeleteSchedulerDefinition) Name() string {
+	return OperationName
+}
+
+// Marshal returns the json encoding of the operation definition.
+func (d *DeleteSchedulerDefinition) Marshal() []byte {
+	bytes, err := json.Marshal(d)
+	if err != nil {
+		zap.L().With(zap.Error(err)).Error("error marshalling update scheduler operation definition")
+		return nil
+	}
+
+	return bytes
+}
+
+// Unmarshal decodes the provided bytes array using definition struct.
+func (d *DeleteSchedulerDefinition) Unmarshal(raw []byte) error {
+	err := json.Unmarshal(raw, d)
+	if err != nil {
+		return fmt.Errorf("error marshalling update scheduler operation definition: %w", err)
+	}
+
+	return nil
+}

--- a/internal/core/operations/deletescheduler/delete_scheduler_executor.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_executor.go
@@ -1,0 +1,63 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deletescheduler
+
+import (
+	"context"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/logs"
+	"github.com/topfreegames/maestro/internal/core/operations"
+	"go.uber.org/zap"
+)
+
+type DeleteSchedulerExecutor struct {
+}
+
+var _ operations.Executor = (*DeleteSchedulerExecutor)(nil)
+
+func NewExecutor() *DeleteSchedulerExecutor {
+	return &DeleteSchedulerExecutor{}
+}
+
+// Execute deletes the scheduler, cleaning all bounded resources in the runtime and on storages.
+func (e *DeleteSchedulerExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) operations.ExecutionError {
+	_ = zap.L().With(
+		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
+		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
+		zap.String(logs.LogFieldOperationPhase, "Execute"),
+		zap.String(logs.LogFieldOperationID, op.ID),
+	)
+
+	return nil
+}
+
+// Rollback does nothing.
+func (e *DeleteSchedulerExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr operations.ExecutionError) error {
+	return nil
+}
+
+// Name returns the name of the Operation.
+func (e *DeleteSchedulerExecutor) Name() string {
+	return OperationName
+}

--- a/internal/core/operations/healthcontroller/health_controller_executor.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor.go
@@ -77,7 +77,7 @@ func (ex *SchedulerHealthControllerExecutor) Execute(ctx context.Context, op *op
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "Execute"),
+		zap.String(logs.LogFieldOperationPhase, "Execute"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -78,7 +78,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Execute(ctx context.Context, op *op
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "Execute"),
+		zap.String(logs.LogFieldOperationPhase, "Execute"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 	opDef, ok := definition.(*CreateNewSchedulerVersionDefinition)
@@ -123,7 +123,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Rollback(ctx context.Context, op *o
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "Rollback"),
+		zap.String(logs.LogFieldOperationPhase, "Rollback"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 	if gameRoom, ok := ex.validationRoomIdsMap[op.SchedulerName]; ok {

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/topfreegames/maestro/internal/core/operations"
 	"github.com/topfreegames/maestro/internal/core/operations/add_rooms"
 	"github.com/topfreegames/maestro/internal/core/operations/create_scheduler"
+	"github.com/topfreegames/maestro/internal/core/operations/deletescheduler"
 	"github.com/topfreegames/maestro/internal/core/operations/healthcontroller"
 	"github.com/topfreegames/maestro/internal/core/operations/newschedulerversion"
 	"github.com/topfreegames/maestro/internal/core/operations/remove_rooms"
@@ -61,6 +62,9 @@ func ProvideDefinitionConstructors() map[string]operations.DefinitionConstructor
 	definitionConstructors[healthcontroller.OperationName] = func() operations.Definition {
 		return &healthcontroller.SchedulerHealthControllerDefinition{}
 	}
+	definitionConstructors[deletescheduler.OperationName] = func() operations.Definition {
+		return &deletescheduler.DeleteSchedulerDefinition{}
+	}
 
 	return definitionConstructors
 
@@ -88,6 +92,7 @@ func ProvideExecutors(
 	executors[switch_active_version.OperationName] = switch_active_version.NewExecutor(roomManager, schedulerManager, operationManager, roomStorage)
 	executors[newschedulerversion.OperationName] = newschedulerversion.NewExecutor(roomManager, schedulerManager, operationManager, newSchedulerVersionConfig)
 	executors[healthcontroller.OperationName] = healthcontroller.NewExecutor(roomStorage, instanceStorage, schedulerStorage, operationManager, autoscaler, healthControllerConfig)
+	executors[deletescheduler.OperationName] = deletescheduler.NewExecutor()
 
 	return executors
 

--- a/internal/core/ports/mock/scheduler_ports_mock.go
+++ b/internal/core/ports/mock/scheduler_ports_mock.go
@@ -238,17 +238,17 @@ func (mr *MockSchedulerStorageMockRecorder) CreateSchedulerVersion(ctx, transact
 }
 
 // DeleteScheduler mocks base method.
-func (m *MockSchedulerStorage) DeleteScheduler(ctx context.Context, scheduler *entities.Scheduler) error {
+func (m *MockSchedulerStorage) DeleteScheduler(ctx context.Context, transactionID ports.TransactionID, scheduler *entities.Scheduler) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteScheduler", ctx, scheduler)
+	ret := m.ctrl.Call(m, "DeleteScheduler", ctx, transactionID, scheduler)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteScheduler indicates an expected call of DeleteScheduler.
-func (mr *MockSchedulerStorageMockRecorder) DeleteScheduler(ctx, scheduler interface{}) *gomock.Call {
+func (mr *MockSchedulerStorageMockRecorder) DeleteScheduler(ctx, transactionID, scheduler interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScheduler", reflect.TypeOf((*MockSchedulerStorage)(nil).DeleteScheduler), ctx, scheduler)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScheduler", reflect.TypeOf((*MockSchedulerStorage)(nil).DeleteScheduler), ctx, transactionID, scheduler)
 }
 
 // GetAllSchedulers mocks base method.

--- a/internal/core/ports/scheduler_ports.go
+++ b/internal/core/ports/scheduler_ports.go
@@ -57,7 +57,7 @@ type SchedulerStorage interface {
 	GetAllSchedulers(ctx context.Context) ([]*entities.Scheduler, error)
 	CreateScheduler(ctx context.Context, scheduler *entities.Scheduler) error
 	UpdateScheduler(ctx context.Context, scheduler *entities.Scheduler) error
-	DeleteScheduler(ctx context.Context, scheduler *entities.Scheduler) error
+	DeleteScheduler(ctx context.Context, transactionID TransactionID, scheduler *entities.Scheduler) error
 	CreateSchedulerVersion(ctx context.Context, transactionID TransactionID, scheduler *entities.Scheduler) error
 	RunWithTransaction(ctx context.Context, transactionFunc func(transactionId TransactionID) error) error
 }

--- a/internal/core/services/scheduler_manager/scheduler_manager.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager.go
@@ -296,7 +296,7 @@ func (s *SchedulerManager) DeleteScheduler(ctx context.Context, schedulerName st
 		return fmt.Errorf("no scheduler found to delete: %w", err)
 	}
 
-	err = s.schedulerStorage.DeleteScheduler(ctx, scheduler)
+	err = s.schedulerStorage.DeleteScheduler(ctx, "", scheduler)
 	if err != nil {
 		return fmt.Errorf("not able to delete scheduler %s: %w", schedulerName, err)
 	}

--- a/internal/core/services/scheduler_manager/scheduler_manager_test.go
+++ b/internal/core/services/scheduler_manager/scheduler_manager_test.go
@@ -831,7 +831,7 @@ func TestDeleteScheduler(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerName).Return(scheduler, nil)
-		schedulerStorage.EXPECT().DeleteScheduler(gomock.Any(), scheduler).Return(nil)
+		schedulerStorage.EXPECT().DeleteScheduler(gomock.Any(), ports.TransactionID(""), scheduler).Return(nil)
 
 		err := schedulerManager.DeleteScheduler(ctx, schedulerName)
 
@@ -859,7 +859,7 @@ func TestDeleteScheduler(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		schedulerManager := NewSchedulerManager(schedulerStorage, nil, nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerName).Return(scheduler, nil)
-		schedulerStorage.EXPECT().DeleteScheduler(gomock.Any(), scheduler).Return(errors.NewErrUnexpected("err"))
+		schedulerStorage.EXPECT().DeleteScheduler(gomock.Any(), ports.TransactionID(""), scheduler).Return(errors.NewErrUnexpected("err"))
 
 		err := schedulerManager.DeleteScheduler(ctx, schedulerName)
 


### PR DESCRIPTION
### What ❓ 
Add transactionID argument to scheduler storage DeleteScheduler method.

### Why 🤔 
This will enable us to use the DeleteScheduler method within a transactional context.