### PR TITLE
Feature/create clean operation history method

### DIFF
--- a/internal/adapters/operation/operation_storage_redis.go
+++ b/internal/adapters/operation/operation_storage_redis.go
@@ -271,11 +271,11 @@ func (r *redisOperationStorage) CleanOperationsHistory(ctx context.Context, sche
 		return err
 	}
 
-	operationIDsKeys := make([]string, len(operationsIDs))
-	for i, operationID := range operationsIDs {
-		operationIDsKeys[i] = r.buildSchedulerOperationKey(schedulerName, operationID)
-	}
-	if len(operationIDsKeys) > 0 {
+	if len(operationsIDs) > 0 {
+		operationIDsKeys := make([]string, len(operationsIDs))
+		for i, operationID := range operationsIDs {
+			operationIDsKeys[i] = r.buildSchedulerOperationKey(schedulerName, operationID)
+		}
 		pipe := r.client.Pipeline()
 		pipe.Del(ctx, r.buildSchedulerHistoryOperationsKey(schedulerName))
 		pipe.Del(ctx, operationIDsKeys...)

--- a/internal/adapters/operation/operation_storage_redis.go
+++ b/internal/adapters/operation/operation_storage_redis.go
@@ -271,9 +271,9 @@ func (r *redisOperationStorage) CleanOperationsHistory(ctx context.Context, sche
 		return err
 	}
 
-	var operationIDsKeys []string
-	for _, operationID := range operationsIDs {
-		operationIDsKeys = append(operationIDsKeys, r.buildSchedulerOperationKey(schedulerName, operationID))
+	operationIDsKeys := make([]string, len(operationsIDs))
+	for i, operationID := range operationsIDs {
+		operationIDsKeys[i] = r.buildSchedulerOperationKey(schedulerName, operationID)
 	}
 	if len(operationIDsKeys) > 0 {
 		pipe := r.client.Pipeline()

--- a/internal/core/logs/logs.go
+++ b/internal/core/logs/logs.go
@@ -33,4 +33,5 @@ const (
 	LogFieldServiceName         = "service_name"
 	LogFieldExecutorName        = "executor_name"
 	LogFieldHandlerName         = "handler_name"
+	LogFieldOperationPhase      = "operation_phase"
 )

--- a/internal/core/operations/create_scheduler/create_scheduler_executor.go
+++ b/internal/core/operations/create_scheduler/create_scheduler_executor.go
@@ -52,7 +52,7 @@ func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op *operation.Ope
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "Execute"),
+		zap.String(logs.LogFieldOperationPhase, "Execute"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 
@@ -70,7 +70,7 @@ func (e *CreateSchedulerExecutor) Rollback(ctx context.Context, op *operation.Op
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "Rollback"),
+		zap.String(logs.LogFieldOperationPhase, "Rollback"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 

--- a/internal/core/operations/deletescheduler/delete_scheduler_definition.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_definition.go
@@ -1,0 +1,69 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deletescheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"go.uber.org/zap"
+)
+
+const OperationName = "delete_scheduler"
+
+type DeleteSchedulerDefinition struct {
+	SchedulerName string `json:"schedulerName"`
+}
+
+// ShouldExecute always return true, we're going to always perform the scheduler deletion when requested.
+func (d *DeleteSchedulerDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
+	return true
+}
+
+// Name returns the scheduler name.
+func (d *DeleteSchedulerDefinition) Name() string {
+	return OperationName
+}
+
+// Marshal returns the json encoding of the operation definition.
+func (d *DeleteSchedulerDefinition) Marshal() []byte {
+	bytes, err := json.Marshal(d)
+	if err != nil {
+		zap.L().With(zap.Error(err)).Error("error marshalling update scheduler operation definition")
+		return nil
+	}
+
+	return bytes
+}
+
+// Unmarshal decodes the provided bytes array using definition struct.
+func (d *DeleteSchedulerDefinition) Unmarshal(raw []byte) error {
+	err := json.Unmarshal(raw, d)
+	if err != nil {
+		return fmt.Errorf("error marshalling update scheduler operation definition: %w", err)
+	}
+
+	return nil
+}

--- a/internal/core/operations/deletescheduler/delete_scheduler_executor.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_executor.go
@@ -1,0 +1,63 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deletescheduler
+
+import (
+	"context"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/logs"
+	"github.com/topfreegames/maestro/internal/core/operations"
+	"go.uber.org/zap"
+)
+
+type DeleteSchedulerExecutor struct {
+}
+
+var _ operations.Executor = (*DeleteSchedulerExecutor)(nil)
+
+func NewExecutor() *DeleteSchedulerExecutor {
+	return &DeleteSchedulerExecutor{}
+}
+
+// Execute deletes the scheduler, cleaning all bounded resources in the runtime and on storages.
+func (e *DeleteSchedulerExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) operations.ExecutionError {
+	_ = zap.L().With(
+		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
+		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
+		zap.String(logs.LogFieldOperationPhase, "Execute"),
+		zap.String(logs.LogFieldOperationID, op.ID),
+	)
+
+	return nil
+}
+
+// Rollback does nothing.
+func (e *DeleteSchedulerExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr operations.ExecutionError) error {
+	return nil
+}
+
+// Name returns the name of the Operation.
+func (e *DeleteSchedulerExecutor) Name() string {
+	return OperationName
+}

--- a/internal/core/operations/healthcontroller/health_controller_executor.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor.go
@@ -77,7 +77,7 @@ func (ex *SchedulerHealthControllerExecutor) Execute(ctx context.Context, op *op
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "Execute"),
+		zap.String(logs.LogFieldOperationPhase, "Execute"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -78,7 +78,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Execute(ctx context.Context, op *op
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "Execute"),
+		zap.String(logs.LogFieldOperationPhase, "Execute"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 	opDef, ok := definition.(*CreateNewSchedulerVersionDefinition)
@@ -123,7 +123,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Rollback(ctx context.Context, op *o
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
-		zap.String("operation_phase", "Rollback"),
+		zap.String(logs.LogFieldOperationPhase, "Rollback"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 	if gameRoom, ok := ex.validationRoomIdsMap[op.SchedulerName]; ok {

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/topfreegames/maestro/internal/core/operations"
 	"github.com/topfreegames/maestro/internal/core/operations/add_rooms"
 	"github.com/topfreegames/maestro/internal/core/operations/create_scheduler"
+	"github.com/topfreegames/maestro/internal/core/operations/deletescheduler"
 	"github.com/topfreegames/maestro/internal/core/operations/healthcontroller"
 	"github.com/topfreegames/maestro/internal/core/operations/newschedulerversion"
 	"github.com/topfreegames/maestro/internal/core/operations/remove_rooms"
@@ -61,6 +62,9 @@ func ProvideDefinitionConstructors() map[string]operations.DefinitionConstructor
 	definitionConstructors[healthcontroller.OperationName] = func() operations.Definition {
 		return &healthcontroller.SchedulerHealthControllerDefinition{}
 	}
+	definitionConstructors[deletescheduler.OperationName] = func() operations.Definition {
+		return &deletescheduler.DeleteSchedulerDefinition{}
+	}
 
 	return definitionConstructors
 
@@ -88,6 +92,7 @@ func ProvideExecutors(
 	executors[switch_active_version.OperationName] = switch_active_version.NewExecutor(roomManager, schedulerManager, operationManager, roomStorage)
 	executors[newschedulerversion.OperationName] = newschedulerversion.NewExecutor(roomManager, schedulerManager, operationManager, newSchedulerVersionConfig)
 	executors[healthcontroller.OperationName] = healthcontroller.NewExecutor(roomStorage, instanceStorage, schedulerStorage, operationManager, autoscaler, healthControllerConfig)
+	executors[deletescheduler.OperationName] = deletescheduler.NewExecutor()
 
 	return executors
 

--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -397,6 +397,20 @@ func (m *MockOperationStorage) EXPECT() *MockOperationStorageMockRecorder {
 	return m.recorder
 }
 
+// CleanOperationsHistory mocks base method.
+func (m *MockOperationStorage) CleanOperationsHistory(ctx context.Context, schedulerName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanOperationsHistory", ctx, schedulerName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanOperationsHistory indicates an expected call of CleanOperationsHistory.
+func (mr *MockOperationStorageMockRecorder) CleanOperationsHistory(ctx, schedulerName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanOperationsHistory", reflect.TypeOf((*MockOperationStorage)(nil).CleanOperationsHistory), ctx, schedulerName)
+}
+
 // CreateOperation mocks base method.
 func (m *MockOperationStorage) CreateOperation(ctx context.Context, operation *operation.Operation) error {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -96,8 +96,10 @@ type OperationStorage interface {
 	// UpdateOperationStatus only updates the operation status for the given
 	// operation ID.
 	UpdateOperationStatus(ctx context.Context, schedulerName, operationID string, status operation.Status) error
-	// UpdateOperationExecutionHistory updates the operation execution history
+	// UpdateOperationExecutionHistory updates the operation execution history.
 	UpdateOperationExecutionHistory(ctx context.Context, op *operation.Operation) error
+	// CleanOperationsHistory clears the operation execution history.
+	CleanOperationsHistory(ctx context.Context, schedulerName string) error
 }
 
 type OperationLeaseStorage interface {


### PR DESCRIPTION
### What ❓
Create **CleanOperationsHistory** method in operation storage port and adapter, including unitary tests.

### Why 🤔 
This will be one of the steps that our delete scheduler logic flow will take: clean all the operations history, including the history sorted set and each operation hash key.