### PR TITLE
Feature/implement delete scheduler op executor

### DIFF
--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -81,7 +81,7 @@ func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_
 	autoscaler := service.NewAutoscaler(policyMap)
 	newschedulerversionConfig := service.NewCreateSchedulerVersionConfig(c)
 	healthcontrollerConfig := service.NewHealthControllerConfig(c)
-	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager, roomStorage, schedulerManager, gameRoomInstanceStorage, operationManager, autoscaler, newschedulerversionConfig, healthcontrollerConfig)
+	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager, roomStorage, schedulerManager, gameRoomInstanceStorage, schedulerCache, operationStorage, operationManager, autoscaler, newschedulerversionConfig, healthcontrollerConfig)
 	configuration, err := service.NewWorkersConfig(c)
 	if err != nil {
 		return nil, err

--- a/internal/adapters/scheduler/scheduler_storage_pg.go
+++ b/internal/adapters/scheduler/scheduler_storage_pg.go
@@ -337,7 +337,7 @@ func (s schedulerStorage) DeleteScheduler(ctx context.Context, transactionID por
 			return errors.NewErrNotFound("transaction %s not found", transactionID)
 		}
 		runSchedulerStorageFunctionCollectingLatency("DeleteScheduler", func() {
-			_, err = txClient.ExecOne(queryDeleteScheduler, scheduler.Name)
+			_, err = txClient.Exec(queryDeleteScheduler, scheduler.Name)
 		})
 
 	} else {

--- a/internal/core/operations/deletescheduler/delete_scheduler_definition.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_definition.go
@@ -33,9 +33,7 @@ import (
 
 const OperationName = "delete_scheduler"
 
-type DeleteSchedulerDefinition struct {
-	SchedulerName string `json:"schedulerName"`
-}
+type DeleteSchedulerDefinition struct{}
 
 // ShouldExecute always return true, we're going to always perform the scheduler deletion when requested.
 func (d *DeleteSchedulerDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {

--- a/internal/core/operations/deletescheduler/delete_scheduler_executor.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_executor.go
@@ -129,9 +129,6 @@ func (e *DeleteSchedulerExecutor) Name() string {
 }
 
 func (e *DeleteSchedulerExecutor) waitForAllInstancesToBeDeleted(ctx context.Context, scheduler *entities.Scheduler, logger *zap.Logger) error {
-	ticker := time.NewTicker(time.Millisecond * 100)
-	defer ticker.Stop()
-
 	instancesCount, err := e.instanceStorage.GetInstanceCount(ctx, scheduler.Name)
 	if err != nil {
 		logger.Error("failed to get instance count", zap.Error(err))
@@ -145,6 +142,9 @@ func (e *DeleteSchedulerExecutor) waitForAllInstancesToBeDeleted(ctx context.Con
 		terminationGracePeriodSeconds = v1.DefaultTerminationGracePeriodSeconds
 	}
 	schedulerDeletionTimeout := time.Duration(terminationGracePeriodSeconds*instancesCount) * time.Second
+
+	ticker := time.NewTicker(time.Duration(terminationGracePeriodSeconds) * time.Second)
+	defer ticker.Stop()
 
 	timeoutContext, cancelFunc := context.WithTimeout(ctx, schedulerDeletionTimeout)
 	defer cancelFunc()

--- a/internal/core/operations/deletescheduler/delete_scheduler_executor.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_executor.go
@@ -24,8 +24,9 @@ package deletescheduler
 
 import (
 	"context"
-	v1 "k8s.io/api/core/v1"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/ports"
@@ -71,10 +72,11 @@ func (e *DeleteSchedulerExecutor) Execute(ctx context.Context, op *operation.Ope
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 	schedulerName := definition.(*DeleteSchedulerDefinition).SchedulerName
-	scheduler, err := e.schedulerCache.GetScheduler(ctx, schedulerName)
+
+	scheduler, err := e.getScheduler(ctx, schedulerName)
 
 	if err != nil {
-		logger.Error("failed to get scheduler from cache", zap.Error(err))
+		logger.Error("failed to get scheduler", zap.Error(err))
 		return operations.NewErrUnexpected(err)
 	}
 
@@ -161,4 +163,16 @@ func (e *DeleteSchedulerExecutor) waitForAllInstancesToBeDeleted(ctx context.Con
 		}
 	}
 	return nil
+}
+
+func (e *DeleteSchedulerExecutor) getScheduler(ctx context.Context, schedulerName string) (*entities.Scheduler, error) {
+	scheduler, err := e.schedulerCache.GetScheduler(ctx, schedulerName)
+	if err != nil {
+		scheduler, err = e.schedulerStorage.GetScheduler(ctx, schedulerName)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return scheduler, nil
+
 }

--- a/internal/core/operations/deletescheduler/delete_scheduler_executor.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_executor.go
@@ -136,6 +136,8 @@ func (e *DeleteSchedulerExecutor) waitForAllInstancesToBeDeleted(ctx context.Con
 		return err
 	}
 
+	// TODO: the TerminationGracePeriod field should have validation enforcing it to be a positive number, or have
+	// the default value we are using here.
 	terminationGracePeriodSeconds := int(scheduler.Spec.TerminationGracePeriod.Seconds())
 	if terminationGracePeriodSeconds == 0 {
 		terminationGracePeriodSeconds = v1.DefaultTerminationGracePeriodSeconds

--- a/internal/core/operations/deletescheduler/delete_scheduler_executor.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_executor.go
@@ -75,7 +75,7 @@ func (e *DeleteSchedulerExecutor) Execute(ctx context.Context, op *operation.Ope
 		zap.String(logs.LogFieldOperationPhase, "Execute"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
-	schedulerName := definition.(*DeleteSchedulerDefinition).SchedulerName
+	schedulerName := op.SchedulerName
 
 	scheduler, err := e.getScheduler(ctx, schedulerName)
 
@@ -134,9 +134,13 @@ func (e *DeleteSchedulerExecutor) Name() string {
 
 func (e *DeleteSchedulerExecutor) waitForAllInstancesToBeDeleted(ctx context.Context, op *operation.Operation, scheduler *entities.Scheduler, logger *zap.Logger) error {
 	instancesCount, err := e.instanceStorage.GetInstanceCount(ctx, scheduler.Name)
+
 	if err != nil {
 		logger.Error("failed to get instance count", zap.Error(err))
 		return err
+	}
+	if instancesCount == 0 {
+		return nil
 	}
 
 	// TODO: the TerminationGracePeriod field should have validation enforcing it to be a positive number, or have

--- a/internal/core/operations/deletescheduler/delete_scheduler_executor_test.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_executor_test.go
@@ -1,0 +1,309 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deletescheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	instancemock "github.com/topfreegames/maestro/internal/adapters/instance_storage/mock"
+	runtimemock "github.com/topfreegames/maestro/internal/adapters/runtime/mock"
+	"github.com/topfreegames/maestro/internal/core/entities"
+	"github.com/topfreegames/maestro/internal/core/entities/game_room"
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/operations"
+	"github.com/topfreegames/maestro/internal/core/ports"
+	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
+)
+
+func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
+	scheduler := &entities.Scheduler{
+		Name: "schedulerTest",
+		Spec: game_room.Spec{
+			TerminationGracePeriod: 100 * time.Millisecond,
+		},
+	}
+
+	t.Run("returns no error", func(t *testing.T) {
+		t.Run("when no internal error occurs with 0 running instances", func(t *testing.T) {
+			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, runtime := prepareMocks(t)
+			ctx := context.Background()
+
+			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
+			op := &operation.Operation{}
+
+			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
+			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, f func(transactionId ports.TransactionID) error) error {
+					return f("transactionID")
+				})
+			schedulerStorage.EXPECT().DeleteScheduler(ctx, ports.TransactionID("transactionID"), scheduler)
+			runtime.EXPECT().DeleteScheduler(ctx, scheduler)
+
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(0, nil)
+			schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name)
+			operationStorage.EXPECT().CleanOperationsHistory(ctx, scheduler.Name)
+
+			err := executor.Execute(ctx, op, definition)
+
+			require.Nil(t, err)
+		})
+
+		t.Run("when no internal error occurs with 20 running instances", func(t *testing.T) {
+			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, runtime := prepareMocks(t)
+			ctx := context.Background()
+
+			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
+			op := &operation.Operation{}
+
+			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
+			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, f func(transactionId ports.TransactionID) error) error {
+					return f("transactionID")
+				})
+			schedulerStorage.EXPECT().DeleteScheduler(ctx, ports.TransactionID("transactionID"), scheduler)
+			runtime.EXPECT().DeleteScheduler(ctx, scheduler)
+
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(20, nil).Times(1)
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(15, nil).Times(1)
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(10, nil).Times(1)
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(5, nil).Times(1)
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(0, nil).Times(1)
+
+			schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name)
+			operationStorage.EXPECT().CleanOperationsHistory(ctx, scheduler.Name)
+
+			err := executor.Execute(ctx, op, definition)
+
+			require.Nil(t, err)
+		})
+
+		t.Run("when it fails to wait for all instances to be deleted error", func(t *testing.T) {
+			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, runtime := prepareMocks(t)
+			ctx := context.Background()
+
+			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
+			op := &operation.Operation{}
+
+			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
+			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, f func(transactionId ports.TransactionID) error) error {
+					return f("transactionID")
+				})
+			schedulerStorage.EXPECT().DeleteScheduler(ctx, ports.TransactionID("transactionID"), scheduler)
+			runtime.EXPECT().DeleteScheduler(ctx, scheduler)
+
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(0, errors.New("some error instance storage"))
+			schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name)
+			operationStorage.EXPECT().CleanOperationsHistory(ctx, scheduler.Name)
+
+			err := executor.Execute(ctx, op, definition)
+
+			require.Nil(t, err)
+		})
+
+		t.Run("when it fails to delete scheduler from cache", func(t *testing.T) {
+			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, runtime := prepareMocks(t)
+			ctx := context.Background()
+
+			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
+			op := &operation.Operation{}
+
+			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
+			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, f func(transactionId ports.TransactionID) error) error {
+					return f("transactionID")
+				})
+			schedulerStorage.EXPECT().DeleteScheduler(ctx, ports.TransactionID("transactionID"), scheduler)
+			runtime.EXPECT().DeleteScheduler(ctx, scheduler)
+
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(0, nil)
+			schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name).Return(errors.New("failed to delete scheduler from cache"))
+			operationStorage.EXPECT().CleanOperationsHistory(ctx, scheduler.Name)
+
+			err := executor.Execute(ctx, op, definition)
+
+			require.Nil(t, err)
+		})
+
+		t.Run("when it fails to clean operations history", func(t *testing.T) {
+			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, runtime := prepareMocks(t)
+			ctx := context.Background()
+
+			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
+			op := &operation.Operation{}
+
+			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
+			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, f func(transactionId ports.TransactionID) error) error {
+					return f("transactionID")
+				})
+			schedulerStorage.EXPECT().DeleteScheduler(ctx, ports.TransactionID("transactionID"), scheduler)
+			runtime.EXPECT().DeleteScheduler(ctx, scheduler)
+
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(0, nil)
+			schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name)
+			operationStorage.EXPECT().CleanOperationsHistory(ctx, scheduler.Name).Return(errors.New("failed to clean operations history"))
+
+			err := executor.Execute(ctx, op, definition)
+
+			require.Nil(t, err)
+		})
+
+		t.Run("when some error occurs when waiting for instances to be deleted", func(t *testing.T) {
+			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, runtime := prepareMocks(t)
+			ctx := context.Background()
+
+			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
+			op := &operation.Operation{}
+
+			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
+			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, f func(transactionId ports.TransactionID) error) error {
+					return f("transactionID")
+				})
+			schedulerStorage.EXPECT().DeleteScheduler(ctx, ports.TransactionID("transactionID"), scheduler)
+			runtime.EXPECT().DeleteScheduler(ctx, scheduler)
+
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(10, nil)
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(0, errors.New("some error"))
+
+			schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name)
+			operationStorage.EXPECT().CleanOperationsHistory(ctx, scheduler.Name)
+
+			err := executor.Execute(ctx, op, definition)
+
+			require.Nil(t, err)
+		})
+
+		t.Run("when timeout waiting for instances to be deleted", func(t *testing.T) {
+			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, runtime := prepareMocks(t)
+			ctx := context.Background()
+
+			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
+			op := &operation.Operation{}
+
+			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
+			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, f func(transactionId ports.TransactionID) error) error {
+					return f("transactionID")
+				})
+			schedulerStorage.EXPECT().DeleteScheduler(ctx, ports.TransactionID("transactionID"), scheduler)
+			runtime.EXPECT().DeleteScheduler(ctx, scheduler)
+
+			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(1, nil).AnyTimes()
+
+			schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name)
+			operationStorage.EXPECT().CleanOperationsHistory(ctx, scheduler.Name)
+
+			err := executor.Execute(ctx, op, definition)
+
+			require.Nil(t, err)
+		})
+	})
+
+	t.Run("returns error", func(t *testing.T) {
+		t.Run("when it fails to load the scheduler from cache the first time", func(t *testing.T) {
+			executor, _, schedulerCache, _, _, _ := prepareMocks(t)
+			ctx := context.Background()
+
+			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
+			op := &operation.Operation{}
+
+			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(nil, errors.New("some error on cache"))
+
+			err := executor.Execute(ctx, op, definition)
+
+			require.Equal(t, operations.NewErrUnexpected(errors.New("some error on cache")), err)
+		})
+
+		t.Run("when it fails to delete scheduler in storage", func(t *testing.T) {
+			executor, schedulerStorage, schedulerCache, _, _, _ := prepareMocks(t)
+			ctx := context.Background()
+
+			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
+			op := &operation.Operation{}
+
+			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
+			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, f func(transactionId ports.TransactionID) error) error {
+					return f("transactionID")
+				})
+			schedulerStorage.EXPECT().DeleteScheduler(ctx, ports.TransactionID("transactionID"), scheduler).
+				Return(errors.New("some error on storage"))
+
+			err := executor.Execute(ctx, op, definition)
+			require.Equal(t, operations.NewErrUnexpected(errors.New("some error on storage")), err)
+		})
+
+		t.Run("when it fails to delete scheduler in runtime", func(t *testing.T) {
+			executor, schedulerStorage, schedulerCache, _, _, runtime := prepareMocks(t)
+
+			ctx := context.Background()
+
+			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
+			op := &operation.Operation{}
+
+			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
+			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
+				DoAndReturn(func(ctx context.Context, f func(transactionId ports.TransactionID) error) error {
+					return f("transactionID")
+				})
+			schedulerStorage.EXPECT().DeleteScheduler(ctx, ports.TransactionID("transactionID"), scheduler)
+			runtime.EXPECT().DeleteScheduler(ctx, scheduler).Return(errors.New("some error on runtime"))
+
+			err := executor.Execute(ctx, op, definition)
+			require.Equal(t, operations.NewErrUnexpected(errors.New("some error on runtime")), err)
+		})
+	})
+}
+
+func prepareMocks(t *testing.T) (
+	*DeleteSchedulerExecutor,
+	*mockports.MockSchedulerStorage,
+	*mockports.MockSchedulerCache,
+	*instancemock.MockGameRoomInstanceStorage,
+	*mockports.MockOperationStorage,
+	*runtimemock.MockRuntime,
+) {
+	mockCtrl := gomock.NewController(t)
+	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+	schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
+	instanceStorage := instancemock.NewMockGameRoomInstanceStorage(mockCtrl)
+	operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+	runtime := runtimemock.NewMockRuntime(mockCtrl)
+
+	op := NewExecutor(
+		schedulerStorage,
+		schedulerCache,
+		instanceStorage,
+		operationStorage,
+		runtime,
+	)
+
+	return op, schedulerStorage, schedulerCache, instanceStorage, operationStorage, runtime
+}

--- a/internal/core/operations/deletescheduler/delete_scheduler_executor_test.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_executor_test.go
@@ -25,7 +25,6 @@ package deletescheduler
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -92,8 +91,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(20, nil).Times(1)
 			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(10, nil).Times(1)
 			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(0, nil).Times(1)
-			operationManager.EXPECT().AppendOperationEventToExecutionHistory(ctx, op, fmt.Sprintf("Waiting for instances to be deleted: 10")).Times(1)
-			operationManager.EXPECT().AppendOperationEventToExecutionHistory(ctx, op, fmt.Sprintf("Waiting for instances to be deleted: 0")).Times(1)
+			operationManager.EXPECT().AppendOperationEventToExecutionHistory(ctx, op, "Waiting for instances to be deleted: 10").Times(1)
+			operationManager.EXPECT().AppendOperationEventToExecutionHistory(ctx, op, "Waiting for instances to be deleted: 0").Times(1)
 
 			schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name)
 			operationStorage.EXPECT().CleanOperationsHistory(ctx, scheduler.Name)
@@ -242,7 +241,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			runtime.EXPECT().DeleteScheduler(ctx, scheduler)
 
 			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(1, nil).AnyTimes()
-			operationManager.EXPECT().AppendOperationEventToExecutionHistory(ctx, op, fmt.Sprintf("Waiting for instances to be deleted: 1")).AnyTimes()
+			operationManager.EXPECT().AppendOperationEventToExecutionHistory(ctx, op, "Waiting for instances to be deleted: 1").AnyTimes()
 
 			schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name)
 			operationStorage.EXPECT().CleanOperationsHistory(ctx, scheduler.Name)

--- a/internal/core/operations/deletescheduler/delete_scheduler_executor_test.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_executor_test.go
@@ -53,8 +53,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
@@ -77,8 +77,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, operationManager, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
@@ -106,8 +106,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, errors.New("error getting scheduler from cache"))
 			schedulerStorage.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -131,8 +131,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
@@ -155,8 +155,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
@@ -179,8 +179,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
@@ -203,8 +203,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
@@ -229,8 +229,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, operationManager, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
@@ -257,8 +257,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, _, _, _, _ := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(nil, errors.New("some error on cache"))
 			schedulerStorage.EXPECT().GetScheduler(ctx, scheduler.Name).Return(nil, errors.New("some error on storage"))
@@ -272,8 +272,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, _, _, _, _ := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).
@@ -292,8 +292,8 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{SchedulerName: scheduler.Name}
-			op := &operation.Operation{}
+			definition := &DeleteSchedulerDefinition{}
+			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
 			schedulerStorage.EXPECT().RunWithTransaction(ctx, gomock.Any()).

--- a/internal/core/operations/deletescheduler/delete_scheduler_executor_test.go
+++ b/internal/core/operations/deletescheduler/delete_scheduler_executor_test.go
@@ -44,7 +44,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 	scheduler := &entities.Scheduler{
 		Name: "schedulerTest",
 		Spec: game_room.Spec{
-			TerminationGracePeriod: 100 * time.Millisecond,
+			TerminationGracePeriod: 5 * time.Second,
 		},
 	}
 
@@ -89,9 +89,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			runtime.EXPECT().DeleteScheduler(ctx, scheduler)
 
 			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(20, nil).Times(1)
-			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(15, nil).Times(1)
 			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(10, nil).Times(1)
-			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(5, nil).Times(1)
 			instanceStorage.EXPECT().GetInstanceCount(ctx, scheduler.Name).Return(0, nil).Times(1)
 
 			schedulerCache.EXPECT().DeleteScheduler(ctx, scheduler.Name)

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -78,6 +78,8 @@ func ProvideExecutors(
 	roomStorage ports.RoomStorage,
 	schedulerManager *scheduler_manager.SchedulerManager,
 	instanceStorage ports.GameRoomInstanceStorage,
+	schedulerCache ports.SchedulerCache,
+	operationStorage ports.OperationStorage,
 	operationManager ports.OperationManager,
 	autoscaler autoscaler.Autoscaler,
 	newSchedulerVersionConfig newschedulerversion.Config,
@@ -92,7 +94,7 @@ func ProvideExecutors(
 	executors[switch_active_version.OperationName] = switch_active_version.NewExecutor(roomManager, schedulerManager, operationManager, roomStorage)
 	executors[newschedulerversion.OperationName] = newschedulerversion.NewExecutor(roomManager, schedulerManager, operationManager, newSchedulerVersionConfig)
 	executors[healthcontroller.OperationName] = healthcontroller.NewExecutor(roomStorage, instanceStorage, schedulerStorage, operationManager, autoscaler, healthControllerConfig)
-	executors[deletescheduler.OperationName] = deletescheduler.NewExecutor()
+	executors[deletescheduler.OperationName] = deletescheduler.NewExecutor(schedulerStorage, schedulerCache, instanceStorage, operationStorage, runtime)
 
 	return executors
 

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -94,7 +94,7 @@ func ProvideExecutors(
 	executors[switch_active_version.OperationName] = switch_active_version.NewExecutor(roomManager, schedulerManager, operationManager, roomStorage)
 	executors[newschedulerversion.OperationName] = newschedulerversion.NewExecutor(roomManager, schedulerManager, operationManager, newSchedulerVersionConfig)
 	executors[healthcontroller.OperationName] = healthcontroller.NewExecutor(roomStorage, instanceStorage, schedulerStorage, operationManager, autoscaler, healthControllerConfig)
-	executors[deletescheduler.OperationName] = deletescheduler.NewExecutor(schedulerStorage, schedulerCache, instanceStorage, operationStorage, runtime)
+	executors[deletescheduler.OperationName] = deletescheduler.NewExecutor(schedulerStorage, schedulerCache, instanceStorage, operationStorage, operationManager, runtime)
 
 	return executors
 

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -125,6 +125,7 @@ func (om *OperationManager) PendingOperationsChan(ctx context.Context, scheduler
 		for {
 			operationID, err := om.Flow.NextOperationID(ctx, schedulerName)
 			if err != nil {
+				om.Logger.Error("failed to get next operation ID", zap.Error(err), zap.String(logs.LogFieldSchedulerName, schedulerName))
 				return
 			}
 			opsChan <- operationID


### PR DESCRIPTION
### What ❓ 
Implement delete scheduler operation executor logic, including unitary tests and a little fix on scheduler storage DeleteScheduler method.

### Why 🤔 
To enable users to delete a scheduler by enqueueing a operation that has the core logic implemented.