### PR TITLE
fix logic that makes it harder for maestro to scale up on a high load

### DIFF
--- a/internal/core/operations/healthcontroller/health_controller_executor.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor.go
@@ -86,15 +86,13 @@ func (ex *SchedulerHealthControllerExecutor) Execute(ctx context.Context, op *op
 		return operations.NewErrUnexpected(err)
 	}
 
-	nonexistentGameRoomIDs := ex.checkNonexistentGameRoomsIDs(gameRoomIDs, instances)
-	if len(nonexistentGameRoomIDs) > 0 {
+	nonexistentGameRoomsIDs, existentGameRoomsInstancesMap := ex.mapExistentAndNonExistentGameRooms(gameRoomIDs, instances)
+	if len(nonexistentGameRoomsIDs) > 0 {
 		logger.Error("found registered rooms that no longer exists")
-		ex.tryEnsureCorrectRoomsOnStorage(ctx, op, logger, nonexistentGameRoomIDs)
+		ex.tryEnsureCorrectRoomsOnStorage(ctx, op, logger, nonexistentGameRoomsIDs)
 	}
 
-	existentGameRoomIDs := filterExistentGameRooms(gameRoomIDs, nonexistentGameRoomIDs)
-
-	availableRooms, expiredRooms := ex.findAvailableAndExpiredRooms(ctx, op, existentGameRoomIDs, instances)
+	availableRooms, expiredRooms := ex.findAvailableAndExpiredRooms(ctx, op, existentGameRoomsInstancesMap)
 	if len(expiredRooms) > 0 {
 		logger.Sugar().Infof("found %v expired rooms to be deleted", len(expiredRooms))
 		err = ex.enqueueRemoveExpiredRooms(ctx, op, logger, expiredRooms)
@@ -147,23 +145,6 @@ func (ex *SchedulerHealthControllerExecutor) loadActualState(ctx context.Context
 	return
 }
 
-func (ex *SchedulerHealthControllerExecutor) checkNonexistentGameRoomsIDs(gameRoomIDs []string, gameRoomInstances []*game_room.Instance) []string {
-	var nonexistentGameRoomsIDs []string
-	for _, gameRoomID := range gameRoomIDs {
-		found := false
-		for _, instance := range gameRoomInstances {
-			if instance.ID == gameRoomID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			nonexistentGameRoomsIDs = append(nonexistentGameRoomsIDs, gameRoomID)
-		}
-	}
-	return nonexistentGameRoomsIDs
-}
-
 func (ex *SchedulerHealthControllerExecutor) tryEnsureCorrectRoomsOnStorage(ctx context.Context, op *operation.Operation, logger *zap.Logger, nonexistentGameRoomIDs []string) {
 	for _, gameRoomID := range nonexistentGameRoomIDs {
 		err := ex.roomStorage.DeleteRoom(ctx, op.SchedulerName, gameRoomID)
@@ -208,42 +189,33 @@ func (ex *SchedulerHealthControllerExecutor) ensureDesiredAmountOfInstances(ctx 
 	return nil
 }
 
-func (ex *SchedulerHealthControllerExecutor) findAvailableAndExpiredRooms(ctx context.Context, op *operation.Operation, gameRoomsIDs []string, instances []*game_room.Instance) (availableRoomsIDs, expiredRoomsIDs []string) {
-	for _, gameRoomID := range gameRoomsIDs {
-		if !ex.isGameRoomInstanceReady(gameRoomID, instances) {
-			availableRoomsIDs = append(availableRoomsIDs, gameRoomID)
+func (ex *SchedulerHealthControllerExecutor) findAvailableAndExpiredRooms(ctx context.Context, op *operation.Operation, existentGameRoomsInstancesMap map[string]*game_room.Instance) (availableRoomsIDs, expiredRoomsIDs []string) {
+	for gameRoomId, instance := range existentGameRoomsInstancesMap {
+		if instance.Status.Type == game_room.InstancePending {
+			availableRoomsIDs = append(availableRoomsIDs, gameRoomId)
 			continue
 		}
 
-		room, err := ex.roomStorage.GetRoom(ctx, op.SchedulerName, gameRoomID)
+		room, err := ex.roomStorage.GetRoom(ctx, op.SchedulerName, gameRoomId)
 		if err != nil {
 			continue
 		}
 
 		switch {
 		case ex.isInitializingRoomExpired(room):
-			expiredRoomsIDs = append(expiredRoomsIDs, gameRoomID)
+			expiredRoomsIDs = append(expiredRoomsIDs, gameRoomId)
 		case ex.isRoomPingExpired(room):
-			expiredRoomsIDs = append(expiredRoomsIDs, gameRoomID)
+			expiredRoomsIDs = append(expiredRoomsIDs, gameRoomId)
 		case ex.isRoomStatus(room, game_room.GameStatusTerminating):
 			continue
 		case ex.isRoomStatus(room, game_room.GameStatusError):
 			continue
 		default:
-			availableRoomsIDs = append(availableRoomsIDs, gameRoomID)
+			availableRoomsIDs = append(availableRoomsIDs, gameRoomId)
 		}
 	}
 
 	return availableRoomsIDs, expiredRoomsIDs
-}
-
-func (ex *SchedulerHealthControllerExecutor) isGameRoomInstanceReady(gameRoomId string, instances []*game_room.Instance) bool {
-	for _, instance := range instances {
-		if instance.ID == gameRoomId {
-			return instance.Status.Type == game_room.InstanceReady
-		}
-	}
-	return false
 }
 
 func (ex *SchedulerHealthControllerExecutor) isInitializingRoomExpired(room *game_room.GameRoom) bool {
@@ -290,16 +262,22 @@ func (ex *SchedulerHealthControllerExecutor) getDesiredNumberOfRooms(ctx context
 	return scheduler.RoomsReplicas, nil
 }
 
-func filterExistentGameRooms(a, b []string) []string {
-	mb := make(map[string]struct{}, len(b))
-	for _, x := range b {
-		mb[x] = struct{}{}
-	}
-	var diff []string
-	for _, x := range a {
-		if _, found := mb[x]; !found {
-			diff = append(diff, x)
+func (ex *SchedulerHealthControllerExecutor) mapExistentAndNonExistentGameRooms(gameRoomIDs []string, instances []*game_room.Instance) ([]string, map[string]*game_room.Instance) {
+	nonexistentGameRoomsIDs := make([]string, 0)
+	existentGameRoomsInstancesMap := make(map[string]*game_room.Instance)
+	for _, gameRoomID := range gameRoomIDs {
+		found := false
+		for _, instance := range instances {
+			if instance.ID == gameRoomID {
+				found = true
+				existentGameRoomsInstancesMap[gameRoomID] = instance
+				break
+			}
+		}
+		if !found {
+			nonexistentGameRoomsIDs = append(nonexistentGameRoomsIDs, gameRoomID)
 		}
 	}
-	return diff
+
+	return nonexistentGameRoomsIDs, existentGameRoomsInstancesMap
 }

--- a/internal/core/operations/healthcontroller/health_controller_executor_test.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor_test.go
@@ -89,8 +89,14 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					operationManager *mockports.MockOperationManager,
 					autoscaler *mockports.MockAutoscaler,
 				) {
+					readyInstance := &game_room.Instance{
+						Status: game_room.InstanceStatus{
+							Type: game_room.InstanceReady,
+						},
+					}
+
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), genericSchedulerNoAutoscaling.Name).Return([]string{}, nil)
-					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), genericSchedulerNoAutoscaling.Name).Return([]*game_room.Instance{}, nil)
+					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), genericSchedulerNoAutoscaling.Name).Return([]*game_room.Instance{readyInstance}, nil)
 					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), genericSchedulerNoAutoscaling.Name).Return(genericSchedulerNoAutoscaling, nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
 				},
@@ -107,7 +113,20 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					autoscaler *mockports.MockAutoscaler,
 				) {
 					gameRoomIDs := []string{"existent-1", "existent-pending-2"}
-					instances := []*game_room.Instance{{ID: "existent-1"}, {ID: "existent-pending-2"}}
+					instances := []*game_room.Instance{
+						{
+							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						}, {
+							ID: "existent-pending-2",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						},
+					}
+
 					// load
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
@@ -147,7 +166,19 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					autoscaler *mockports.MockAutoscaler,
 				) {
 					gameRoomIDs := []string{"existent-1", "existent-pending-2"}
-					instances := []*game_room.Instance{{ID: "existent-1"}, {ID: "existent-pending-2"}}
+					instances := []*game_room.Instance{
+						{
+							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						}, {
+							ID: "existent-pending-2",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						},
+					}
 					// load
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
@@ -194,7 +225,19 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					autoscaler *mockports.MockAutoscaler,
 				) {
 					gameRoomIDs := []string{"existent-1", "existent-pending-2"}
-					instances := []*game_room.Instance{{ID: "existent-1"}, {ID: "existent-pending-2"}}
+					instances := []*game_room.Instance{
+						{
+							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						}, {
+							ID: "existent-pending-2",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						},
+					}
 					// load
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
@@ -211,7 +254,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 
 					expiredCreatedAt := time.Now().Add(5 * -time.Minute)
 					gameRoomUnready := &game_room.GameRoom{
-						ID:          gameRoomIDs[0],
+						ID:          gameRoomIDs[1],
 						SchedulerID: genericSchedulerNoAutoscaling.Name,
 						Status:      game_room.GameStatusUnready,
 						LastPingAt:  time.Now(),
@@ -241,7 +284,19 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					autoscaler *mockports.MockAutoscaler,
 				) {
 					gameRoomIDs := []string{"existent-1", "existent-unready-2"}
-					instances := []*game_room.Instance{{ID: "existent-1"}, {ID: "existent-unready-2"}}
+					instances := []*game_room.Instance{
+						{
+							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						}, {
+							ID: "existent-unready-2",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						},
+					}
 					// load
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
@@ -285,6 +340,9 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					instances := []*game_room.Instance{
 						{
 							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 					}
 					// load
@@ -321,6 +379,9 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					instances := []*game_room.Instance{
 						{
 							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 					}
 					// load
@@ -358,9 +419,15 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					instances := []*game_room.Instance{
 						{
 							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 						{
 							ID: "expired-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 					}
 					// load
@@ -395,6 +462,34 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
+			title: "instance is still pending, do nothing",
+			executionPlan: executionPlan{
+				planMocks: func(
+					roomStorage *mockports.MockRoomStorage,
+					instanceStorage *ismock.MockGameRoomInstanceStorage,
+					schedulerStorage *mockports.MockSchedulerStorage,
+					operationManager *mockports.MockOperationManager,
+					autoscaler *mockports.MockAutoscaler,
+				) {
+					gameRoomIDs := []string{"expired-1"}
+					instances := []*game_room.Instance{
+						{
+							ID: "expired-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstancePending,
+							},
+						},
+					}
+					// load
+					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
+					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
+					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(genericSchedulerNoAutoscaling, nil)
+
+					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), "current amount of rooms is equal to desired amount, no changes needed")
+				},
+			},
+		},
+		{
 			title: "expired room found, enqueue remove rooms with specified ID fails, continues operation and enqueue new add rooms",
 			executionPlan: executionPlan{
 				planMocks: func(
@@ -408,9 +503,15 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					instances := []*game_room.Instance{
 						{
 							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 						{
 							ID: "expired-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 					}
 					// load
@@ -554,6 +655,9 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					instances := []*game_room.Instance{
 						{
 							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 					}
 					// load
@@ -591,6 +695,9 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					instances := []*game_room.Instance{
 						{
 							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 					}
 					// load
@@ -628,6 +735,9 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					instances := []*game_room.Instance{
 						{
 							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 					}
 					// load
@@ -665,6 +775,9 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					instances := []*game_room.Instance{
 						{
 							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 					}
 					// load
@@ -749,6 +862,9 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					instances := []*game_room.Instance{
 						{
 							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
 						},
 					}
 					// load
@@ -780,7 +896,19 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					autoscaler *mockports.MockAutoscaler,
 				) {
 					gameRoomIDs := []string{"existent-1", "existent-2"}
-					instances := []*game_room.Instance{{ID: "existent-1"}, {ID: "existent-2"}}
+					instances := []*game_room.Instance{
+						{
+							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						}, {
+							ID: "existent-2",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						},
+					}
 					// load
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
@@ -814,7 +942,19 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					autoscaler *mockports.MockAutoscaler,
 				) {
 					gameRoomIDs := []string{"existent-1", "existent-with-error-2"}
-					instances := []*game_room.Instance{{ID: "existent-1"}, {ID: "existent-with-error-2"}}
+					instances := []*game_room.Instance{
+						{
+							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						}, {
+							ID: "existent-with-error-2",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						},
+					}
 					// load
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
@@ -855,7 +995,19 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					autoscaler *mockports.MockAutoscaler,
 				) {
 					gameRoomIDs := []string{"existent-1", "existent-terminating-2"}
-					instances := []*game_room.Instance{{ID: "existent-1"}, {ID: "existent-terminating-2"}}
+					instances := []*game_room.Instance{
+						{
+							ID: "existent-1",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						}, {
+							ID: "existent-terminating-2",
+							Status: game_room.InstanceStatus{
+								Type: game_room.InstanceReady,
+							},
+						},
+					}
 					// load
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)


### PR DESCRIPTION
## What?
Fix logic that makes health controller enqueue remove rooms for rooms that kubernetes is still trying to process

## Why?
Although this logic does not make Maestro fail to scale, it is very counterproductive since, on a high load, Maestro asks kube to delete instances that are still pending