### PR TITLE
Add component metric label to workers manager metrics

### DIFF
--- a/internal/core/monitoring/constants.go
+++ b/internal/core/monitoring/constants.go
@@ -37,6 +37,7 @@ const (
 	LabelSuccess           = "success"
 	LabelReason            = "reason"
 	LabelScheduler         = "scheduler"
+	LabelComponent         = "maestro_component"
 	LabelInstanceEventType = "instanceEventType"
 	LabelGame              = "game"
 	LabelOperation         = "operation"

--- a/internal/core/services/workers_manager/metrics.go
+++ b/internal/core/services/workers_manager/metrics.go
@@ -29,29 +29,28 @@ import (
 var (
 	currentWorkersGaugeMetric = monitoring.CreateGaugeMetric(&monitoring.MetricOpts{
 		Namespace: monitoring.Namespace,
-		Subsystem: monitoring.SubsystemWorker,
 		Name:      "current_workers",
 		Help:      "Current number of alive workers",
 		Labels: []string{
 			monitoring.LabelScheduler,
+			monitoring.LabelComponent,
 		},
 	})
 
 	workersSyncCounterMetric = monitoring.CreateCounterMetric(&monitoring.MetricOpts{
 		Namespace: monitoring.Namespace,
-		Subsystem: monitoring.SubsystemWorker,
 		Name:      "workers_sync",
 		Help:      "Times of the workers sync processes",
 		Labels:    []string{},
 	})
 )
 
-func reportWorkerStart(schedulerName string) {
-	currentWorkersGaugeMetric.WithLabelValues(schedulerName).Inc()
+func reportWorkerStart(schedulerName string, component string) {
+	currentWorkersGaugeMetric.WithLabelValues(schedulerName, component).Inc()
 }
 
-func reportWorkerStop(schedulerName string) {
-	currentWorkersGaugeMetric.WithLabelValues(schedulerName).Dec()
+func reportWorkerStop(schedulerName string, component string) {
+	currentWorkersGaugeMetric.WithLabelValues(schedulerName, component).Dec()
 }
 
 func reportWorkersSynced() {


### PR DESCRIPTION
### What ❓ 
Add `component` label to workers' manager metrics.

### Why 🤔 
Currently, we aren't able to differentiate workers' manager metrics from the maestro component that is running it, and we have three components that use the worker's structure: `runtime watcher`, `operation executor`, and `metrics reporter`.

