### PR TITLE
Include component name in worker builder

### DIFF
--- a/cmd/metricsreporter/wire.go
+++ b/cmd/metricsreporter/wire.go
@@ -35,8 +35,11 @@ import (
 	"github.com/topfreegames/maestro/internal/service"
 )
 
-func provideMetricsReporterBuilder() workers.WorkerBuilder {
-	return metricsreporter.NewMetricsReporterWorker
+func provideMetricsReporterBuilder() *workers.WorkerBuilder {
+	return &workers.WorkerBuilder{
+		Func:          metricsreporter.NewMetricsReporterWorker,
+		ComponentName: metricsreporter.WorkerName,
+	}
 }
 
 func provideMetricsReporterConfig(c config.Config) *workerconfigs.MetricsReporterConfig {

--- a/cmd/metricsreporter/wire_gen.go
+++ b/cmd/metricsreporter/wire_gen.go
@@ -44,8 +44,11 @@ func initializeMetricsReporter(c config.Config) (*workers_manager.WorkersManager
 
 // wire.go:
 
-func provideMetricsReporterBuilder() workers.WorkerBuilder {
-	return metricsreporter.NewMetricsReporterWorker
+func provideMetricsReporterBuilder() *workers.WorkerBuilder {
+	return &workers.WorkerBuilder{
+		Func:          metricsreporter.NewMetricsReporterWorker,
+		ComponentName: metricsreporter.WorkerName,
+	}
 }
 
 func provideMetricsReporterConfig(c config.Config) *config2.MetricsReporterConfig {

--- a/cmd/runtimewatcher/wire.go
+++ b/cmd/runtimewatcher/wire.go
@@ -35,8 +35,11 @@ import (
 	"github.com/topfreegames/maestro/internal/service"
 )
 
-func provideRuntimeWatcherBuilder() workers.WorkerBuilder {
-	return runtime_watcher_worker.NewRuntimeWatcherWorker
+func provideRuntimeWatcherBuilder() *workers.WorkerBuilder {
+	return &workers.WorkerBuilder{
+		Func:          runtime_watcher_worker.NewRuntimeWatcherWorker,
+		ComponentName: runtime_watcher_worker.WorkerName,
+	}
 }
 
 var WorkerOptionsSet = wire.NewSet(

--- a/cmd/runtimewatcher/wire_gen.go
+++ b/cmd/runtimewatcher/wire_gen.go
@@ -69,8 +69,11 @@ func initializeRuntimeWatcher(c config.Config) (*workers_manager.WorkersManager,
 
 // wire.go:
 
-func provideRuntimeWatcherBuilder() workers.WorkerBuilder {
-	return runtime_watcher_worker.NewRuntimeWatcherWorker
+func provideRuntimeWatcherBuilder() *workers.WorkerBuilder {
+	return &workers.WorkerBuilder{
+		Func:          runtime_watcher_worker.NewRuntimeWatcherWorker,
+		ComponentName: runtime_watcher_worker.WorkerName,
+	}
 }
 
 var WorkerOptionsSet = wire.NewSet(service.NewRuntimeKubernetes, RoomManagerSet, wire.Struct(new(workers.WorkerOptions), "RoomManager", "Runtime"))

--- a/cmd/worker/wire.go
+++ b/cmd/worker/wire.go
@@ -35,7 +35,7 @@ import (
 	"github.com/topfreegames/maestro/internal/service"
 )
 
-func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_manager.WorkersManager, error) {
+func initializeWorker(c config.Config, builder *workers.WorkerBuilder) (*workers_manager.WorkersManager, error) {
 	wire.Build(
 		// ports + adapters
 		service.NewRuntimeKubernetes,

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -17,7 +17,7 @@ import (
 
 // Injectors from wire.go:
 
-func initializeWorker(c config.Config, builder workers.WorkerBuilder) (*workers_manager.WorkersManager, error) {
+func initializeWorker(c config.Config, builder *workers.WorkerBuilder) (*workers_manager.WorkersManager, error) {
 	schedulerStorage, err := service.NewSchedulerStoragePg(c)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -26,6 +26,7 @@ import (
 	"context"
 
 	"github.com/topfreegames/maestro/cmd/commom"
+	"github.com/topfreegames/maestro/internal/core/workers"
 
 	"github.com/spf13/cobra"
 	"github.com/topfreegames/maestro/internal/core/workers/operation_execution_worker"
@@ -62,7 +63,11 @@ func runWorker() {
 	}
 
 	// TODO(gabrielcorado): support multiple workers.
-	operationExecutionWorkerManager, err := initializeWorker(config, operation_execution_worker.NewOperationExecutionWorker)
+	workerBuilder := &workers.WorkerBuilder{
+		Func:          operation_execution_worker.NewOperationExecutionWorker,
+		ComponentName: operation_execution_worker.WorkerName,
+	}
+	operationExecutionWorkerManager, err := initializeWorker(config, workerBuilder)
 	if err != nil {
 		zap.L().With(zap.Error(err)).Fatal("failed to initialize operation execution worker manager")
 	}

--- a/internal/core/services/workers_manager/workers_manager_test.go
+++ b/internal/core/services/workers_manager/workers_manager_test.go
@@ -67,9 +67,9 @@ func TestStart(t *testing.T) {
 		configs := configmock.NewMockConfig(mockCtrl)
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 		workerStopCh := make(chan struct{})
-		workerBuilder := func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
+		workerBuilder := &workers.WorkerBuilder{Func: func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
 			return &workermock.MockWorker{Run: false, StopCh: workerStopCh}
-		}
+		}, ComponentName: "mock"}
 
 		ctx, cancelFn := context.WithCancel(context.Background())
 		configs.EXPECT().GetDuration(syncWorkersIntervalPath).Return(time.Second)
@@ -131,9 +131,9 @@ func TestStart(t *testing.T) {
 		configs.EXPECT().GetDuration(syncWorkersIntervalPath).Return(time.Second)
 		configs.EXPECT().GetDuration(workersStopTimeoutDurationPath).Return(10 * time.Second)
 		schedulerStorage.EXPECT().GetAllSchedulers(context.Background()).Return(nil, errors.ErrUnexpected)
-		workerBuilder := func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
+		workerBuilder := &workers.WorkerBuilder{Func: func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
 			return &workermock.MockWorker{Run: false}
-		}
+		}, ComponentName: "mock"}
 
 		workersManager := NewWorkersManager(workerBuilder, configs, schedulerStorage, nil)
 
@@ -164,12 +164,13 @@ func TestStart(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 
 		workerStopCh := make(chan struct{})
-		workerBuilder := func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
-			return &workermock.MockWorker{
-				Run:    false,
-				StopCh: workerStopCh,
-			}
-		}
+		workerBuilder := &workers.WorkerBuilder{
+			Func: func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
+				return &workermock.MockWorker{
+					Run:    false,
+					StopCh: workerStopCh,
+				}
+			}, ComponentName: "mock"}
 
 		ctx, cancelFn := context.WithCancel(context.Background())
 		configs.EXPECT().GetDuration(syncWorkersIntervalPath).Return(time.Second)
@@ -229,8 +230,11 @@ func TestStart(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 
 		workerStopCh := make(chan struct{})
-		workerBuilder := func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
-			return &workermock.MockWorker{Run: false, StopCh: workerStopCh}
+		workerBuilder := &workers.WorkerBuilder{
+			Func: func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
+				return &workermock.MockWorker{Run: false, StopCh: workerStopCh}
+			},
+			ComponentName: "mock",
 		}
 
 		ctx, cancelFn := context.WithCancel(context.Background())
@@ -311,8 +315,10 @@ func TestStart(t *testing.T) {
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 
 		workerStopCh := make(chan struct{})
-		workerBuilder := func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
-			return &workermock.MockWorker{Run: false, StopCh: workerStopCh}
+		workerBuilder := &workers.WorkerBuilder{
+			Func: func(_ *entities.Scheduler, _ *workers.WorkerOptions) workers.Worker {
+				return &workermock.MockWorker{Run: false, StopCh: workerStopCh}
+			}, ComponentName: "mock",
 		}
 
 		ctx, cancelFn := context.WithCancel(context.Background())

--- a/internal/core/workers/metricsreporter/metrics_reporter_worker.go
+++ b/internal/core/workers/metricsreporter/metrics_reporter_worker.go
@@ -40,6 +40,8 @@ import (
 
 var _ workers.Worker = (*MetricsReporterWorker)(nil)
 
+const WorkerName = "metrics_reporter"
+
 // MetricsReporterWorker is the service responsible producing periodic metrics.
 type MetricsReporterWorker struct {
 	scheduler           *entities.Scheduler
@@ -57,7 +59,7 @@ func NewMetricsReporterWorker(scheduler *entities.Scheduler, opts *workers.Worke
 		config:          opts.MetricsReporterConfig,
 		roomStorage:     opts.RoomStorage,
 		instanceStorage: opts.InstanceStorage,
-		logger:          zap.L().With(zap.String(logs.LogFieldServiceName, "metrics_reporter_worker"), zap.String(logs.LogFieldSchedulerName, scheduler.Name)),
+		logger:          zap.L().With(zap.String(logs.LogFieldServiceName, WorkerName), zap.String(logs.LogFieldSchedulerName, scheduler.Name)),
 	}
 }
 

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker.go
@@ -42,6 +42,8 @@ import (
 
 var _ workers.Worker = (*OperationExecutionWorker)(nil)
 
+const WorkerName = "operation_execution"
+
 // OperationExecutionWorker is the service responsible for implementing the worker
 // responsibilities.
 type OperationExecutionWorker struct {
@@ -64,7 +66,7 @@ func NewOperationExecutionWorker(scheduler *entities.Scheduler, opts *workers.Wo
 		operationManager:                  opts.OperationManager,
 		executorsByName:                   opts.OperationExecutors,
 		scheduler:                         scheduler,
-		logger:                            zap.L().With(zap.String(logs.LogFieldServiceName, "worker"), zap.String(logs.LogFieldSchedulerName, scheduler.Name)),
+		logger:                            zap.L().With(zap.String(logs.LogFieldServiceName, WorkerName), zap.String(logs.LogFieldSchedulerName, scheduler.Name)),
 	}
 }
 

--- a/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
+++ b/internal/core/workers/runtime_watcher_worker/runtime_watcher_worker.go
@@ -38,6 +38,8 @@ import (
 
 var _ workers.Worker = (*runtimeWatcherWorker)(nil)
 
+const WorkerName = "runtime_watcher"
+
 // runtimeWatcherWorker is a work that will watch for changes on the Runtime
 // and apply to keep the Maestro state up-to-date. It is not expected to perform
 // any action over the game rooms or the scheduler.
@@ -57,7 +59,7 @@ func NewRuntimeWatcherWorker(scheduler *entities.Scheduler, opts *workers.Worker
 		scheduler:   scheduler,
 		roomManager: opts.RoomManager,
 		runtime:     opts.Runtime,
-		logger:      zap.L().With(zap.String(logs.LogFieldServiceName, "runtime_watcher"), zap.String(logs.LogFieldSchedulerName, scheduler.Name)),
+		logger:      zap.L().With(zap.String(logs.LogFieldServiceName, WorkerName), zap.String(logs.LogFieldSchedulerName, scheduler.Name)),
 	}
 }
 

--- a/internal/core/workers/worker.go
+++ b/internal/core/workers/worker.go
@@ -79,5 +79,8 @@ func ProvideWorkerOptions(
 	}
 }
 
-// WorkerBuilder defines a function that knows how to construct a worker.
-type WorkerBuilder func(scheduler *entities.Scheduler, options *WorkerOptions) Worker
+// WorkerBuilder defines a struct that knows how to construct a worker.
+type WorkerBuilder struct {
+	Func          func(scheduler *entities.Scheduler, options *WorkerOptions) Worker
+	ComponentName string
+}


### PR DESCRIPTION
### What ❓ 
Refactor worker builder to include component name and delete the logic that was using reflection.

### Why 🤔 
The way we were using reflection to define the builder's component name wasn't the ideal approach, this is just a code refactor.