### PR TITLE
Improve metrics name convention

### DIFF
--- a/internal/core/monitoring/metrics.go
+++ b/internal/core/monitoring/metrics.go
@@ -41,6 +41,9 @@ type MetricOpts struct {
 	Name      string
 	Help      string
 	Labels    []string
+
+	// MetricUnit will only be used by Gauge metric to fill which unit the metric is related.
+	MetricUnit string
 }
 
 func CreateCounterMetric(options *MetricOpts) *prometheus.CounterVec {
@@ -48,7 +51,7 @@ func CreateCounterMetric(options *MetricOpts) *prometheus.CounterVec {
 		prometheus.CounterOpts{
 			Namespace: options.Namespace,
 			Subsystem: options.Subsystem,
-			Name:      options.Name + "_counter",
+			Name:      options.Name + "_total",
 			Help:      options.Help + " (counter)",
 		},
 		options.Labels,
@@ -69,11 +72,16 @@ func CreateLatencyMetric(options *MetricOpts) *prometheus.HistogramVec {
 }
 
 func CreateGaugeMetric(options *MetricOpts) *prometheus.GaugeVec {
+	name := options.Name
+	if len(options.MetricUnit) > 0 {
+		name = options.Name + "_" + options.MetricUnit
+	}
+
 	return promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: options.Namespace,
 			Subsystem: options.Subsystem,
-			Name:      options.Name + "_gauge",
+			Name:      name + "_total",
 			Help:      options.Help + " (gauge)",
 		},
 		options.Labels,

--- a/internal/core/monitoring/metrics.go
+++ b/internal/core/monitoring/metrics.go
@@ -47,11 +47,16 @@ type MetricOpts struct {
 }
 
 func CreateCounterMetric(options *MetricOpts) *prometheus.CounterVec {
+	name := options.Name
+	if len(options.MetricUnit) > 0 {
+		name = options.Name + "_" + options.MetricUnit
+	}
+
 	return promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: options.Namespace,
 			Subsystem: options.Subsystem,
-			Name:      options.Name + "_total",
+			Name:      name + "_total",
 			Help:      options.Help + " (counter)",
 		},
 		options.Labels,
@@ -72,16 +77,11 @@ func CreateLatencyMetric(options *MetricOpts) *prometheus.HistogramVec {
 }
 
 func CreateGaugeMetric(options *MetricOpts) *prometheus.GaugeVec {
-	name := options.Name
-	if len(options.MetricUnit) > 0 {
-		name = options.Name + "_" + options.MetricUnit
-	}
-
 	return promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: options.Namespace,
 			Subsystem: options.Subsystem,
-			Name:      name + "_total",
+			Name:      options.Name + "_total",
 			Help:      options.Help + " (gauge)",
 		},
 		options.Labels,

--- a/internal/core/monitoring/metrics.go
+++ b/internal/core/monitoring/metrics.go
@@ -81,7 +81,7 @@ func CreateGaugeMetric(options *MetricOpts) *prometheus.GaugeVec {
 		prometheus.GaugeOpts{
 			Namespace: options.Namespace,
 			Subsystem: options.Subsystem,
-			Name:      options.Name + "_total",
+			Name:      options.Name,
 			Help:      options.Help + " (gauge)",
 		},
 		options.Labels,

--- a/internal/core/monitoring/metrics_test.go
+++ b/internal/core/monitoring/metrics_test.go
@@ -92,7 +92,7 @@ func TestCounterCreation(t *testing.T) {
 		gauge.WithLabelValues("true").Inc()
 
 		metrics, _ := prometheus.DefaultGatherer.Gather()
-		metricFamily := FilterMetric(metrics, "maestro_test_gauge_test_total")
+		metricFamily := FilterMetric(metrics, "maestro_test_gauge_test")
 		trueMetric := metricFamily.GetMetric()[0]
 		require.Equal(t, float64(1), trueMetric.GetGauge().GetValue())
 
@@ -104,7 +104,7 @@ func TestCounterCreation(t *testing.T) {
 		gauge.WithLabelValues("true").Dec()
 
 		metrics, _ = prometheus.DefaultGatherer.Gather()
-		metricFamily = FilterMetric(metrics, "maestro_test_gauge_test_total")
+		metricFamily = FilterMetric(metrics, "maestro_test_gauge_test")
 
 		trueMetric = metricFamily.GetMetric()[1]
 		require.Equal(t, float64(0), trueMetric.GetGauge().GetValue())

--- a/internal/core/monitoring/metrics_test.go
+++ b/internal/core/monitoring/metrics_test.go
@@ -38,17 +38,18 @@ func TestCounterCreation(t *testing.T) {
 	t.Run("successfully fetch counter metric", func(t *testing.T) {
 
 		counter := CreateCounterMetric(&MetricOpts{
-			Namespace: "maestro",
-			Subsystem: "test",
-			Name:      "counter_test",
-			Help:      "Test Counter",
-			Labels:    []string{"success"},
+			Namespace:  "maestro",
+			Subsystem:  "test",
+			Name:       "counter_test",
+			Help:       "Test Counter",
+			Labels:     []string{"success"},
+			MetricUnit: "unit",
 		})
 
 		counter.WithLabelValues("true").Inc()
 
 		metrics, _ := prometheus.DefaultGatherer.Gather()
-		metricFamily := FilterMetric(metrics, "maestro_test_counter_test_counter")
+		metricFamily := FilterMetric(metrics, "maestro_test_counter_test_unit_total")
 		trueMetric := metricFamily.GetMetric()[0]
 		require.Equal(t, float64(1), trueMetric.GetCounter().GetValue())
 
@@ -60,7 +61,7 @@ func TestCounterCreation(t *testing.T) {
 		counter.WithLabelValues("true").Inc()
 
 		metrics, _ = prometheus.DefaultGatherer.Gather()
-		metricFamily = FilterMetric(metrics, "maestro_test_counter_test_counter")
+		metricFamily = FilterMetric(metrics, "maestro_test_counter_test_unit_total")
 
 		trueMetric = metricFamily.GetMetric()[1]
 		require.Equal(t, float64(2), trueMetric.GetCounter().GetValue())
@@ -91,7 +92,7 @@ func TestCounterCreation(t *testing.T) {
 		gauge.WithLabelValues("true").Inc()
 
 		metrics, _ := prometheus.DefaultGatherer.Gather()
-		metricFamily := FilterMetric(metrics, "maestro_test_gauge_test_gauge")
+		metricFamily := FilterMetric(metrics, "maestro_test_gauge_test_total")
 		trueMetric := metricFamily.GetMetric()[0]
 		require.Equal(t, float64(1), trueMetric.GetGauge().GetValue())
 
@@ -103,7 +104,7 @@ func TestCounterCreation(t *testing.T) {
 		gauge.WithLabelValues("true").Dec()
 
 		metrics, _ = prometheus.DefaultGatherer.Gather()
-		metricFamily = FilterMetric(metrics, "maestro_test_gauge_test_gauge")
+		metricFamily = FilterMetric(metrics, "maestro_test_gauge_test_total")
 
 		trueMetric = metricFamily.GetMetric()[1]
 		require.Equal(t, float64(0), trueMetric.GetGauge().GetValue())


### PR DESCRIPTION
### Why
Maestro is using a non-conventional name for its metrics.
### What
- Change metrics finishing in `_counter` to `_total`.
- Change metrics finishing in  `_gauge` to `_unit_total`.