### PR TITLE
Remove expired terminating game room

### DIFF
--- a/internal/core/operations/healthcontroller/health_controller_executor_test.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor_test.go
@@ -1038,7 +1038,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "game room status terminating with initialization timeout found, considered expired, remove room operation enqueued",
+			title: "game room status terminating with terminating timeout found, considered expired, remove room operation enqueued",
 			executionPlan: executionPlan{
 				planMocks: func(
 					roomStorage *mockports.MockRoomStorage,

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -59,10 +59,12 @@ func NewCreateSchedulerVersionConfig(c config.Config) newschedulerversion.Config
 func NewHealthControllerConfig(c config.Config) healthcontroller.Config {
 	initializationTimeout := time.Duration(c.GetInt(roomInitializationTimeoutMillisConfigPath)) * time.Millisecond
 	pingTimeout := time.Duration(c.GetInt(roomPingTimeoutMillisConfigPath)) * time.Millisecond
+	deletionTimeout := time.Duration(c.GetInt(roomDeletionTimeoutMillisConfigPath)) * time.Millisecond
 
 	config := healthcontroller.Config{
 		RoomInitializationTimeout: initializationTimeout,
 		RoomPingTimeout:           pingTimeout,
+		RoomDeletionTimeout:       deletionTimeout,
 	}
 
 	return config


### PR DESCRIPTION
### Why
When a game room is in a `terminating` state it does not do anything to remove it seems it reaches out the max deletion timeout. This PR proposes to fix this behavior.
### What
- Add `isRoomTerminatingExpired` case to add to expired rooms this one that reached out the max deletion timeout
- Add `RoomDeletionTimeout` to health controller config
- Add a test case to cover this scenario.