### PR TITLE
Update golang to 1.18.4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.18.3'
+        go-version: '1.18.4'
     - name: Checkout
       uses: actions/checkout@v2
     - name: Restore cache
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.18.3'
+        go-version: '1.18.4'
     - name: Checkout
       uses: actions/checkout@v2
     - name: Restore cache
@@ -55,7 +55,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: '1.18.3'
+        go-version: '1.18.4'
     - name: Checkout
       uses: actions/checkout@v2
     - name: Restore cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-FROM golang:1.18.3-alpine AS build-env
+FROM golang:1.18.4-alpine AS build-env
 
 WORKDIR /build
 


### PR DESCRIPTION
### Why
quay.io found two security issues [link](https://quay.io/repository/tfgco/maestro/manifest/sha256:e2e13010c615b8519c19b60127c5f0f5012300175503d1632557bd10ecff6620?tab=vulnerabilities). This PR proposes to update the version of the base `golang` to avoid using the deprecated `busybox`.

### What
- Update golang image version to `1.18.4`