### PR TITLE
Feat/add validation fail fast

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.3'
+          go-version: '1.18.4'
       - name: Checkout
         uses: actions/checkout@v2
       - name: Restore cache

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint: lint/go lint/protobuf ## Execute linters.
 
 .PHONY: lint/go
 lint/go: ## Execute golangci-lint.
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.2 run
 
 .PHONY: lint/protobuf
 lint/protobuf: ## Execute buf linter.

--- a/internal/core/operations/errors.go
+++ b/internal/core/operations/errors.go
@@ -35,6 +35,7 @@ type errorKind int
 const (
 	ErrKindUnexpected errorKind = iota
 	ErrKindInvalidGru
+	ErrKindGruInError
 	ErrKindReadyPingTimeout
 	ErrKindTerminatingPingTimeout
 )
@@ -42,6 +43,7 @@ const (
 var (
 	ErrUnexpected             = &operationExecutionError{kind: ErrKindUnexpected}
 	ErrInvalidGru             = &operationExecutionError{kind: ErrKindInvalidGru}
+	ErrGruInError             = &operationExecutionError{kind: ErrKindGruInError}
 	ErrReadyPingTimeout       = &operationExecutionError{kind: ErrKindReadyPingTimeout}
 	ErrTerminatingPingTimeout = &operationExecutionError{kind: ErrKindReadyPingTimeout}
 )
@@ -90,6 +92,15 @@ func NewErrInvalidGru(gameRoom *game_room.GameRoom, err error) *operationExecuti
 		kind: ErrKindInvalidGru,
 		formattedMessage: fmt.Sprintf(`The GRU could not be validated. Maestro got timeout waiting for the GRU with ID: %s to be ready. You can check if
 		the GRU image is stable on the its logs. If you could not spot any issues, please contact us.`, gameRoom.ID),
+		err: err,
+	}
+}
+
+func NewErrGruInError(roomID, statusDescription string, err error) *operationExecutionError {
+	return &operationExecutionError{
+		kind: ErrKindGruInError,
+		formattedMessage: fmt.Sprintf(`The GRU could not be validated. The room created for validation with ID %s is entering in error state. You can check if
+		the GRU image is stable on the its logs using the provided room id. Last event in the game room: %s`, roomID, statusDescription),
 		err: err,
 	}
 }

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -156,7 +156,7 @@ func (ex *CreateNewSchedulerVersionExecutor) validateGameRoomCreation(ctx contex
 	timeoutContext, cancelFunc := context.WithTimeout(ctx, duration)
 	defer cancelFunc()
 
-	waitRoomErr := ex.roomManager.WaitRoomStatus(timeoutContext, gameRoom, game_room.GameStatusReady)
+	_, waitRoomErr := ex.roomManager.WaitRoomStatus(timeoutContext, gameRoom, []game_room.GameRoomStatus{game_room.GameStatusReady})
 	if waitRoomErr != nil {
 		logger.Error(fmt.Sprintf("error waiting validation room with ID: %s to be ready", gameRoom.ID))
 	}

--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor_test.go
@@ -82,7 +82,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		gameRoom := &game_room.GameRoom{ID: "id-1"}
 
 		roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), true).Return(gameRoom, nil, nil)
-		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, game_room.GameStatusReady).Return(nil)
+		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, []game_room.GameRoomStatus{game_room.GameStatusReady}).Return(game_room.GameStatusError, nil)
 		roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 
 		schedulerManager.
@@ -129,7 +129,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		gameRoom := &game_room.GameRoom{ID: "id-1"}
 
 		roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), true).Return(gameRoom, nil, nil)
-		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, game_room.GameStatusReady).Return(nil)
+		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, []game_room.GameRoomStatus{game_room.GameStatusReady}).Return(game_room.GameStatusError, nil)
 		roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 
 		schedulerManager.
@@ -176,7 +176,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		gameRoom := &game_room.GameRoom{ID: "id-1"}
 
 		roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), true).Return(gameRoom, nil, nil)
-		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, game_room.GameStatusReady).Return(nil)
+		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, []game_room.GameRoomStatus{game_room.GameStatusReady}).Return(game_room.GameStatusError, nil)
 		roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(nil)
 
 		schedulerManager.
@@ -223,7 +223,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		gameRoom := &game_room.GameRoom{ID: "id-1"}
 
 		roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), true).Return(gameRoom, nil, nil)
-		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, game_room.GameStatusReady).Return(nil)
+		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, []game_room.GameRoomStatus{game_room.GameStatusReady}).Return(game_room.GameStatusError, nil)
 		roomManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any()).Return(errors.NewErrUnexpected("some_error"))
 
 		schedulerManager.
@@ -372,7 +372,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		gameRoom := &game_room.GameRoom{ID: "id-1", SchedulerID: "some-scheduler"}
 
 		roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), true).Return(gameRoom, nil, nil)
-		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, game_room.GameStatusReady).Return(serviceerrors.NewErrGameRoomStatusWaitingTimeout("some error"))
+		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, []game_room.GameRoomStatus{game_room.GameStatusReady}).Return(game_room.GameStatusError, serviceerrors.NewErrGameRoomStatusWaitingTimeout("some error"))
 		roomManager.EXPECT().DeleteRoom(gomock.Any(), gameRoom).Return(nil)
 
 		schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), newScheduler.Name).Return(currentActiveScheduler, nil)
@@ -413,7 +413,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		gameRoom := &game_room.GameRoom{ID: "id-1", SchedulerID: "some-scheduler"}
 
 		roomManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), true).Return(gameRoom, nil, nil)
-		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, game_room.GameStatusReady).Return(fmt.Errorf("some error"))
+		roomManager.EXPECT().WaitRoomStatus(gomock.Any(), gameRoom, []game_room.GameRoomStatus{game_room.GameStatusReady}).Return(game_room.GameStatusError, fmt.Errorf("some error"))
 		roomManager.EXPECT().DeleteRoom(gomock.Any(), gameRoom).Return(nil)
 
 		schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), newScheduler.Name).Return(currentActiveScheduler, nil)

--- a/internal/core/ports/mock/rooms_ports_mock.go
+++ b/internal/core/ports/mock/rooms_ports_mock.go
@@ -171,11 +171,12 @@ func (mr *MockRoomManagerMockRecorder) UpdateRoomInstance(ctx, gameRoomInstance 
 }
 
 // WaitRoomStatus mocks base method.
-func (m *MockRoomManager) WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status game_room.GameRoomStatus) error {
+func (m *MockRoomManager) WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status []game_room.GameRoomStatus) (game_room.GameRoomStatus, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitRoomStatus", ctx, gameRoom, status)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(game_room.GameRoomStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // WaitRoomStatus indicates an expected call of WaitRoomStatus.

--- a/internal/core/ports/room_ports.go
+++ b/internal/core/ports/room_ports.go
@@ -74,7 +74,7 @@ type RoomManager interface {
 	UpdateGameRoomStatus(ctx context.Context, schedulerId, gameRoomId string) error
 	// WaitRoomStatus blocks the caller until the context is canceled, an error
 	// happens in the process or the game room has the desired status.
-	WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status game_room.GameRoomStatus) error
+	WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status []game_room.GameRoomStatus) (game_room.GameRoomStatus, error)
 }
 
 // Secondary Ports (output, driven ports)

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -346,7 +346,7 @@ func (m *RoomManager) WaitRoomStatus(ctx context.Context, gameRoom *game_room.Ga
 	}
 
 	// the room has the desired state already
-	if Contains(status, fromStorage.Status) {
+	if contains(status, fromStorage.Status) {
 		return fromStorage.Status, nil
 	}
 
@@ -357,7 +357,7 @@ watchLoop:
 			err = ctx.Err()
 			break watchLoop
 		case gameRoomEvent := <-watcher.ResultChan():
-			if Contains(status, gameRoomEvent.Status) {
+			if contains(status, gameRoomEvent.Status) {
 				resultStatus = gameRoomEvent.Status
 				break watchLoop
 			}
@@ -436,7 +436,7 @@ func removeDuplicateValues(slice []string) []string {
 	return res
 }
 
-func Contains[T comparable](s []T, e T) bool {
+func contains[T comparable](s []T, e T) bool {
 	for _, v := range s {
 		if v == e {
 			return true

--- a/internal/core/services/room_manager/room_manager.go
+++ b/internal/core/services/room_manager/room_manager.go
@@ -332,23 +332,22 @@ func (m *RoomManager) UpdateGameRoomStatus(ctx context.Context, schedulerId, gam
 	return nil
 }
 
-func (m *RoomManager) WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status game_room.GameRoomStatus) error {
-	var err error
+func (m *RoomManager) WaitRoomStatus(ctx context.Context, gameRoom *game_room.GameRoom, status []game_room.GameRoomStatus) (resultStatus game_room.GameRoomStatus, err error) {
 	watcher, err := m.RoomStorage.WatchRoomStatus(ctx, gameRoom)
 	if err != nil {
-		return fmt.Errorf("failed to start room status watcher: %w", err)
+		return resultStatus, fmt.Errorf("failed to start room status watcher: %w", err)
 	}
 
 	defer watcher.Stop()
 
 	fromStorage, err := m.RoomStorage.GetRoom(ctx, gameRoom.SchedulerID, gameRoom.ID)
 	if err != nil {
-		return fmt.Errorf("error while retrieving current game room status: %w", err)
+		return resultStatus, fmt.Errorf("error while retrieving current game room status: %w", err)
 	}
 
 	// the room has the desired state already
-	if fromStorage.Status == status {
-		return nil
+	if Contains(status, fromStorage.Status) {
+		return fromStorage.Status, nil
 	}
 
 watchLoop:
@@ -358,7 +357,8 @@ watchLoop:
 			err = ctx.Err()
 			break watchLoop
 		case gameRoomEvent := <-watcher.ResultChan():
-			if gameRoomEvent.Status == status {
+			if Contains(status, gameRoomEvent.Status) {
+				resultStatus = gameRoomEvent.Status
 				break watchLoop
 			}
 		}
@@ -367,12 +367,12 @@ watchLoop:
 	if err != nil {
 		waitErr := fmt.Errorf("failed to wait until room has desired status: %s, reason: %w", status, err)
 		if errors.Is(err, context.DeadlineExceeded) {
-			return serviceerrors.NewErrGameRoomStatusWaitingTimeout("").WithError(waitErr)
+			return resultStatus, serviceerrors.NewErrGameRoomStatusWaitingTimeout("").WithError(waitErr)
 		}
-		return waitErr
+		return resultStatus, waitErr
 	}
 
-	return nil
+	return resultStatus, nil
 }
 
 func (m *RoomManager) createRoomOnStorageAndRuntime(ctx context.Context, scheduler entities.Scheduler, isValidationRoom bool) (*game_room.GameRoom, *game_room.Instance, error) {
@@ -434,4 +434,13 @@ func removeDuplicateValues(slice []string) []string {
 	}
 
 	return res
+}
+
+func Contains[T comparable](s []T, e T) bool {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -33,11 +33,11 @@ import (
 	"testing"
 	"time"
 
+	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/topfreegames/maestro/internal/core/entities/events"
-
-	"golang.org/x/sync/errgroup"
 
 	"github.com/topfreegames/maestro/internal/core/ports"
 
@@ -773,87 +773,216 @@ func TestSchedulerMaxSurge(t *testing.T) {
 	})
 }
 
-func TestRoomManager_WaitGameRoomStatus(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
+func TestRoomManager_WaitRoomStatus(t *testing.T) {
 
-	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-	watcher := mockports.NewMockRoomStorageStatusWatcher(mockCtrl)
-	roomManager := New(
-		clockmock.NewFakeClock(time.Now()),
-		pamock.NewMockPortAllocator(mockCtrl),
-		roomStorage,
-		ismock.NewMockGameRoomInstanceStorage(mockCtrl),
-		runtimemock.NewMockRuntime(mockCtrl),
-		mockports.NewMockEventsService(mockCtrl),
-		RoomManagerConfig{},
-	)
+	t.Run("return the desired state and no error when the desired status is reached after some time", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
 
-	transition := game_room.GameStatusReady
-	gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusPending}
+		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+		watcher := mockports.NewMockRoomStorageStatusWatcher(mockCtrl)
+		roomManager := New(
+			clockmock.NewFakeClock(time.Now()),
+			pamock.NewMockPortAllocator(mockCtrl),
+			roomStorage,
+			ismock.NewMockGameRoomInstanceStorage(mockCtrl),
+			runtimemock.NewMockRuntime(mockCtrl),
+			mockports.NewMockEventsService(mockCtrl),
+			RoomManagerConfig{},
+		)
 
-	var group errgroup.Group
-	waitCalled := make(chan struct{})
-	eventsChan := make(chan game_room.StatusEvent)
-	group.Go(func() error {
-		waitCalled <- struct{}{}
+		statusReady := game_room.GameStatusReady
+		gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusPending}
+
+		executionResult := make(chan struct {
+			Status game_room.GameRoomStatus
+			Error  error
+		})
+		statusEventChan := make(chan game_room.StatusEvent)
+		go func() {
+			roomStorage.EXPECT().GetRoom(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(gameRoom, nil)
+			roomStorage.EXPECT().WatchRoomStatus(gomock.Any(), gameRoom).Return(watcher, nil)
+			watcher.EXPECT().ResultChan().Return(statusEventChan)
+			watcher.EXPECT().Stop()
+
+			status, err := roomManager.WaitRoomStatus(context.Background(), gameRoom, []game_room.GameRoomStatus{statusReady})
+
+			executionResult <- struct {
+				Status game_room.GameRoomStatus
+				Error  error
+			}{Status: status, Error: err}
+		}()
+
+		statusEventChan <- game_room.StatusEvent{RoomID: gameRoom.ID, SchedulerName: gameRoom.SchedulerID, Status: statusReady}
+		result := <-executionResult
+		require.NoError(t, result.Error)
+		require.Equal(t, statusReady, result.Status)
+	})
+
+	t.Run("return the desired state and no error when the desired status is already the current one", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+		watcher := mockports.NewMockRoomStorageStatusWatcher(mockCtrl)
+		roomManager := New(
+			clockmock.NewFakeClock(time.Now()),
+			pamock.NewMockPortAllocator(mockCtrl),
+			roomStorage,
+			ismock.NewMockGameRoomInstanceStorage(mockCtrl),
+			runtimemock.NewMockRuntime(mockCtrl),
+			mockports.NewMockEventsService(mockCtrl),
+			RoomManagerConfig{},
+		)
+
+		statusReady := game_room.GameStatusReady
+		gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusReady}
 
 		roomStorage.EXPECT().GetRoom(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(gameRoom, nil)
 		roomStorage.EXPECT().WatchRoomStatus(gomock.Any(), gameRoom).Return(watcher, nil)
-		watcher.EXPECT().ResultChan().Return(eventsChan)
 		watcher.EXPECT().Stop()
 
-		return roomManager.WaitRoomStatus(context.Background(), gameRoom, transition)
-	})
+		status, err := roomManager.WaitRoomStatus(context.Background(), gameRoom, []game_room.GameRoomStatus{statusReady})
 
-	<-waitCalled
-	eventsChan <- game_room.StatusEvent{RoomID: gameRoom.ID, SchedulerName: gameRoom.SchedulerID, Status: transition}
-
-	require.Eventually(t, func() bool {
-		err := group.Wait()
 		require.NoError(t, err)
-		return err == nil
-	}, 2*time.Second, time.Second)
-}
-
-func TestRoomManager_WaitGameRoomStatus_Deadline(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-
-	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
-	watcher := mockports.NewMockRoomStorageStatusWatcher(mockCtrl)
-	roomManager := New(
-		clockmock.NewFakeClock(time.Now()),
-		pamock.NewMockPortAllocator(mockCtrl),
-		roomStorage,
-		ismock.NewMockGameRoomInstanceStorage(mockCtrl),
-		runtimemock.NewMockRuntime(mockCtrl),
-		mockports.NewMockEventsService(mockCtrl),
-		RoomManagerConfig{},
-	)
-
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Millisecond))
-	gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusReady}
-
-	var group errgroup.Group
-	waitCalled := make(chan struct{})
-	eventsChan := make(chan game_room.StatusEvent)
-	group.Go(func() error {
-		waitCalled <- struct{}{}
-		defer cancel()
-
-		roomStorage.EXPECT().GetRoom(ctx, gameRoom.SchedulerID, gameRoom.ID).Return(gameRoom, nil)
-		roomStorage.EXPECT().WatchRoomStatus(gomock.Any(), gameRoom).Return(watcher, nil)
-		watcher.EXPECT().ResultChan().Return(eventsChan)
-		watcher.EXPECT().Stop()
-
-		return roomManager.WaitRoomStatus(ctx, gameRoom, game_room.GameStatusOccupied)
+		require.Equal(t, statusReady, status)
 	})
 
-	<-waitCalled
-	require.Eventually(t, func() bool {
-		err := group.Wait()
-		require.Error(t, err)
-		return err != nil
-	}, 2*time.Second, time.Second)
+	t.Run("return error when some error when generating watcher", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+		roomManager := New(
+			clockmock.NewFakeClock(time.Now()),
+			pamock.NewMockPortAllocator(mockCtrl),
+			roomStorage,
+			ismock.NewMockGameRoomInstanceStorage(mockCtrl),
+			runtimemock.NewMockRuntime(mockCtrl),
+			mockports.NewMockEventsService(mockCtrl),
+			RoomManagerConfig{},
+		)
+
+		statusReady := game_room.GameStatusReady
+		gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusPending}
+
+		roomStorage.EXPECT().WatchRoomStatus(gomock.Any(), gameRoom).Return(nil, errors.New("some error"))
+
+		_, err := roomManager.WaitRoomStatus(context.Background(), gameRoom, []game_room.GameRoomStatus{statusReady})
+
+		require.EqualError(t, err, "failed to start room status watcher: some error")
+	})
+
+	t.Run("return error when some error when generating watcher", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+		watcher := mockports.NewMockRoomStorageStatusWatcher(mockCtrl)
+		roomManager := New(
+			clockmock.NewFakeClock(time.Now()),
+			pamock.NewMockPortAllocator(mockCtrl),
+			roomStorage,
+			ismock.NewMockGameRoomInstanceStorage(mockCtrl),
+			runtimemock.NewMockRuntime(mockCtrl),
+			mockports.NewMockEventsService(mockCtrl),
+			RoomManagerConfig{},
+		)
+
+		statusReady := game_room.GameStatusReady
+		gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusPending}
+
+		roomStorage.EXPECT().GetRoom(context.Background(), gameRoom.SchedulerID, gameRoom.ID).Return(nil, errors.New("some error"))
+		roomStorage.EXPECT().WatchRoomStatus(gomock.Any(), gameRoom).Return(watcher, nil)
+		watcher.EXPECT().Stop()
+
+		_, err := roomManager.WaitRoomStatus(context.Background(), gameRoom, []game_room.GameRoomStatus{statusReady})
+
+		require.EqualError(t, err, "error while retrieving current game room status: some error")
+	})
+
+	t.Run("return ErrGameRoomStatusWaitingTimeout error when the context deadline is exceeded due to timeout", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+		watcher := mockports.NewMockRoomStorageStatusWatcher(mockCtrl)
+		roomManager := New(
+			clockmock.NewFakeClock(time.Now()),
+			pamock.NewMockPortAllocator(mockCtrl),
+			roomStorage,
+			ismock.NewMockGameRoomInstanceStorage(mockCtrl),
+			runtimemock.NewMockRuntime(mockCtrl),
+			mockports.NewMockEventsService(mockCtrl),
+			RoomManagerConfig{},
+		)
+
+		statusReady := game_room.GameStatusReady
+		gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusPending}
+
+		ctx, _ := context.WithTimeout(context.Background(), time.Second*1)
+		executionResult := make(chan struct {
+			Status game_room.GameRoomStatus
+			Error  error
+		})
+		statusEventChan := make(chan game_room.StatusEvent)
+		go func() {
+			roomStorage.EXPECT().GetRoom(ctx, gameRoom.SchedulerID, gameRoom.ID).Return(gameRoom, nil)
+			roomStorage.EXPECT().WatchRoomStatus(ctx, gameRoom).Return(watcher, nil)
+			watcher.EXPECT().ResultChan().Return(statusEventChan)
+			watcher.EXPECT().Stop()
+
+			status, err := roomManager.WaitRoomStatus(ctx, gameRoom, []game_room.GameRoomStatus{statusReady})
+
+			executionResult <- struct {
+				Status game_room.GameRoomStatus
+				Error  error
+			}{Status: status, Error: err}
+		}()
+
+		result := <-executionResult
+
+		require.True(t, errors.Is(result.Error, serviceerrors.ErrGameRoomStatusWaitingTimeout))
+		require.EqualError(t, result.Error, "failed to wait until room has desired status: [ready], reason: context deadline exceeded")
+	})
+
+	t.Run("return error when the context is canceled for any other reason", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+
+		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
+		watcher := mockports.NewMockRoomStorageStatusWatcher(mockCtrl)
+		roomManager := New(
+			clockmock.NewFakeClock(time.Now()),
+			pamock.NewMockPortAllocator(mockCtrl),
+			roomStorage,
+			ismock.NewMockGameRoomInstanceStorage(mockCtrl),
+			runtimemock.NewMockRuntime(mockCtrl),
+			mockports.NewMockEventsService(mockCtrl),
+			RoomManagerConfig{},
+		)
+
+		statusReady := game_room.GameStatusReady
+		gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusPending}
+
+		ctx, canceFn := context.WithCancel(context.Background())
+		executionResult := make(chan struct {
+			Status game_room.GameRoomStatus
+			Error  error
+		})
+		statusEventChan := make(chan game_room.StatusEvent)
+		go func() {
+			roomStorage.EXPECT().GetRoom(ctx, gameRoom.SchedulerID, gameRoom.ID).Return(gameRoom, nil)
+			roomStorage.EXPECT().WatchRoomStatus(ctx, gameRoom).Return(watcher, nil)
+			watcher.EXPECT().ResultChan().Return(statusEventChan)
+			watcher.EXPECT().Stop()
+
+			status, err := roomManager.WaitRoomStatus(ctx, gameRoom, []game_room.GameRoomStatus{statusReady})
+
+			executionResult <- struct {
+				Status game_room.GameRoomStatus
+				Error  error
+			}{Status: status, Error: err}
+		}()
+
+		canceFn()
+		result := <-executionResult
+		require.EqualError(t, result.Error, "failed to wait until room has desired status: [ready], reason: context canceled")
+	})
 }
 
 func TestUpdateGameRoomStatus(t *testing.T) {

--- a/internal/core/services/room_manager/room_manager_test.go
+++ b/internal/core/services/room_manager/room_manager_test.go
@@ -936,7 +936,8 @@ func TestRoomManager_WaitRoomStatus(t *testing.T) {
 		statusReady := game_room.GameStatusReady
 		gameRoom := &game_room.GameRoom{ID: "transition-test", SchedulerID: "scheduler-test", Status: game_room.GameStatusPending}
 
-		ctx, _ := context.WithTimeout(context.Background(), time.Second*1)
+		ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*1)
+		defer cancelFn()
 		executionResult := make(chan struct {
 			Status game_room.GameRoomStatus
 			Error  error


### PR DESCRIPTION
### What ❓ 
Add game room validation fail fast, including:
- Update in RoomManager **_WaitRoomStatus_** method to accept a list of states in which it can wait
- Update in NewSchedulerVersionExecutor **_validateGameRoomCreation_** method to wait for the error state, and return with a different and more descriptive error when the room enters an error scenario.

### Why 🤔 
Currently, our validation logic continues to wait for the game room to reach `ready` state even when the room enters in `error` state, making it stop to wait the game room to enter in `ready` state after error will improve the operation usage experience, also ensuring the instance error description will be included in the operation execution history.