### PR TITLE
Update golang version used in lint ci

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.3'
+          go-version: '1.18.4'
       - name: Checkout
         uses: actions/checkout@v2
       - name: Restore cache

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint: lint/go lint/protobuf ## Execute linters.
 
 .PHONY: lint/go
 lint/go: ## Execute golangci-lint.
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.2 run
 
 .PHONY: lint/protobuf
 lint/protobuf: ## Execute buf linter.


### PR DESCRIPTION
### What ❓ 
Update golang version used in our lint ci job

### Why 🤔 
After the go version update in the project, we forgot to update the go version used in our lint ci job
