### PR TITLE
Chore/add new field to healthcontroller definition

### DIFF
--- a/internal/adapters/operation/operation_storage_redis.go
+++ b/internal/adapters/operation/operation_storage_redis.go
@@ -29,6 +29,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/topfreegames/maestro/internal/core/operations"
+
 	"go.uber.org/zap"
 
 	"github.com/topfreegames/maestro/internal/adapters/metrics"
@@ -290,6 +292,18 @@ func (r *redisOperationStorage) CleanOperationsHistory(ctx context.Context, sche
 		}
 	}
 
+	return nil
+}
+
+func (r *redisOperationStorage) UpdateOperationDefinition(ctx context.Context, schedulerName string, operationID string, def operations.Definition) error {
+	_, err := r.client.HSet(ctx, r.buildSchedulerOperationKey(schedulerName, operationID), map[string]interface{}{
+		definitionNameRedisKey:     def.Name(),
+		definitionContentsRedisKey: def.Marshal(),
+	}).Result()
+
+	if err != nil {
+		return fmt.Errorf("failed to update operation definition: %w", err)
+	}
 	return nil
 }
 

--- a/internal/core/operations/healthcontroller/health_controller_definition.go
+++ b/internal/core/operations/healthcontroller/health_controller_definition.go
@@ -33,7 +33,9 @@ import (
 
 const OperationName = "health_controller"
 
-type SchedulerHealthControllerDefinition struct{}
+type SchedulerHealthControllerDefinition struct {
+	TookAction *bool `json:"took_action,omitempty"`
+}
 
 func (def *SchedulerHealthControllerDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
 	return true

--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -95,17 +95,17 @@ func (mr *MockOperationManagerMockRecorder) EnqueueOperationCancellationRequest(
 }
 
 // FinishOperation mocks base method.
-func (m *MockOperationManager) FinishOperation(ctx context.Context, op *operation.Operation) error {
+func (m *MockOperationManager) FinishOperation(ctx context.Context, op *operation.Operation, def operations.Definition) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FinishOperation", ctx, op)
+	ret := m.ctrl.Call(m, "FinishOperation", ctx, op, def)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // FinishOperation indicates an expected call of FinishOperation.
-func (mr *MockOperationManagerMockRecorder) FinishOperation(ctx, op interface{}) *gomock.Call {
+func (mr *MockOperationManagerMockRecorder) FinishOperation(ctx, op, def interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishOperation", reflect.TypeOf((*MockOperationManager)(nil).FinishOperation), ctx, op)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishOperation", reflect.TypeOf((*MockOperationManager)(nil).FinishOperation), ctx, op, def)
 }
 
 // GetOperation mocks base method.
@@ -468,6 +468,20 @@ func (m *MockOperationStorage) ListSchedulerFinishedOperations(ctx context.Conte
 func (mr *MockOperationStorageMockRecorder) ListSchedulerFinishedOperations(ctx, schedulerName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSchedulerFinishedOperations", reflect.TypeOf((*MockOperationStorage)(nil).ListSchedulerFinishedOperations), ctx, schedulerName)
+}
+
+// UpdateOperationDefinition mocks base method.
+func (m *MockOperationStorage) UpdateOperationDefinition(ctx context.Context, schedulerName, operationID string, def operations.Definition) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateOperationDefinition", ctx, schedulerName, operationID, def)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateOperationDefinition indicates an expected call of UpdateOperationDefinition.
+func (mr *MockOperationStorageMockRecorder) UpdateOperationDefinition(ctx, schedulerName, operationID, def interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOperationDefinition", reflect.TypeOf((*MockOperationStorage)(nil).UpdateOperationDefinition), ctx, schedulerName, operationID, def)
 }
 
 // UpdateOperationExecutionHistory mocks base method.

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -46,7 +46,7 @@ type OperationManager interface {
 	// StartOperation used when an operation will start executing.
 	StartOperation(ctx context.Context, op *operation.Operation, cancelFunction context.CancelFunc) error
 	// FinishOperation used when an operation has finished executing, with error or not.
-	FinishOperation(ctx context.Context, op *operation.Operation) error
+	FinishOperation(ctx context.Context, op *operation.Operation, def operations.Definition) error
 	// ListSchedulerPendingOperations returns a list of operations with pending status for the given scheduler.
 	ListSchedulerPendingOperations(ctx context.Context, schedulerName string) ([]*operation.Operation, error)
 	// ListSchedulerActiveOperations returns a list of operations with active status for the given scheduler.
@@ -100,6 +100,8 @@ type OperationStorage interface {
 	UpdateOperationExecutionHistory(ctx context.Context, op *operation.Operation) error
 	// CleanOperationsHistory clears the operation execution history.
 	CleanOperationsHistory(ctx context.Context, schedulerName string) error
+	// UpdateOperationDefinition updates the operation definition.
+	UpdateOperationDefinition(ctx context.Context, schedulerName string, operationID string, def operations.Definition) error
 }
 
 type OperationLeaseStorage interface {

--- a/internal/core/services/operation_manager/operation_manager.go
+++ b/internal/core/services/operation_manager/operation_manager.go
@@ -191,10 +191,14 @@ func (om *OperationManager) ListSchedulerFinishedOperations(ctx context.Context,
 	return om.Storage.ListSchedulerFinishedOperations(ctx, schedulerName)
 }
 
-func (om *OperationManager) FinishOperation(ctx context.Context, op *operation.Operation) error {
-	err := om.Storage.UpdateOperationStatus(ctx, op.SchedulerName, op.ID, op.Status)
+func (om *OperationManager) FinishOperation(ctx context.Context, op *operation.Operation, def operations.Definition) error {
+	err := om.Storage.UpdateOperationDefinition(ctx, op.SchedulerName, op.ID, def)
 	if err != nil {
-		return fmt.Errorf("failed to finish operation: %w", err)
+		return fmt.Errorf("failed to update operation definition: %w", err)
+	}
+	err = om.Storage.UpdateOperationStatus(ctx, op.SchedulerName, op.ID, op.Status)
+	if err != nil {
+		return fmt.Errorf("failed to update operation status: %w", err)
 	}
 
 	om.OperationCancelFunctions.removeFunction(op.SchedulerName, op.ID)

--- a/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
+++ b/internal/core/workers/operation_execution_worker/operation_execution_worker_test.go
@@ -90,7 +90,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationManager.EXPECT().GrantLease(gomock.AssignableToTypeOf(workerContext), expectedOperation)
 		operationManager.EXPECT().StartOperation(gomock.AssignableToTypeOf(operationContext), expectedOperation, gomock.Any())
 		operationManager.EXPECT().StartLeaseRenewGoRoutine(gomock.AssignableToTypeOf(workerContext), expectedOperation)
-		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation, operationDefinition)
 		operationManager.EXPECT().RevokeLease(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation finished")
 
@@ -166,7 +166,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Starting operation rollback")
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation rollback flow execution finished with success")
 
-		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation, operationDefinition)
 		operationManager.EXPECT().RevokeLease(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation finished")
 
@@ -235,7 +235,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Starting operation rollback")
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation rollback flow execution finished with success")
 
-		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation, operationDefinition)
 		operationManager.EXPECT().RevokeLease(gomock.Any(), expectedOperation)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation finished")
 
@@ -282,7 +282,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationManager.EXPECT().GetOperation(gomock.Any(), scheduler.Name, expectedOperation.ID).Return(expectedOperation, operationDefinition, nil)
 		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), expectedOperation.SchedulerName).Return(pendingOpsChan)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation evicted")
-		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation, operationDefinition)
 
 		go func() {
 			pendingOpsChan <- expectedOperation.ID
@@ -331,7 +331,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), expectedOperation.SchedulerName).Return(pendingOpsChan)
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(false)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation evicted")
-		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation, operationDefinition)
 
 		go func() {
 			pendingOpsChan <- expectedOperation.ID
@@ -388,7 +388,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Starting operation")
 		operationManager.EXPECT().GrantLease(gomock.AssignableToTypeOf(workerContext), expectedOperation).Return(nil)
 		operationManager.EXPECT().StartOperation(gomock.AssignableToTypeOf(operationContext), expectedOperation, gomock.Any()).Return(errors.New("some error starting operation"))
-		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation, operationDefinition)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Failed to start operation, reason: some error starting operation")
 
 		go func() {
@@ -443,7 +443,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationDefinition.EXPECT().ShouldExecute(gomock.Any(), []*operation.Operation{}).Return(true)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Starting operation")
 		operationManager.EXPECT().GrantLease(gomock.AssignableToTypeOf(workerContext), expectedOperation).Return(errors.New("some error granting lease"))
-		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation)
+		operationManager.EXPECT().FinishOperation(gomock.Any(), expectedOperation, operationDefinition)
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Failed to grant lease to operation, reason: some error granting lease")
 		// Ends the worker by cancelling it
 

--- a/proto/apidocs.swagger.json
+++ b/proto/apidocs.swagger.json
@@ -103,7 +103,23 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1UpdateRoomWithPingRequest"
+              "type": "object",
+              "properties": {
+                "metadata": {
+                  "type": "object",
+                  "description": "Target room metadata."
+                },
+                "status": {
+                  "type": "string",
+                  "description": "Indicates the room status."
+                },
+                "timestamp": {
+                  "type": "string",
+                  "format": "int64",
+                  "description": "Timestamp of the ping event."
+                }
+              },
+              "description": "The ping request."
             }
           }
         ],
@@ -150,7 +166,23 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ForwardPlayerEventRequest"
+              "type": "object",
+              "properties": {
+                "metadata": {
+                  "type": "object",
+                  "description": "Player event metadata."
+                },
+                "event": {
+                  "type": "string",
+                  "description": "The player event name."
+                },
+                "timestamp": {
+                  "type": "string",
+                  "format": "int64",
+                  "description": "Timestamp of the player event."
+                }
+              },
+              "description": "The player event request."
             }
           }
         ],
@@ -197,7 +229,23 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ForwardRoomEventRequest"
+              "type": "object",
+              "properties": {
+                "metadata": {
+                  "type": "object",
+                  "description": "Room event metadata."
+                },
+                "event": {
+                  "type": "string",
+                  "description": "The room event name."
+                },
+                "timestamp": {
+                  "type": "string",
+                  "format": "int64",
+                  "description": "Timestamp of the room event."
+                }
+              },
+              "description": "The room event request."
             }
           }
         ],
@@ -244,7 +292,23 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1UpdateRoomStatusRequest"
+              "type": "object",
+              "properties": {
+                "metadata": {
+                  "type": "object",
+                  "description": "Status update metadata."
+                },
+                "status": {
+                  "type": "string",
+                  "description": "The room status."
+                },
+                "timestamp": {
+                  "type": "string",
+                  "format": "int64",
+                  "description": "Timestamp of the status update."
+                }
+              },
+              "description": "The player event request."
             }
           }
         ],
@@ -393,7 +457,42 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1NewSchedulerVersionRequest"
+              "type": "object",
+              "properties": {
+                "game": {
+                  "type": "string",
+                  "description": "Game the new scheduler will be part of."
+                },
+                "spec": {
+                  "$ref": "#/definitions/v1Spec",
+                  "description": "The spec object defines all the game room container configurations and spec."
+                },
+                "portRange": {
+                  "$ref": "#/definitions/v1PortRange",
+                  "description": "The port range object describes what is the port range used to allocate game rooms."
+                },
+                "maxSurge": {
+                  "type": "string",
+                  "title": "The max surge of new rooms, used to scale and update"
+                },
+                "roomsReplicas": {
+                  "type": "integer",
+                  "format": "int32",
+                  "description": "The rooms replicas is the desired number of rooms that maestro should keep available."
+                },
+                "autoscaling": {
+                  "$ref": "#/definitions/v1Autoscaling",
+                  "title": "The autoscaling defines the autoscaling and its policy to be followed"
+                },
+                "forwarders": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/v1Forwarder"
+                  },
+                  "title": "List of Scheduler forwarders"
+                }
+              },
+              "description": "Scheduler is the struct that defines a maestro scheduler."
             }
           }
         ],
@@ -431,7 +530,38 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1PatchSchedulerRequest"
+              "type": "object",
+              "properties": {
+                "spec": {
+                  "$ref": "#/definitions/v1OptionalSpec",
+                  "description": "The spec object defines all the game room container configurations and spec."
+                },
+                "portRange": {
+                  "$ref": "#/definitions/v1PortRange",
+                  "description": "The port range object describes what is the port range used to allocate game rooms."
+                },
+                "maxSurge": {
+                  "type": "string",
+                  "title": "The max surge of new rooms, used to scale and update"
+                },
+                "roomsReplicas": {
+                  "type": "integer",
+                  "format": "int32",
+                  "title": "Rooms Replicas is the desired number of rooms"
+                },
+                "autoscaling": {
+                  "$ref": "#/definitions/v1OptionalAutoscaling",
+                  "title": "Autoscaling rules to the scheduler"
+                },
+                "forwarders": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/v1Forwarder"
+                  },
+                  "title": "List of Scheduler forwarders"
+                }
+              },
+              "description": "PatchSchedulerRequest is the struct that defines a partial update of a maestro scheduler."
             }
           }
         ],
@@ -538,7 +668,14 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1SwitchActiveVersionRequest"
+              "type": "object",
+              "properties": {
+                "version": {
+                  "type": "string",
+                  "title": "Version that will be activate in Scheduler"
+                }
+              },
+              "title": "Switch Active Version Request"
             }
           }
         ],
@@ -1043,33 +1180,6 @@
       },
       "title": "Delete scheduler payload"
     },
-    "v1ForwardPlayerEventRequest": {
-      "type": "object",
-      "properties": {
-        "schedulerName": {
-          "type": "string",
-          "description": "Target scheduler name.\nNOTE: On http protocol, this operates as a path param."
-        },
-        "roomName": {
-          "type": "string",
-          "description": "Target room name.\nNOTE: On http protocol, this operates as a path param."
-        },
-        "metadata": {
-          "type": "object",
-          "description": "Player event metadata."
-        },
-        "event": {
-          "type": "string",
-          "description": "The player event name."
-        },
-        "timestamp": {
-          "type": "string",
-          "format": "int64",
-          "description": "Timestamp of the player event."
-        }
-      },
-      "description": "The player event request."
-    },
     "v1ForwardPlayerEventResponse": {
       "type": "object",
       "properties": {
@@ -1083,33 +1193,6 @@
         }
       },
       "description": "The player event response."
-    },
-    "v1ForwardRoomEventRequest": {
-      "type": "object",
-      "properties": {
-        "schedulerName": {
-          "type": "string",
-          "description": "Target scheduler name.\nNOTE: On http protocol, this operates as a path param."
-        },
-        "roomName": {
-          "type": "string",
-          "description": "Target room name.\nNOTE: On http protocol, this operates as a path param."
-        },
-        "metadata": {
-          "type": "object",
-          "description": "Room event metadata."
-        },
-        "event": {
-          "type": "string",
-          "description": "The room event name."
-        },
-        "timestamp": {
-          "type": "string",
-          "format": "int64",
-          "description": "Timestamp of the room event."
-        }
-      },
-      "description": "The room event request."
     },
     "v1ForwardRoomEventResponse": {
       "type": "object",
@@ -1314,48 +1397,6 @@
       },
       "description": "The list schedulers response message."
     },
-    "v1NewSchedulerVersionRequest": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Unique identifier for the scheduler."
-        },
-        "game": {
-          "type": "string",
-          "description": "Game the new scheduler will be part of."
-        },
-        "spec": {
-          "$ref": "#/definitions/v1Spec",
-          "description": "The spec object defines all the game room container configurations and spec."
-        },
-        "portRange": {
-          "$ref": "#/definitions/v1PortRange",
-          "description": "The port range object describes what is the port range used to allocate game rooms."
-        },
-        "maxSurge": {
-          "type": "string",
-          "title": "The max surge of new rooms, used to scale and update"
-        },
-        "roomsReplicas": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The rooms replicas is the desired number of rooms that maestro should keep available."
-        },
-        "autoscaling": {
-          "$ref": "#/definitions/v1Autoscaling",
-          "title": "The autoscaling defines the autoscaling and its policy to be followed"
-        },
-        "forwarders": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1Forwarder"
-          },
-          "title": "List of Scheduler forwarders"
-        }
-      },
-      "description": "Scheduler is the struct that defines a maestro scheduler."
-    },
     "v1NewSchedulerVersionResponse": {
       "type": "object",
       "properties": {
@@ -1477,44 +1518,6 @@
         }
       },
       "description": "OptionalSpec is the specifications of the scheduler, with relevant info about what is being used.\nThis message is used to patch spec configuration."
-    },
-    "v1PatchSchedulerRequest": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Unique identifier for the scheduler."
-        },
-        "spec": {
-          "$ref": "#/definitions/v1OptionalSpec",
-          "description": "The spec object defines all the game room container configurations and spec."
-        },
-        "portRange": {
-          "$ref": "#/definitions/v1PortRange",
-          "description": "The port range object describes what is the port range used to allocate game rooms."
-        },
-        "maxSurge": {
-          "type": "string",
-          "title": "The max surge of new rooms, used to scale and update"
-        },
-        "roomsReplicas": {
-          "type": "integer",
-          "format": "int32",
-          "title": "Rooms Replicas is the desired number of rooms"
-        },
-        "autoscaling": {
-          "$ref": "#/definitions/v1OptionalAutoscaling",
-          "title": "Autoscaling rules to the scheduler"
-        },
-        "forwarders": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1Forwarder"
-          },
-          "title": "List of Scheduler forwarders"
-        }
-      },
-      "description": "PatchSchedulerRequest is the struct that defines a partial update of a maestro scheduler."
     },
     "v1PatchSchedulerResponse": {
       "type": "object",
@@ -1769,20 +1772,6 @@
       },
       "description": "Spec is the specifications of the scheduler, with relevant info about what is being used."
     },
-    "v1SwitchActiveVersionRequest": {
-      "type": "object",
-      "properties": {
-        "schedulerName": {
-          "type": "string",
-          "title": "Scheduler Name"
-        },
-        "version": {
-          "type": "string",
-          "title": "Version that will be activate in Scheduler"
-        }
-      },
-      "title": "Switch Active Version Request"
-    },
     "v1SwitchActiveVersionResponse": {
       "type": "object",
       "properties": {
@@ -1793,33 +1782,6 @@
       },
       "title": "Switch Active Version Response"
     },
-    "v1UpdateRoomStatusRequest": {
-      "type": "object",
-      "properties": {
-        "schedulerName": {
-          "type": "string",
-          "description": "Target scheduler name.\nNOTE: On http protocol, this operates as a path param."
-        },
-        "roomName": {
-          "type": "string",
-          "description": "Target room name.\nNOTE: On http protocol, this operates as a path param."
-        },
-        "metadata": {
-          "type": "object",
-          "description": "Status update metadata."
-        },
-        "status": {
-          "type": "string",
-          "description": "The room status."
-        },
-        "timestamp": {
-          "type": "string",
-          "format": "int64",
-          "description": "Timestamp of the status update."
-        }
-      },
-      "description": "The player event request."
-    },
     "v1UpdateRoomStatusResponse": {
       "type": "object",
       "properties": {
@@ -1829,33 +1791,6 @@
         }
       },
       "description": "The player event response."
-    },
-    "v1UpdateRoomWithPingRequest": {
-      "type": "object",
-      "properties": {
-        "schedulerName": {
-          "type": "string",
-          "description": "Target scheduler name.\nNOTE: On http protocol, this operates as a path param."
-        },
-        "roomName": {
-          "type": "string",
-          "description": "Target room name.\nNOTE: On http protocol, this operates as a path param."
-        },
-        "metadata": {
-          "type": "object",
-          "description": "Target room metadata."
-        },
-        "status": {
-          "type": "string",
-          "description": "Indicates the room status."
-        },
-        "timestamp": {
-          "type": "string",
-          "format": "int64",
-          "description": "Timestamp of the ping event."
-        }
-      },
-      "description": "The ping request."
     },
     "v1UpdateRoomWithPingResponse": {
       "type": "object",


### PR DESCRIPTION
### What ❓ 
- Create new method on operation storage to update definition after the operation is executed
- Update health controller operation executor and definition to use and populate this new field
- Update operations manager FinishOperation method to also update the operation definition after its execution


### Why 🤔 
We need to include a new field in health controller definition called TookAction, which will indicate if the operation took some action or not