### PR TITLE
Feat/store noop operations in new sorted set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,9 @@ deps/down: ## Delete containers dependencies.
 .PHONY: maestro/start
 maestro/start: build-linux-x86_64 ## Start Maestro with all of its dependencies.
 	@echo "Starting maestro..."
-	@cd ./e2e/framework/maestro; docker-compose --project-name maestro up -d
+	@cd ./e2e/framework/maestro; docker-compose --project-name maestro up --build -d
 	@MAESTRO_MIGRATION_PATH="file://internal/service/migrations" go run main.go migrate;
-	@cd ./e2e/framework/maestro; docker-compose --project-name maestro start worker runtime-watcher #Worker and watcher do not work before migration, so we start them after it.
+	@cd ./e2e/framework/maestro; docker-compose --project-name maestro up --build -d worker runtime-watcher #Worker and watcher do not work before migration, so we start them after it.
 	@echo "Maestro is up and running!"
 
 .PHONY: maestro/down

--- a/internal/adapters/operation/operation_storage_redis.go
+++ b/internal/adapters/operation/operation_storage_redis.go
@@ -422,7 +422,7 @@ func operationHasNoAction(op *operation.Operation) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		return !*def.TookAction, nil
+		return def.TookAction != nil && !*def.TookAction, nil
 	}
 	return false, nil
 }

--- a/internal/adapters/operation/operation_storage_redis_test.go
+++ b/internal/adapters/operation/operation_storage_redis_test.go
@@ -513,76 +513,182 @@ func TestListSchedulerFinishedOperations(t *testing.T) {
 }
 
 func TestUpdateOperationStatus(t *testing.T) {
-	t.Run("set operation as active", func(t *testing.T) {
-		client := test.GetRedisConnection(t, redisAddress)
-		now := time.Now()
-		clock := clockmock.NewFakeClock(now)
-		operationsTTLMap := map[Definition]time.Duration{}
-		storage := NewRedisOperationStorage(client, clock, operationsTTLMap)
+	schedulerName := "test-scheduler"
 
-		op := &operation.Operation{
-			ID:            "some-op-id",
-			SchedulerName: "test-scheduler",
-			Status:        operation.StatusPending,
-		}
+	baseOperation := &operation.Operation{
+		ID:             "some-op-id-1",
+		SchedulerName:  schedulerName,
+		DefinitionName: "test-definition",
+		CreatedAt:      time.Date(2022, time.November, 19, 6, 12, 15, 0, time.UTC),
+		Input:          []byte("hello test"),
+		ExecutionHistory: []operation.OperationEvent{
+			{
+				CreatedAt: time.Date(1999, time.November, 19, 6, 12, 15, 0, time.UTC),
+				Event:     "some-event",
+			},
+		},
+	}
 
-		err := storage.CreateOperation(context.Background(), op)
-		require.NoError(t, err)
+	t.Run("with success", func(t *testing.T) {
 
-		err = storage.UpdateOperationStatus(context.Background(), op.SchedulerName, op.ID, operation.StatusInProgress)
-		require.NoError(t, err)
+		t.Run("transit operation from pending to in-progress, update status and store it in active sorted set", func(t *testing.T) {
+			client := test.GetRedisConnection(t, redisAddress)
+			now := time.Now()
+			clock := clockmock.NewFakeClock(now)
+			operationsTTLMap := map[Definition]time.Duration{}
+			storage := NewRedisOperationStorage(client, clock, operationsTTLMap)
+			op := *baseOperation
+			op.Status = operation.StatusPending
 
-		operationStored, err := client.HGetAll(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID)).Result()
-		require.NoError(t, err)
+			// Create Operation hashmap
+			executionHistoryJson, err := json.Marshal(op.ExecutionHistory)
+			require.NoError(t, err)
+			err = client.HSet(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID), map[string]interface{}{
+				idRedisKey:                 op.ID,
+				schedulerNameRedisKey:      op.SchedulerName,
+				statusRedisKey:             strconv.Itoa(int(op.Status)),
+				definitionNameRedisKey:     op.DefinitionName,
+				createdAtRedisKey:          op.CreatedAt.Format(time.RFC3339Nano),
+				definitionContentsRedisKey: op.Input,
+				executionHistoryRedisKey:   executionHistoryJson,
+			}).Err()
+			require.NoError(t, err)
 
-		intStatus, err := strconv.Atoi(operationStored[statusRedisKey])
-		require.NoError(t, err)
-		require.Equal(t, operation.StatusInProgress, operation.Status(intStatus))
+			err = storage.UpdateOperationStatus(context.Background(), op.SchedulerName, op.ID, operation.StatusInProgress)
+			assert.NoError(t, err)
 
-		score, err := client.ZScore(context.Background(), storage.buildSchedulerActiveOperationsKey(op.SchedulerName), op.ID).Result()
-		require.NoError(t, err)
-		require.Equal(t, float64(now.Unix()), score)
+			// Assert the status was updated
+			updatedStatus, err := client.HGet(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID), statusRedisKey).Result()
+			assert.NoError(t, err)
+			intStatus, err := strconv.Atoi(updatedStatus)
+			assert.NoError(t, err)
+			assert.Equal(t, operation.StatusInProgress, operation.Status(intStatus))
 
-		err = client.ZScore(context.Background(), storage.buildSchedulerHistoryOperationsKey(op.SchedulerName), op.ID).Err()
-		require.ErrorIs(t, redis.Nil, err)
+			// Assert the operation was added to the active sorted set
+			updatedAt, err := client.ZScore(context.Background(), storage.buildSchedulerActiveOperationsKey(op.SchedulerName), op.ID).Result()
+			assert.NoError(t, err)
+			assert.Equal(t, float64(now.Unix()), updatedAt)
+		})
+
+		t.Run("transit operation from in-progress to finished, update status and store it in history sorted set", func(t *testing.T) {
+			client := test.GetRedisConnection(t, redisAddress)
+			now := time.Now()
+			clock := clockmock.NewFakeClock(now)
+			operationsTTLMap := map[Definition]time.Duration{}
+			storage := NewRedisOperationStorage(client, clock, operationsTTLMap)
+			op := *baseOperation
+			op.Status = operation.StatusInProgress
+
+			// Create Operation hashmap and add it to active sorted set
+			err := client.ZAdd(context.Background(), storage.buildSchedulerActiveOperationsKey(op.SchedulerName), &redis.Z{
+				Member: op.ID,
+				Score:  float64(op.CreatedAt.Unix()),
+			}).Err()
+			require.NoError(t, err)
+			executionHistoryJson, err := json.Marshal(op.ExecutionHistory)
+			require.NoError(t, err)
+			err = client.HSet(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID), map[string]interface{}{
+				idRedisKey:                 op.ID,
+				schedulerNameRedisKey:      op.SchedulerName,
+				statusRedisKey:             strconv.Itoa(int(op.Status)),
+				definitionNameRedisKey:     op.DefinitionName,
+				createdAtRedisKey:          op.CreatedAt.Format(time.RFC3339Nano),
+				definitionContentsRedisKey: op.Input,
+				executionHistoryRedisKey:   executionHistoryJson,
+			}).Err()
+			require.NoError(t, err)
+
+			err = storage.UpdateOperationStatus(context.Background(), op.SchedulerName, op.ID, operation.StatusFinished)
+			assert.NoError(t, err)
+
+			// Assert the status was updated
+			updatedStatus, err := client.HGet(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID), statusRedisKey).Result()
+			assert.NoError(t, err)
+			intStatus, err := strconv.Atoi(updatedStatus)
+			assert.NoError(t, err)
+			assert.Equal(t, operation.StatusFinished, operation.Status(intStatus))
+
+			// Assert the operation was added to the history sorted set
+			updatedAt, err := client.ZScore(context.Background(), storage.buildSchedulerHistoryOperationsKey(op.SchedulerName), op.ID).Result()
+			assert.NoError(t, err)
+			assert.Equal(t, float64(now.Unix()), updatedAt)
+
+			// Assert the operation was removed from the active sorted set
+			_, err = client.ZScore(context.Background(), storage.buildSchedulerActiveOperationsKey(op.SchedulerName), op.ID).Result()
+			assert.ErrorIs(t, redis.Nil, err)
+		})
+
+		t.Run("transit a no-action operation from in-progress to finished, update status and store it in noaction sorted set", func(t *testing.T) {
+			client := test.GetRedisConnection(t, redisAddress)
+			now := time.Now()
+			clock := clockmock.NewFakeClock(now)
+			operationsTTLMap := map[Definition]time.Duration{}
+			storage := NewRedisOperationStorage(client, clock, operationsTTLMap)
+			op := *baseOperation
+			op.Status = operation.StatusInProgress
+			op.DefinitionName = healthcontroller.OperationName
+			tookAction := false
+			definition := &healthcontroller.SchedulerHealthControllerDefinition{TookAction: &tookAction}
+			op.Input = definition.Marshal()
+
+			// Create Operation hashmap and add it to active sorted set
+			err := client.ZAdd(context.Background(), storage.buildSchedulerActiveOperationsKey(op.SchedulerName), &redis.Z{
+				Member: op.ID,
+				Score:  float64(op.CreatedAt.Unix()),
+			}).Err()
+			require.NoError(t, err)
+			executionHistoryJson, err := json.Marshal(op.ExecutionHistory)
+			require.NoError(t, err)
+			err = client.HSet(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID), map[string]interface{}{
+				idRedisKey:                 op.ID,
+				schedulerNameRedisKey:      op.SchedulerName,
+				statusRedisKey:             strconv.Itoa(int(op.Status)),
+				definitionNameRedisKey:     op.DefinitionName,
+				createdAtRedisKey:          op.CreatedAt.Format(time.RFC3339Nano),
+				definitionContentsRedisKey: op.Input,
+				executionHistoryRedisKey:   executionHistoryJson,
+			}).Err()
+			require.NoError(t, err)
+
+			err = storage.UpdateOperationStatus(context.Background(), op.SchedulerName, op.ID, operation.StatusFinished)
+			assert.NoError(t, err)
+
+			// Assert the status was updated
+			updatedStatus, err := client.HGet(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID), statusRedisKey).Result()
+			assert.NoError(t, err)
+			intStatus, err := strconv.Atoi(updatedStatus)
+			assert.NoError(t, err)
+			assert.Equal(t, operation.StatusFinished, operation.Status(intStatus))
+
+			// Assert the operation was added to the noaction sorted set
+			updatedAt, err := client.ZScore(context.Background(), storage.buildSchedulerNoActionKey(op.SchedulerName), op.ID).Result()
+			assert.NoError(t, err)
+			assert.Equal(t, float64(now.Unix()), updatedAt)
+
+			// Assert the operation was removed from the active sorted set
+			_, err = client.ZScore(context.Background(), storage.buildSchedulerActiveOperationsKey(op.SchedulerName), op.ID).Result()
+			assert.ErrorIs(t, redis.Nil, err)
+		})
 	})
 
-	t.Run("update operation status to inactive", func(t *testing.T) {
-		client := test.GetRedisConnection(t, redisAddress)
-		now := time.Now()
-		clock := clockmock.NewFakeClock(now)
-		operationsTTLMap := map[Definition]time.Duration{}
-		storage := NewRedisOperationStorage(client, clock, operationsTTLMap)
+	t.Run("with error", func(t *testing.T) {
 
-		op := &operation.Operation{
-			ID:            "some-op-id",
-			SchedulerName: "test-scheduler",
-			Status:        operation.StatusPending,
-		}
+		t.Run("returns error when the client is closed", func(t *testing.T) {
+			client := test.GetRedisConnection(t, redisAddress)
+			now := time.Now()
+			clock := clockmock.NewFakeClock(now)
+			operationsTTLMap := map[Definition]time.Duration{}
+			storage := NewRedisOperationStorage(client, clock, operationsTTLMap)
+			op := *baseOperation
 
-		err := storage.CreateOperation(context.Background(), op)
-		require.NoError(t, err)
+			err := client.Close()
+			require.NoError(t, err)
 
-		err = storage.UpdateOperationStatus(context.Background(), op.SchedulerName, op.ID, operation.StatusInProgress)
-		require.NoError(t, err)
-
-		err = storage.UpdateOperationStatus(context.Background(), op.SchedulerName, op.ID, operation.StatusError)
-		require.NoError(t, err)
-
-		operationStored, err := client.HGetAll(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID)).Result()
-		require.NoError(t, err)
-
-		intStatus, err := strconv.Atoi(operationStored[statusRedisKey])
-		require.NoError(t, err)
-		require.Equal(t, operation.StatusError, operation.Status(intStatus))
-
-		score, err := client.ZScore(context.Background(), storage.buildSchedulerHistoryOperationsKey(op.SchedulerName), op.ID).Result()
-		require.NoError(t, err)
-		require.Equal(t, float64(now.Unix()), score)
-
-		err = client.ZScore(context.Background(), storage.buildSchedulerActiveOperationsKey(op.SchedulerName), op.ID).Err()
-		require.ErrorIs(t, redis.Nil, err)
+			err = storage.UpdateOperationStatus(context.Background(), op.SchedulerName, op.ID, operation.StatusInProgress)
+			assert.ErrorContains(t, err, "failed to fetch operation for updating status: redis: client is closed")
+		})
 	})
+
 }
 
 func TestUpdateOperationDefinition(t *testing.T) {

--- a/internal/core/operations/healthcontroller/health_controller_executor.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor.go
@@ -297,7 +297,7 @@ func (ex *SchedulerHealthControllerExecutor) mapExistentAndNonExistentGameRooms(
 }
 
 func (ex *SchedulerHealthControllerExecutor) setTookAction(def *SchedulerHealthControllerDefinition, tookAction bool) {
-	if def.TookAction != nil && *def.TookAction == true {
+	if def.TookAction != nil && *def.TookAction {
 		return
 	}
 	def.TookAction = &tookAction

--- a/internal/core/operations/healthcontroller/health_controller_executor.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor.go
@@ -101,6 +101,7 @@ func (ex *SchedulerHealthControllerExecutor) Execute(ctx context.Context, op *op
 		if err != nil {
 			logger.Error("could not enqueue operation to delete expired rooms", zap.Error(err))
 		}
+		ex.setTookAction(def, true)
 	}
 
 	desiredNumberOfRooms, err := ex.getDesiredNumberOfRooms(ctx, logger, scheduler)
@@ -191,7 +192,7 @@ func (ex *SchedulerHealthControllerExecutor) ensureDesiredAmountOfInstances(ctx 
 
 	logger.Info(msgToAppend)
 	ex.operationManager.AppendOperationEventToExecutionHistory(ctx, op, msgToAppend)
-	def.TookAction = &tookAction
+	ex.setTookAction(def, tookAction)
 	return nil
 }
 
@@ -293,4 +294,11 @@ func (ex *SchedulerHealthControllerExecutor) mapExistentAndNonExistentGameRooms(
 	}
 
 	return nonexistentGameRoomsIDs, existentGameRoomsInstancesMap
+}
+
+func (ex *SchedulerHealthControllerExecutor) setTookAction(def *SchedulerHealthControllerDefinition, tookAction bool) {
+	if def.TookAction != nil && *def.TookAction == true {
+		return
+	}
+	def.TookAction = &tookAction
 }

--- a/internal/core/operations/healthcontroller/health_controller_executor_test.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor_test.go
@@ -77,11 +77,13 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 	genericOperation := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 
 	testCases := []struct {
-		title string
+		title      string
+		definition *healthcontroller.SchedulerHealthControllerDefinition
 		executionPlan
 	}{
 		{
-			title: "nothing to do, no operations enqueued",
+			title:      "nothing to do, no operations enqueued",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -105,7 +107,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "game room status pending with no initialization timeout found, considered available, so nothing to do, no operations enqueued",
+			title:      "game room status pending with no initialization timeout found, considered available, so nothing to do, no operations enqueued",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -159,7 +162,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "game room status pending with initialization timeout found, considered expired, remove room operation enqueued",
+			title:      "game room status pending with initialization timeout found, considered expired, remove room operation enqueued",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -219,7 +223,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "game room status unready with initialization timeout found, considered expired, remove room operation enqueued",
+			title:      "game room status unready with initialization timeout found, considered expired, remove room operation enqueued",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -279,7 +284,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "game room status unready and not expired found, considered available, so nothing to do, no operations enqueued",
+			title:      "game room status unready and not expired found, considered available, so nothing to do, no operations enqueued",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -333,7 +339,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "nonexistent game room IDs found, deletes from storage",
+			title:      "nonexistent game room IDs found, deletes from storage",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -373,7 +380,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "nonexistent game room IDs found but fails on first, keeps trying to delete",
+			title:      "nonexistent game room IDs found but fails on first, keeps trying to delete",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -414,9 +422,10 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "expired room found, enqueue remove rooms with specified ID",
+			title:      "expired room found, enqueue remove rooms with specified ID",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
-				tookAction: false,
+				tookAction: true,
 				planMocks: func(
 					roomStorage *mockports.MockRoomStorage,
 					instanceStorage *ismock.MockGameRoomInstanceStorage,
@@ -471,7 +480,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "instance is still pending, do nothing",
+			title:      "instance is still pending, do nothing",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -500,7 +510,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "expired room found, enqueue remove rooms with specified ID fails, continues operation and enqueue new add rooms",
+			title:      "expired room found, enqueue remove rooms with specified ID fails, continues operation and enqueue new add rooms",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -558,7 +569,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "autoscaling not configured, have less available rooms than expected, enqueue add rooms",
+			title:      "autoscaling not configured, have less available rooms than expected, enqueue add rooms",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -583,7 +595,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "autoscaling configured but disabled, have less available rooms than expected, enqueue add rooms",
+			title:      "autoscaling configured but disabled, have less available rooms than expected, enqueue add rooms",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -608,7 +621,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "autoscaling configured and enabled, have less available rooms than expected, enqueue add rooms",
+			title:      "autoscaling configured and enabled, have less available rooms than expected, enqueue add rooms",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -633,7 +647,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "enqueue add rooms fails, finish operation",
+			title:      "enqueue add rooms fails, finish operation",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -657,7 +672,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "autoscaling not configured, have more available rooms than expected, enqueue remove rooms",
+			title:      "autoscaling not configured, have more available rooms than expected, enqueue remove rooms",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -698,7 +714,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "autoscaling configured but disabled, have more available rooms than expected, enqueue remove rooms",
+			title:      "autoscaling configured but disabled, have more available rooms than expected, enqueue remove rooms",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -739,7 +756,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "autoscaling configured and enabled, have more available rooms than expected, enqueue remove rooms",
+			title:      "autoscaling configured and enabled, have more available rooms than expected, enqueue remove rooms",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -780,7 +798,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "enqueue remove rooms fails, finish operation with error",
+			title:      "enqueue remove rooms fails, finish operation with error",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -820,7 +839,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "fails loading rooms, stops operation",
+			title:      "fails loading rooms, stops operation",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -836,7 +856,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "fails loading instances, stops operation",
+			title:      "fails loading instances, stops operation",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -853,7 +874,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "fails loading scheduler, stops operation",
+			title:      "fails loading scheduler, stops operation",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -871,7 +893,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "fails calculating the desired number of rooms with autoscaler, stops operation and return error",
+			title:      "fails calculating the desired number of rooms with autoscaler, stops operation and return error",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -909,7 +932,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "fails on getRoom, consider room ignored and enqueues new add rooms",
+			title:      "fails on getRoom, consider room ignored and enqueues new add rooms",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -956,7 +980,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "room with status error, consider room ignored and enqueues new add rooms",
+			title:      "room with status error, consider room ignored and enqueues new add rooms",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -1010,7 +1035,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "room with status terminating, and considered valid, consider room ignored and enqueues new add rooms",
+			title:      "room with status terminating, and considered valid, consider room ignored and enqueues new add rooms",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -1064,7 +1090,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title: "game room status terminating with terminating timeout found, considered expired, remove room operation enqueued",
+			title:      "game room status terminating with terminating timeout found, considered expired, remove room operation enqueued",
+			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -1143,12 +1170,12 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			testCase.executionPlan.planMocks(roomsStorage, instanceStorage, schedulerStorage, operationManager, autoscaler)
 
 			ctx := context.Background()
-			err := executor.Execute(ctx, genericOperation, definition)
+			err := executor.Execute(ctx, genericOperation, testCase.definition)
 			if testCase.executionPlan.shouldFail {
 				assert.NotNil(t, err)
 			} else {
 				assert.Nil(t, err)
-				assert.Equal(t, testCase.executionPlan.tookAction, *definition.TookAction)
+				assert.Equal(t, testCase.executionPlan.tookAction, *testCase.definition.TookAction)
 			}
 		})
 	}


### PR DESCRIPTION
### What ❓ 
Update operations storage **_UpdateOperationStatus_** method to store no-action operations in another sorted set instead the _history_.

### Why 🤔 
We are currently including health controller operations that have no action in the operations history. With the high number of no-action health controller operations that are executed periodically, our operations listing ends up with a lot of "noise" with operations that don't really bring the information that the final user needs.   