### PR TITLE
Use the operation context in validation retry function

### DIFF
--- a/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
+++ b/internal/core/operations/newschedulerversion/new_scheduler_version_executor.go
@@ -110,7 +110,7 @@ func (ex *CreateNewSchedulerVersionExecutor) Execute(ctx context.Context, op *op
 			currentAttempt++
 			validationError := ex.validateGameRoomCreation(ctx, newScheduler, logger)
 			return ex.treatValidationError(ctx, op, validationError, currentAttempt)
-		}, retry.Attempts(uint(ex.config.RoomValidationAttempts)))
+		}, retry.Attempts(uint(ex.config.RoomValidationAttempts)), retry.Context(ctx))
 		if retryError != nil {
 			logger.Error("game room validation failed after all attempts", zap.Error(retryError))
 			ex.operationManager.AppendOperationEventToExecutionHistory(ctx, op, allAttemptsFailedMessageTemplate)


### PR DESCRIPTION
### What ❓
Pass the operation context to retry function to prevent the new_scheduler_version operation to continue game room validation when the operation is canceled. 

### Why 🤔 
We have found a bug in which the new_scheduler_version operation continues to try to validate the game room when the operations is canceled.