### PR TITLE
Normalize operations struct names

### DIFF
--- a/e2e/suites/utils.go
+++ b/e2e/suites/utils.go
@@ -265,7 +265,7 @@ func createSchedulerWithForwardersAndWaitForIt(
 }
 
 func createTestOperation(ctx context.Context, t *testing.T, operationStorage ports.OperationStorage, operationFlow ports.OperationFlow, schedulerName string, sleepSeconds int) *operation.Operation {
-	definition := test.TestOperationDefinition{
+	definition := test.Definition{
 		SleepSeconds: sleepSeconds,
 	}
 

--- a/internal/core/operations/healthcontroller/health_controller_executor.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor.go
@@ -165,7 +165,7 @@ func (ex *SchedulerHealthControllerExecutor) ensureDesiredAmountOfInstances(ctx 
 	switch {
 	case actualAmount > desiredAmount: // Need to scale down
 		removeAmount := actualAmount - desiredAmount
-		removeOperation, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &remove.RemoveRoomsDefinition{
+		removeOperation, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &remove.Definition{
 			Amount: removeAmount,
 		})
 		if err != nil {
@@ -175,7 +175,7 @@ func (ex *SchedulerHealthControllerExecutor) ensureDesiredAmountOfInstances(ctx 
 		msgToAppend = fmt.Sprintf("created operation (id: %s) to remove %v rooms.", removeOperation.ID, removeAmount)
 	case actualAmount < desiredAmount: // Need to scale up
 		addAmount := desiredAmount - actualAmount
-		addOperation, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &add.AddRoomsDefinition{
+		addOperation, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &add.Definition{
 			Amount: int32(addAmount),
 		})
 		if err != nil {
@@ -246,7 +246,7 @@ func (ex *SchedulerHealthControllerExecutor) isRoomStatus(room *game_room.GameRo
 }
 
 func (ex *SchedulerHealthControllerExecutor) enqueueRemoveExpiredRooms(ctx context.Context, op *operation.Operation, logger *zap.Logger, expiredRoomsIDs []string) error {
-	removeOperation, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &remove.RemoveRoomsDefinition{
+	removeOperation, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &remove.Definition{
 		RoomsIDs: expiredRoomsIDs,
 	})
 	if err != nil {

--- a/internal/core/operations/healthcontroller/health_controller_executor_test.go
+++ b/internal/core/operations/healthcontroller/health_controller_executor_test.go
@@ -213,10 +213,10 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.RemoveRoomsDefinition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.Definition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(op, nil)
 
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.AddRoomsDefinition{Amount: 1}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.Definition{Amount: 1}).Return(op, nil)
 
 					genericSchedulerNoAutoscaling.RoomsReplicas = 2
 				},
@@ -274,10 +274,10 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.RemoveRoomsDefinition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.Definition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(op, nil)
 
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.AddRoomsDefinition{Amount: 1}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.Definition{Amount: 1}).Return(op, nil)
 
 					genericSchedulerNoAutoscaling.RoomsReplicas = 2
 				},
@@ -475,7 +475,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					genericSchedulerNoAutoscaling.RoomsReplicas = 1
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.RemoveRoomsDefinition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.Definition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(op, nil)
 				},
 			},
 		},
@@ -560,11 +560,11 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					roomStorage.EXPECT().GetRoom(gomock.Any(), genericSchedulerNoAutoscaling.Name, gameRoomIDs[1]).Return(expiredGameRoom, nil)
 
 					genericSchedulerNoAutoscaling.RoomsReplicas = 2
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.RemoveRoomsDefinition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(nil, errors.New("error"))
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.Definition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(nil, errors.New("error"))
 
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.AddRoomsDefinition{Amount: 1}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.Definition{Amount: 1}).Return(op, nil)
 				},
 			},
 		},
@@ -590,7 +590,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					genericSchedulerNoAutoscaling.RoomsReplicas = 2
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.AddRoomsDefinition{Amount: 2}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.Definition{Amount: 2}).Return(op, nil)
 				},
 			},
 		},
@@ -616,7 +616,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					genericSchedulerAutoscalingDisabled.RoomsReplicas = 2
 					op := operation.New(genericSchedulerAutoscalingDisabled.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerAutoscalingDisabled.Name, &add.AddRoomsDefinition{Amount: 2}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerAutoscalingDisabled.Name, &add.Definition{Amount: 2}).Return(op, nil)
 				},
 			},
 		},
@@ -642,7 +642,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 
 					op := operation.New(genericSchedulerAutoscalingEnabled.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerAutoscalingEnabled.Name, &add.AddRoomsDefinition{Amount: 2}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerAutoscalingEnabled.Name, &add.Definition{Amount: 2}).Return(op, nil)
 				},
 			},
 		},
@@ -666,7 +666,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(genericSchedulerNoAutoscaling, nil)
 
 					genericSchedulerNoAutoscaling.RoomsReplicas = 2
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.AddRoomsDefinition{Amount: 2}).Return(nil, errors.New("error"))
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.Definition{Amount: 2}).Return(nil, errors.New("error"))
 				},
 				shouldFail: true,
 			},
@@ -709,7 +709,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					genericSchedulerNoAutoscaling.RoomsReplicas = 0
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.RemoveRoomsDefinition{Amount: 1}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.Definition{Amount: 1}).Return(op, nil)
 				},
 			},
 		},
@@ -751,7 +751,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					genericSchedulerAutoscalingDisabled.RoomsReplicas = 0
 					op := operation.New(genericSchedulerAutoscalingDisabled.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerAutoscalingDisabled.Name, &remove.RemoveRoomsDefinition{Amount: 1}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerAutoscalingDisabled.Name, &remove.Definition{Amount: 1}).Return(op, nil)
 				},
 			},
 		},
@@ -793,7 +793,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 
 					op := operation.New(genericSchedulerAutoscalingEnabled.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerAutoscalingEnabled.Name, &remove.RemoveRoomsDefinition{Amount: 1}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerAutoscalingEnabled.Name, &remove.Definition{Amount: 1}).Return(op, nil)
 				},
 			},
 		},
@@ -833,7 +833,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					roomStorage.EXPECT().GetRoom(gomock.Any(), genericSchedulerNoAutoscaling.Name, gameRoomIDs[0]).Return(gameRoom, nil)
 
 					genericSchedulerNoAutoscaling.RoomsReplicas = 0
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.RemoveRoomsDefinition{Amount: 1}).Return(nil, errors.New("error"))
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.Definition{Amount: 1}).Return(nil, errors.New("error"))
 				},
 				shouldFail: true,
 			},
@@ -975,7 +975,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					genericSchedulerNoAutoscaling.RoomsReplicas = 2
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.AddRoomsDefinition{Amount: 1}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.Definition{Amount: 1}).Return(op, nil)
 				},
 			},
 		},
@@ -1030,7 +1030,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					genericSchedulerNoAutoscaling.RoomsReplicas = 2
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.AddRoomsDefinition{Amount: 1}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.Definition{Amount: 1}).Return(op, nil)
 				},
 			},
 		},
@@ -1085,7 +1085,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					genericSchedulerNoAutoscaling.RoomsReplicas = 2
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.AddRoomsDefinition{Amount: 1}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.Definition{Amount: 1}).Return(op, nil)
 				},
 			},
 		},
@@ -1141,10 +1141,10 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.RemoveRoomsDefinition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.Definition{RoomsIDs: []string{gameRoomIDs[1]}}).Return(op, nil)
 
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.AddRoomsDefinition{Amount: 1}).Return(op, nil)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &add.Definition{Amount: 1}).Return(op, nil)
 
 					genericSchedulerNoAutoscaling.RoomsReplicas = 2
 				},

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -43,25 +43,25 @@ func ProvideDefinitionConstructors() map[string]operations.DefinitionConstructor
 		return &createscheduler.Definition{}
 	}
 	definitionConstructors[addrooms.OperationName] = func() operations.Definition {
-		return &addrooms.AddRoomsDefinition{}
+		return &addrooms.Definition{}
 	}
 	definitionConstructors[removerooms.OperationName] = func() operations.Definition {
-		return &removerooms.RemoveRoomsDefinition{}
+		return &removerooms.Definition{}
 	}
 	definitionConstructors[test.OperationName] = func() operations.Definition {
-		return &test.TestOperationDefinition{}
+		return &test.Definition{}
 	}
 	definitionConstructors[newversion.OperationName] = func() operations.Definition {
-		return &newversion.CreateNewSchedulerVersionDefinition{}
+		return &newversion.Definition{}
 	}
 	definitionConstructors[switchversion.OperationName] = func() operations.Definition {
-		return &switchversion.SwitchActiveVersionDefinition{}
+		return &switchversion.Definition{}
 	}
 	definitionConstructors[healthcontroller.OperationName] = func() operations.Definition {
 		return &healthcontroller.SchedulerHealthControllerDefinition{}
 	}
 	definitionConstructors[deletescheduler.OperationName] = func() operations.Definition {
-		return &deletescheduler.DeleteSchedulerDefinition{}
+		return &deletescheduler.Definition{}
 	}
 
 	return definitionConstructors

--- a/internal/core/operations/rooms/add/add_rooms_definition.go
+++ b/internal/core/operations/rooms/add/add_rooms_definition.go
@@ -33,19 +33,19 @@ import (
 
 const OperationName = "add_rooms"
 
-type AddRoomsDefinition struct {
+type Definition struct {
 	Amount int32 `json:"amount"`
 }
 
-func (d *AddRoomsDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
+func (d *Definition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
 	return true
 }
 
-func (d *AddRoomsDefinition) Name() string {
+func (d *Definition) Name() string {
 	return OperationName
 }
 
-func (d *AddRoomsDefinition) Marshal() []byte {
+func (d *Definition) Marshal() []byte {
 	bytes, err := json.Marshal(d)
 	if err != nil {
 		zap.L().With(zap.Error(err)).Error("error marshalling add-rooms operation definition")
@@ -54,7 +54,7 @@ func (d *AddRoomsDefinition) Marshal() []byte {
 	return bytes
 }
 
-func (d *AddRoomsDefinition) Unmarshal(raw []byte) error {
+func (d *Definition) Unmarshal(raw []byte) error {
 	err := json.Unmarshal(raw, d)
 	if err != nil {
 		return fmt.Errorf("error marshalling add-rooms operation definition: %w", err)

--- a/internal/core/operations/rooms/add/add_rooms_executor.go
+++ b/internal/core/operations/rooms/add/add_rooms_executor.go
@@ -39,29 +39,29 @@ import (
 	"github.com/topfreegames/maestro/internal/core/operations"
 )
 
-type AddRoomsExecutor struct {
+type Executor struct {
 	roomManager ports.RoomManager
 	storage     ports.SchedulerStorage
 	logger      *zap.Logger
 }
 
-var _ operations.Executor = (*AddRoomsExecutor)(nil)
+var _ operations.Executor = (*Executor)(nil)
 
-func NewExecutor(roomManager ports.RoomManager, storage ports.SchedulerStorage) *AddRoomsExecutor {
-	return &AddRoomsExecutor{
+func NewExecutor(roomManager ports.RoomManager, storage ports.SchedulerStorage) *Executor {
+	return &Executor{
 		roomManager: roomManager,
 		storage:     storage,
 		logger:      zap.L().With(zap.String(logs.LogFieldServiceName, "worker")),
 	}
 }
 
-func (ex *AddRoomsExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
+func (ex *Executor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
 	executionLogger := ex.logger.With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, definition.Name()),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
-	amount := definition.(*AddRoomsDefinition).Amount
+	amount := definition.(*Definition).Amount
 	scheduler, err := ex.storage.GetScheduler(ctx, op.SchedulerName)
 	if err != nil {
 		executionLogger.Error(fmt.Sprintf("Could not find scheduler with name %s, can not create rooms", op.SchedulerName), zap.Error(err))
@@ -86,15 +86,15 @@ func (ex *AddRoomsExecutor) Execute(ctx context.Context, op *operation.Operation
 	return nil
 }
 
-func (ex *AddRoomsExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (ex *Executor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
 	return nil
 }
 
-func (ex *AddRoomsExecutor) Name() string {
+func (ex *Executor) Name() string {
 	return OperationName
 }
 
-func (ex *AddRoomsExecutor) createRoom(ctx context.Context, scheduler *entities.Scheduler, logger *zap.Logger) error {
+func (ex *Executor) createRoom(ctx context.Context, scheduler *entities.Scheduler, logger *zap.Logger) error {
 	_, _, err := ex.roomManager.CreateRoom(ctx, *scheduler, false)
 	if err != nil {
 		logger.Error("Error while creating room", zap.Error(err))

--- a/internal/core/operations/rooms/add/add_rooms_executor_test.go
+++ b/internal/core/operations/rooms/add/add_rooms_executor_test.go
@@ -45,13 +45,13 @@ import (
 	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
 )
 
-func TestAddRoomsExecutor_Execute(t *testing.T) {
+func TestExecutor_Execute(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
 	clockMock := clock_mock.NewFakeClock(time.Now())
 	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 
-	definition := AddRoomsDefinition{Amount: 10}
+	definition := Definition{Amount: 10}
 
 	container1 := game_room.Container{
 		Name: "container1",
@@ -137,12 +137,12 @@ func TestAddRoomsExecutor_Execute(t *testing.T) {
 	})
 }
 
-func TestAddRoomsExecutor_Rollback(t *testing.T) {
+func TestExecutor_Rollback(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
 	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
 
-	definition := AddRoomsDefinition{Amount: 10}
+	definition := Definition{Amount: 10}
 
 	op := operation.Operation{
 		ID:             "some-op-id",
@@ -154,7 +154,7 @@ func TestAddRoomsExecutor_Rollback(t *testing.T) {
 	t.Run("does nothing and return nil", func(t *testing.T) {
 		roomsManager := mockports.NewMockRoomManager(mockCtrl)
 
-		executor := &AddRoomsExecutor{
+		executor := &Executor{
 			roomManager: roomsManager,
 			storage:     schedulerStorage,
 			logger:      zap.L().With(zap.String(logs.LogFieldServiceName, "worker")),

--- a/internal/core/operations/rooms/remove/remove_rooms_definition.go
+++ b/internal/core/operations/rooms/remove/remove_rooms_definition.go
@@ -33,20 +33,20 @@ import (
 
 const OperationName = "remove_rooms"
 
-type RemoveRoomsDefinition struct {
+type Definition struct {
 	Amount   int      `json:"amount"`
 	RoomsIDs []string `json:"rooms_ids"`
 }
 
-func (d *RemoveRoomsDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
+func (d *Definition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
 	return true
 }
 
-func (d *RemoveRoomsDefinition) Name() string {
+func (d *Definition) Name() string {
 	return OperationName
 }
 
-func (d *RemoveRoomsDefinition) Marshal() []byte {
+func (d *Definition) Marshal() []byte {
 	bytes, err := json.Marshal(d)
 	if err != nil {
 		zap.L().With(zap.Error(err)).Error("error marshalling remove rooms operation definition")
@@ -56,7 +56,7 @@ func (d *RemoveRoomsDefinition) Marshal() []byte {
 	return bytes
 }
 
-func (d *RemoveRoomsDefinition) Unmarshal(raw []byte) error {
+func (d *Definition) Unmarshal(raw []byte) error {
 	err := json.Unmarshal(raw, d)
 	if err != nil {
 		return fmt.Errorf("error marshalling remove rooms operation definition: %w", err)

--- a/internal/core/operations/rooms/remove/remove_rooms_executor_test.go
+++ b/internal/core/operations/rooms/remove/remove_rooms_executor_test.go
@@ -42,14 +42,14 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 )
 
-func TestExecute(t *testing.T) {
+func TestExecutor_Execute(t *testing.T) {
 
 	t.Run("RemoveRoom by Amount", func(t *testing.T) {
 		t.Run("should succeed - no rooms to be removed => returns without error", func(t *testing.T) {
 			executor, _, roomsManager, _ := testSetup(t)
 
 			schedulerName := uuid.NewString()
-			definition := &RemoveRoomsDefinition{Amount: 2}
+			definition := &Definition{Amount: 2}
 			operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 
 			ctx := context.Background()
@@ -65,7 +65,7 @@ func TestExecute(t *testing.T) {
 			executor, _, roomsManager, _ := testSetup(t)
 
 			schedulerName := uuid.NewString()
-			definition := &RemoveRoomsDefinition{Amount: 2}
+			definition := &Definition{Amount: 2}
 			operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 			ctx := context.Background()
 			availableRooms := []*game_room.GameRoom{
@@ -83,7 +83,7 @@ func TestExecute(t *testing.T) {
 			executor, _, roomsManager, operationManager := testSetup(t)
 
 			schedulerName := uuid.NewString()
-			definition := &RemoveRoomsDefinition{Amount: 2}
+			definition := &Definition{Amount: 2}
 			operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 
 			availableRooms := []*game_room.GameRoom{
@@ -106,7 +106,7 @@ func TestExecute(t *testing.T) {
 			executor, _, roomsManager, operationManager := testSetup(t)
 
 			schedulerName := uuid.NewString()
-			definition := &RemoveRoomsDefinition{Amount: 2}
+			definition := &Definition{Amount: 2}
 			operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 
 			availableRooms := []*game_room.GameRoom{
@@ -127,7 +127,7 @@ func TestExecute(t *testing.T) {
 		t.Run("when list rooms has error returns with error", func(t *testing.T) {
 			executor, _, roomsManager, _ := testSetup(t)
 
-			definition := &RemoveRoomsDefinition{Amount: 2}
+			definition := &Definition{Amount: 2}
 			operation := &operation.Operation{ID: "random-uuid", SchedulerName: uuid.NewString()}
 
 			ctx := context.Background()
@@ -144,7 +144,7 @@ func TestExecute(t *testing.T) {
 			executor, _, _, _ := testSetup(t)
 
 			schedulerName := uuid.NewString()
-			definition := &RemoveRoomsDefinition{RoomsIDs: []string{}}
+			definition := &Definition{RoomsIDs: []string{}}
 			operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 
 			ctx := context.Background()
@@ -160,7 +160,7 @@ func TestExecute(t *testing.T) {
 			secondRoomID := "second-room-id"
 
 			schedulerName := uuid.NewString()
-			definition := &RemoveRoomsDefinition{RoomsIDs: []string{firstRoomID, secondRoomID}}
+			definition := &Definition{RoomsIDs: []string{firstRoomID, secondRoomID}}
 			operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 
 			ctx := context.Background()
@@ -192,7 +192,7 @@ func TestExecute(t *testing.T) {
 			secondRoomID := "second-room-id"
 
 			schedulerName := uuid.NewString()
-			definition := &RemoveRoomsDefinition{RoomsIDs: []string{firstRoomID, secondRoomID}}
+			definition := &Definition{RoomsIDs: []string{firstRoomID, secondRoomID}}
 			operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 
 			ctx := context.Background()
@@ -216,7 +216,7 @@ func TestExecute(t *testing.T) {
 			secondRoomID := "second-room-id"
 
 			schedulerName := uuid.NewString()
-			definition := &RemoveRoomsDefinition{RoomsIDs: []string{firstRoomID, secondRoomID}}
+			definition := &Definition{RoomsIDs: []string{firstRoomID, secondRoomID}}
 			operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 
 			ctx := context.Background()
@@ -249,7 +249,7 @@ func TestExecute(t *testing.T) {
 			secondRoomID := "second-room-id"
 
 			schedulerName := uuid.NewString()
-			definition := &RemoveRoomsDefinition{RoomsIDs: []string{firstRoomID, secondRoomID}}
+			definition := &Definition{RoomsIDs: []string{firstRoomID, secondRoomID}}
 			operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 			ctx := context.Background()
 
@@ -279,7 +279,7 @@ func TestExecute(t *testing.T) {
 		executor, _, _, _ := testSetup(t)
 
 		schedulerName := uuid.NewString()
-		definition := &RemoveRoomsDefinition{}
+		definition := &Definition{}
 		operation := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 
 		ctx := context.Background()
@@ -297,7 +297,7 @@ func TestExecute(t *testing.T) {
 		fourthRoomID := "fourth-room-id"
 
 		schedulerName := uuid.NewString()
-		definition := &RemoveRoomsDefinition{
+		definition := &Definition{
 			RoomsIDs: []string{firstRoomID, secondRoomID},
 			Amount:   2,
 		}
@@ -338,7 +338,7 @@ func TestExecute(t *testing.T) {
 
 }
 
-func testSetup(t *testing.T) (*RemoveRoomsExecutor, *mockports.MockRoomStorage, *mockports.MockRoomManager, *mockports.MockOperationManager) {
+func testSetup(t *testing.T) (*Executor, *mockports.MockRoomStorage, *mockports.MockRoomManager, *mockports.MockOperationManager) {
 	mockCtrl := gomock.NewController(t)
 
 	roomsStorage := mockports.NewMockRoomStorage(mockCtrl)

--- a/internal/core/operations/schedulers/create/create_scheduler_executor.go
+++ b/internal/core/operations/schedulers/create/create_scheduler_executor.go
@@ -34,21 +34,21 @@ import (
 	"go.uber.org/zap"
 )
 
-type CreateSchedulerExecutor struct {
+type Executor struct {
 	runtime          ports.Runtime
 	schedulerManager ports.SchedulerManager
 }
 
-var _ operations.Executor = (*CreateSchedulerExecutor)(nil)
+var _ operations.Executor = (*Executor)(nil)
 
-func NewExecutor(runtime ports.Runtime, schedulerManager ports.SchedulerManager) *CreateSchedulerExecutor {
-	return &CreateSchedulerExecutor{
+func NewExecutor(runtime ports.Runtime, schedulerManager ports.SchedulerManager) *Executor {
+	return &Executor{
 		runtime:          runtime,
 		schedulerManager: schedulerManager,
 	}
 }
 
-func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
+func (e *Executor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
@@ -66,7 +66,7 @@ func (e *CreateSchedulerExecutor) Execute(ctx context.Context, op *operation.Ope
 	return nil
 }
 
-func (e *CreateSchedulerExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (e *Executor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
@@ -82,6 +82,6 @@ func (e *CreateSchedulerExecutor) Rollback(ctx context.Context, op *operation.Op
 	return nil
 }
 
-func (e *CreateSchedulerExecutor) Name() string {
+func (e *Executor) Name() string {
 	return OperationName
 }

--- a/internal/core/operations/schedulers/create/create_scheduler_executor_test.go
+++ b/internal/core/operations/schedulers/create/create_scheduler_executor_test.go
@@ -39,7 +39,7 @@ import (
 	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
 )
 
-func TestExecute(t *testing.T) {
+func TestExecutor_Execute(t *testing.T) {
 
 	t.Run("with success", func(t *testing.T) {
 
@@ -84,7 +84,7 @@ func TestExecute(t *testing.T) {
 	})
 }
 
-func TestRollback(t *testing.T) {
+func TestExecutor_Rollback(t *testing.T) {
 	t.Run("it returns nil when delete scheduler on execution error", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		runtime := mockports.NewMockRuntime(mockCtrl)

--- a/internal/core/operations/schedulers/delete/delete_scheduler_definition.go
+++ b/internal/core/operations/schedulers/delete/delete_scheduler_definition.go
@@ -33,20 +33,20 @@ import (
 
 const OperationName = "delete_scheduler"
 
-type DeleteSchedulerDefinition struct{}
+type Definition struct{}
 
 // ShouldExecute always return true, we're going to always perform the scheduler deletion when requested.
-func (d *DeleteSchedulerDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
+func (d *Definition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
 	return true
 }
 
 // Name returns the scheduler name.
-func (d *DeleteSchedulerDefinition) Name() string {
+func (d *Definition) Name() string {
 	return OperationName
 }
 
 // Marshal returns the json encoding of the operation definition.
-func (d *DeleteSchedulerDefinition) Marshal() []byte {
+func (d *Definition) Marshal() []byte {
 	bytes, err := json.Marshal(d)
 	if err != nil {
 		zap.L().With(zap.Error(err)).Error("error marshalling update scheduler operation definition")
@@ -57,7 +57,7 @@ func (d *DeleteSchedulerDefinition) Marshal() []byte {
 }
 
 // Unmarshal decodes the provided bytes array using definition struct.
-func (d *DeleteSchedulerDefinition) Unmarshal(raw []byte) error {
+func (d *Definition) Unmarshal(raw []byte) error {
 	err := json.Unmarshal(raw, d)
 	if err != nil {
 		return fmt.Errorf("error marshalling update scheduler operation definition: %w", err)

--- a/internal/core/operations/schedulers/delete/delete_scheduler_executor.go
+++ b/internal/core/operations/schedulers/delete/delete_scheduler_executor.go
@@ -38,7 +38,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type DeleteSchedulerExecutor struct {
+type Executor struct {
 	schedulerStorage ports.SchedulerStorage
 	schedulerCache   ports.SchedulerCache
 	instanceStorage  ports.GameRoomInstanceStorage
@@ -47,7 +47,7 @@ type DeleteSchedulerExecutor struct {
 	runtime          ports.Runtime
 }
 
-var _ operations.Executor = (*DeleteSchedulerExecutor)(nil)
+var _ operations.Executor = (*Executor)(nil)
 
 func NewExecutor(
 	schedulerStorage ports.SchedulerStorage,
@@ -56,8 +56,8 @@ func NewExecutor(
 	operationStorage ports.OperationStorage,
 	operationManager ports.OperationManager,
 	runtime ports.Runtime,
-) *DeleteSchedulerExecutor {
-	return &DeleteSchedulerExecutor{
+) *Executor {
+	return &Executor{
 		schedulerStorage: schedulerStorage,
 		schedulerCache:   schedulerCache,
 		instanceStorage:  instanceStorage,
@@ -68,7 +68,7 @@ func NewExecutor(
 }
 
 // Execute deletes the scheduler, cleaning all bounded resources in the runtime and on storages.
-func (e *DeleteSchedulerExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
+func (e *Executor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
@@ -123,16 +123,16 @@ func (e *DeleteSchedulerExecutor) Execute(ctx context.Context, op *operation.Ope
 }
 
 // Rollback does nothing.
-func (e *DeleteSchedulerExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (e *Executor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
 	return nil
 }
 
 // Name returns the name of the Operation.
-func (e *DeleteSchedulerExecutor) Name() string {
+func (e *Executor) Name() string {
 	return OperationName
 }
 
-func (e *DeleteSchedulerExecutor) waitForAllInstancesToBeDeleted(ctx context.Context, op *operation.Operation, scheduler *entities.Scheduler, logger *zap.Logger) error {
+func (e *Executor) waitForAllInstancesToBeDeleted(ctx context.Context, op *operation.Operation, scheduler *entities.Scheduler, logger *zap.Logger) error {
 	instancesCount, err := e.instanceStorage.GetInstanceCount(ctx, scheduler.Name)
 
 	if err != nil {
@@ -174,7 +174,7 @@ func (e *DeleteSchedulerExecutor) waitForAllInstancesToBeDeleted(ctx context.Con
 	return nil
 }
 
-func (e *DeleteSchedulerExecutor) getScheduler(ctx context.Context, schedulerName string) (*entities.Scheduler, error) {
+func (e *Executor) getScheduler(ctx context.Context, schedulerName string) (*entities.Scheduler, error) {
 	scheduler, err := e.schedulerCache.GetScheduler(ctx, schedulerName)
 	if err != nil || scheduler == nil {
 		scheduler, err = e.schedulerStorage.GetScheduler(ctx, schedulerName)

--- a/internal/core/operations/schedulers/delete/delete_scheduler_executor_test.go
+++ b/internal/core/operations/schedulers/delete/delete_scheduler_executor_test.go
@@ -37,7 +37,7 @@ import (
 	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
 )
 
-func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
+func TestExecutor_Execute(t *testing.T) {
 	scheduler := &entities.Scheduler{
 		Name: "schedulerTest",
 		Spec: game_room.Spec{
@@ -50,7 +50,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -74,7 +74,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, operationManager, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -103,7 +103,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, errors.New("error getting scheduler from cache"))
@@ -128,7 +128,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -152,7 +152,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -176,7 +176,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -200,7 +200,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, _, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -226,7 +226,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, instanceStorage, operationStorage, operationManager, runtime := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -254,7 +254,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, _, _, _, _ := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(nil, errors.New("some error on cache"))
@@ -269,7 +269,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 			executor, schedulerStorage, schedulerCache, _, _, _, _ := prepareMocks(t)
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -289,7 +289,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 
 			ctx := context.Background()
 
-			definition := &DeleteSchedulerDefinition{}
+			definition := &Definition{}
 			op := &operation.Operation{SchedulerName: scheduler.Name}
 
 			schedulerCache.EXPECT().GetScheduler(ctx, scheduler.Name).Return(scheduler, nil)
@@ -307,7 +307,7 @@ func TestDeleteSchedulerExecutor_Execute(t *testing.T) {
 }
 
 func prepareMocks(t *testing.T) (
-	*DeleteSchedulerExecutor,
+	*Executor,
 	*mockports.MockSchedulerStorage,
 	*mockports.MockSchedulerCache,
 	*mockports.MockGameRoomInstanceStorage,

--- a/internal/core/operations/schedulers/newversion/new_scheduler_version_definition.go
+++ b/internal/core/operations/schedulers/newversion/new_scheduler_version_definition.go
@@ -34,19 +34,19 @@ import (
 
 const OperationName = "create_new_scheduler_version"
 
-type CreateNewSchedulerVersionDefinition struct {
+type Definition struct {
 	NewScheduler *entities.Scheduler `json:"scheduler"`
 }
 
-func (def *CreateNewSchedulerVersionDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
+func (def *Definition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
 	return true
 }
 
-func (def *CreateNewSchedulerVersionDefinition) Name() string {
+func (def *Definition) Name() string {
 	return OperationName
 }
 
-func (def *CreateNewSchedulerVersionDefinition) Marshal() []byte {
+func (def *Definition) Marshal() []byte {
 	bytes, err := json.Marshal(def)
 	if err != nil {
 		zap.L().With(zap.Error(err)).Error("error marshalling update scheduler operation definition")
@@ -56,7 +56,7 @@ func (def *CreateNewSchedulerVersionDefinition) Marshal() []byte {
 	return bytes
 }
 
-func (def *CreateNewSchedulerVersionDefinition) Unmarshal(raw []byte) error {
+func (def *Definition) Unmarshal(raw []byte) error {
 	err := json.Unmarshal(raw, def)
 	if err != nil {
 		return fmt.Errorf("error marshalling update scheduler operation definition: %w", err)

--- a/internal/core/operations/schedulers/newversion/new_scheduler_version_executor_test.go
+++ b/internal/core/operations/schedulers/newversion/new_scheduler_version_executor_test.go
@@ -47,7 +47,7 @@ import (
 	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
 )
 
-func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
+func TestExecutor_Execute(t *testing.T) {
 	err := validations.RegisterValidations()
 	if err != nil {
 		t.Errorf("unexpected error %d'", err)
@@ -65,7 +65,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -115,7 +115,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -168,7 +168,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -218,7 +218,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -268,7 +268,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -317,7 +317,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -348,7 +348,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -380,7 +380,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -421,7 +421,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -467,7 +467,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -508,7 +508,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -551,7 +551,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -601,7 +601,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -646,7 +646,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -689,7 +689,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -732,7 +732,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -774,7 +774,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -804,7 +804,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -835,7 +835,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -871,7 +871,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -892,7 +892,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 		require.EqualError(t, result, "error getting active scheduler: some_error")
 	})
 
-	t.Run("should fail - valid scheduler when provided operation definition != CreateNewSchedulerVersionDefinition, returns error, don't create new version", func(t *testing.T) {
+	t.Run("should fail - valid scheduler when provided operation definition != Definition, returns error, don't create new version", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		newScheduler := *newValidSchedulerWithImageVersion("v1.0")
@@ -902,7 +902,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &add.AddRoomsDefinition{}
+		operationDef := &add.Definition{}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -933,7 +933,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -954,7 +954,7 @@ func TestCreateNewSchedulerVersionExecutor_Execute(t *testing.T) {
 
 }
 
-func TestCreateNewSchedulerVersionExecutor_Rollback(t *testing.T) {
+func TestExecutor_Rollback(t *testing.T) {
 	err := validations.RegisterValidations()
 	if err != nil {
 		t.Errorf("unexpected error %d'", err)
@@ -970,7 +970,7 @@ func TestCreateNewSchedulerVersionExecutor_Rollback(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -997,7 +997,7 @@ func TestCreateNewSchedulerVersionExecutor_Rollback(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)
@@ -1024,7 +1024,7 @@ func TestCreateNewSchedulerVersionExecutor_Rollback(t *testing.T) {
 			DefinitionName: newversion.OperationName,
 			SchedulerName:  newScheduler.Name,
 		}
-		operationDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: &newScheduler}
+		operationDef := &newversion.Definition{NewScheduler: &newScheduler}
 		roomManager := mockports.NewMockRoomManager(mockCtrl)
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationsManager := mockports.NewMockOperationManager(mockCtrl)

--- a/internal/core/operations/schedulers/switchversion/switch_active_version_definition.go
+++ b/internal/core/operations/schedulers/switchversion/switch_active_version_definition.go
@@ -33,19 +33,19 @@ import (
 
 const OperationName = "switch_active_version"
 
-type SwitchActiveVersionDefinition struct {
+type Definition struct {
 	NewActiveVersion string `json:"newActiveVersion"`
 }
 
-func (d *SwitchActiveVersionDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
+func (d *Definition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
 	return true
 }
 
-func (d *SwitchActiveVersionDefinition) Name() string {
+func (d *Definition) Name() string {
 	return OperationName
 }
 
-func (d *SwitchActiveVersionDefinition) Marshal() []byte {
+func (d *Definition) Marshal() []byte {
 	bytes, err := json.Marshal(d)
 	if err != nil {
 		zap.L().With(zap.Error(err)).Error("error marshalling switch active version operation definition")
@@ -55,7 +55,7 @@ func (d *SwitchActiveVersionDefinition) Marshal() []byte {
 	return bytes
 }
 
-func (d *SwitchActiveVersionDefinition) Unmarshal(raw []byte) error {
+func (d *Definition) Unmarshal(raw []byte) error {
 	err := json.Unmarshal(raw, d)
 	if err != nil {
 		return fmt.Errorf("error marshalling switch active version operation definition: %w", err)

--- a/internal/core/operations/schedulers/switchversion/switch_active_version_executor_test.go
+++ b/internal/core/operations/schedulers/switchversion/switch_active_version_executor_test.go
@@ -60,7 +60,7 @@ type mockRoomAndSchedulerAndOperationManager struct {
 	schedulerCache   *mockports.MockSchedulerCache
 }
 
-func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
+func TestExecutor_Execute(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
 	err := validations.RegisterValidations()
@@ -81,7 +81,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	maxSurge := 3
 
 	t.Run("should succeed - Execute switch active version operation replacing pods", func(t *testing.T) {
-		definition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMajorScheduler.Spec.Version}
+		definition := &switchversion.Definition{NewActiveVersion: newMajorScheduler.Spec.Version}
 
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 		mocks.roomManager.EXPECT().SchedulerMaxSurge(gomock.Any(), gomock.Any()).Return(3, nil)
@@ -138,7 +138,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 
 	t.Run("should succeed - Execute switch active version operation not replacing pods", func(t *testing.T) {
-		noReplaceDefinition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMinorScheduler.Spec.Version}
+		noReplaceDefinition := &switchversion.Definition{NewActiveVersion: newMinorScheduler.Spec.Version}
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 
 		mocks.schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), activeScheduler.Name).Return(activeScheduler, nil)
@@ -151,7 +151,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 
 	t.Run("should succeed - Execute switch active version operation (no running rooms)", func(t *testing.T) {
-		definition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMajorScheduler.Spec.Version}
+		definition := &switchversion.Definition{NewActiveVersion: newMajorScheduler.Spec.Version}
 
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 		mocks.roomManager.EXPECT().SchedulerMaxSurge(gomock.Any(), gomock.Any()).Return(maxSurge, nil)
@@ -171,7 +171,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 
 	t.Run("should succeed - Can't create room", func(t *testing.T) {
-		definition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMajorScheduler.Spec.Version}
+		definition := &switchversion.Definition{NewActiveVersion: newMajorScheduler.Spec.Version}
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 
 		mocks.schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), activeScheduler.Name).Return(activeScheduler, nil)
@@ -207,7 +207,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 
 	t.Run("should fail - Can't update scheduler (switch active version on database)", func(t *testing.T) {
-		noReplaceDefinition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMinorScheduler.Spec.Version}
+		noReplaceDefinition := &switchversion.Definition{NewActiveVersion: newMinorScheduler.Spec.Version}
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 
 		mocks.schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), activeScheduler.Name).Return(activeScheduler, nil)
@@ -220,7 +220,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 
 	t.Run("should fail - Can't delete room", func(t *testing.T) {
-		definition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMajorScheduler.Spec.Version}
+		definition := &switchversion.Definition{NewActiveVersion: newMajorScheduler.Spec.Version}
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 
 		mocks.schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), activeScheduler.Name).Return(activeScheduler, nil)
@@ -254,7 +254,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 
 	t.Run("should fail - Can't find max surge", func(t *testing.T) {
-		definition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMajorScheduler.Spec.Version}
+		definition := &switchversion.Definition{NewActiveVersion: newMajorScheduler.Spec.Version}
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 		mocks.roomManager.EXPECT().SchedulerMaxSurge(gomock.Any(), gomock.Any()).Return(0, errors.New("error"))
 
@@ -267,7 +267,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 
 	t.Run("should fail - Can't list rooms to delete", func(t *testing.T) {
-		definition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMajorScheduler.Spec.Version}
+		definition := &switchversion.Definition{NewActiveVersion: newMajorScheduler.Spec.Version}
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 
 		mocks.schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), activeScheduler.Name).Return(activeScheduler, nil)
@@ -285,7 +285,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 
 	t.Run("should fail - Can't count total rooms amount", func(t *testing.T) {
-		definition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMajorScheduler.Spec.Version}
+		definition := &switchversion.Definition{NewActiveVersion: newMajorScheduler.Spec.Version}
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 
 		mocks.schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), activeScheduler.Name).Return(activeScheduler, nil)
@@ -301,7 +301,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 
 	t.Run("should fail - Can't get new scheduler", func(t *testing.T) {
-		definition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMajorScheduler.Spec.Version}
+		definition := &switchversion.Definition{NewActiveVersion: newMajorScheduler.Spec.Version}
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 
 		mocks.schedulerManager.EXPECT().GetSchedulerByVersion(gomock.Any(), newMajorScheduler.Name, newMajorScheduler.Spec.Version).Return(nil, errors.New("error"))
@@ -312,7 +312,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 
 	t.Run("should fail - Can't get active scheduler", func(t *testing.T) {
-		definition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMajorScheduler.Spec.Version}
+		definition := &switchversion.Definition{NewActiveVersion: newMajorScheduler.Spec.Version}
 		mocks := newMockRoomAndSchedulerManager(mockCtrl)
 
 		mocks.schedulerManager.EXPECT().GetSchedulerByVersion(gomock.Any(), newMajorScheduler.Name, newMajorScheduler.Spec.Version).Return(newMajorScheduler, nil)
@@ -324,7 +324,7 @@ func TestSwitchActiveVersionOperation_Execute(t *testing.T) {
 	})
 }
 
-func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
+func TestExecutor_Rollback(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mocks := newMockRoomAndSchedulerManager(mockCtrl)
 
@@ -345,7 +345,7 @@ func TestSwitchActiveVersionOperation_Rollback(t *testing.T) {
 
 	maxSurge := 3
 
-	definition := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newMajorScheduler.Spec.Version}
+	definition := &switchversion.Definition{NewActiveVersion: newMajorScheduler.Spec.Version}
 
 	t.Run("should succeed - Execute on error if operation finishes (no created rooms)", func(t *testing.T) {
 		executor := switchversion.NewExecutor(mocks.roomManager, mocks.schedulerManager, mocks.operationManager, mocks.roomStorage)

--- a/internal/core/operations/test/test_operation_definition.go
+++ b/internal/core/operations/test/test_operation_definition.go
@@ -33,19 +33,19 @@ import (
 
 const OperationName = "test_operation"
 
-type TestOperationDefinition struct {
+type Definition struct {
 	SleepSeconds int `json:"sleepSeconds"`
 }
 
-func (d *TestOperationDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
+func (d *Definition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
 	return true
 }
 
-func (d *TestOperationDefinition) Name() string {
+func (d *Definition) Name() string {
 	return OperationName
 }
 
-func (d *TestOperationDefinition) Marshal() []byte {
+func (d *Definition) Marshal() []byte {
 	bytes, err := json.Marshal(d)
 	if err != nil {
 		zap.L().With(zap.Error(err)).Error("error marshalling test operation definition")
@@ -55,7 +55,7 @@ func (d *TestOperationDefinition) Marshal() []byte {
 	return bytes
 }
 
-func (d *TestOperationDefinition) Unmarshal(raw []byte) error {
+func (d *Definition) Unmarshal(raw []byte) error {
 	err := json.Unmarshal(raw, d)
 	if err != nil {
 		return fmt.Errorf("error marshalling test operation definition: %w", err)

--- a/internal/core/operations/test/test_operation_executor.go
+++ b/internal/core/operations/test/test_operation_executor.go
@@ -31,16 +31,16 @@ import (
 	"go.uber.org/zap"
 )
 
-type TestOperationExecutor struct{}
+type Executor struct{}
 
-var _ operations.Executor = (*TestOperationExecutor)(nil)
+var _ operations.Executor = (*Executor)(nil)
 
-func NewExecutor() *TestOperationExecutor {
-	return &TestOperationExecutor{}
+func NewExecutor() *Executor {
+	return &Executor{}
 }
 
-func (e *TestOperationExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
-	testOperationDefinition := definition.(*TestOperationDefinition)
+func (e *Executor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
+	testOperationDefinition := definition.(*Definition)
 
 	zap.L().Sugar().Infof("sleeping routine for %d seconds", testOperationDefinition.SleepSeconds)
 
@@ -58,10 +58,10 @@ func (e *TestOperationExecutor) Execute(ctx context.Context, op *operation.Opera
 }
 
 // Rollback will do nothing.
-func (e *TestOperationExecutor) Rollback(_ context.Context, _ *operation.Operation, _ operations.Definition, _ error) error {
+func (e *Executor) Rollback(_ context.Context, _ *operation.Operation, _ operations.Definition, _ error) error {
 	return nil
 }
 
-func (e *TestOperationExecutor) Name() string {
+func (e *Executor) Name() string {
 	return OperationName
 }

--- a/internal/core/services/schedulers/scheduler_manager.go
+++ b/internal/core/services/schedulers/scheduler_manager.go
@@ -162,7 +162,7 @@ func (s *SchedulerManager) PatchSchedulerAndCreateNewSchedulerVersionOperation(c
 		return nil, portsErrors.NewErrInvalidArgument("invalid patched scheduler: %s", err.Error())
 	}
 
-	opDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: scheduler}
+	opDef := &newversion.Definition{NewScheduler: scheduler}
 
 	op, err := s.operationManager.CreateOperation(ctx, scheduler.Name, opDef)
 	if err != nil {
@@ -199,7 +199,7 @@ func (s *SchedulerManager) EnqueueNewSchedulerVersionOperation(ctx context.Conte
 		return nil, err
 	}
 
-	opDef := &newversion.CreateNewSchedulerVersionDefinition{NewScheduler: scheduler}
+	opDef := &newversion.Definition{NewScheduler: scheduler}
 
 	op, err := s.operationManager.CreateOperation(ctx, scheduler.Name, opDef)
 	if err != nil {
@@ -210,7 +210,7 @@ func (s *SchedulerManager) EnqueueNewSchedulerVersionOperation(ctx context.Conte
 }
 
 func (s *SchedulerManager) EnqueueSwitchActiveVersionOperation(ctx context.Context, schedulerName, newVersion string) (*operation.Operation, error) {
-	opDef := &switchversion.SwitchActiveVersionDefinition{NewActiveVersion: newVersion}
+	opDef := &switchversion.Definition{NewActiveVersion: newVersion}
 	op, err := s.operationManager.CreateOperation(ctx, schedulerName, opDef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to schedule %s operation: %w", opDef.Name(), err)
@@ -228,7 +228,7 @@ func (s *SchedulerManager) EnqueueDeleteSchedulerOperation(ctx context.Context, 
 
 		return nil, portsErrors.NewErrUnexpected("unexpected error getting scheduler to delete: %s", err.Error())
 	}
-	opDef := &delete.DeleteSchedulerDefinition{}
+	opDef := &delete.Definition{}
 	op, err := s.operationManager.CreateOperation(ctx, schedulerName, opDef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to schedule %s operation: %w", opDef.Name(), err)

--- a/internal/core/services/schedulers/scheduler_manager_test.go
+++ b/internal/core/services/schedulers/scheduler_manager_test.go
@@ -306,7 +306,7 @@ func TestDeleteSchedulerOperation(t *testing.T) {
 	t.Run("return the operation when no error occurs using cache", func(t *testing.T) {
 		scheduler := newValidScheduler()
 		scheduler.PortRange = &entities.PortRange{Start: 0, End: 1}
-		opDef := &delete.DeleteSchedulerDefinition{}
+		opDef := &delete.Definition{}
 
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
@@ -327,7 +327,7 @@ func TestDeleteSchedulerOperation(t *testing.T) {
 	t.Run("return the operation when no error occurs using storage", func(t *testing.T) {
 		scheduler := newValidScheduler()
 		scheduler.PortRange = &entities.PortRange{Start: 0, End: 1}
-		opDef := &delete.DeleteSchedulerDefinition{}
+		opDef := &delete.Definition{}
 
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
@@ -349,7 +349,7 @@ func TestDeleteSchedulerOperation(t *testing.T) {
 	t.Run("return error when some error occurs while creating operation", func(t *testing.T) {
 		scheduler := newValidScheduler()
 		scheduler.PortRange = &entities.PortRange{Start: 0, End: 1}
-		opDef := &delete.DeleteSchedulerDefinition{}
+		opDef := &delete.Definition{}
 
 		ctx := context.Background()
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
@@ -876,7 +876,7 @@ func TestPatchSchedulerAndSwitchActiveVersionOperation(t *testing.T) {
 		Output
 	}{
 		{
-			Title: "There are parameters then send scheduler to CreateNewSchedulerVersionDefinition to changing it",
+			Title: "There are parameters then send scheduler to Definition to changing it",
 			Input: Input{
 				PatchMap: map[string]interface{}{
 					patch.LabelSchedulerMaxSurge: "12%",
@@ -1017,7 +1017,7 @@ func TestPatchSchedulerAndSwitchActiveVersionOperation(t *testing.T) {
 			mockSchedulerStorage.EXPECT().GetScheduler(gomock.Any(), scheduler.Name).Return(scheduler, testCase.ExpectedMock.GetSchedulerError)
 			mockOperationManager.EXPECT().
 				CreateOperation(gomock.Any(), scheduler.Name, gomock.Any()).Do(func(_ context.Context, _ string, op operations.Definition) {
-				newSchedulerVersion, ok := op.(*newversion.CreateNewSchedulerVersionDefinition)
+				newSchedulerVersion, ok := op.(*newversion.Definition)
 				assert.True(t, ok)
 				assert.EqualValues(t, testCase.ExpectedMock.ChangedSchedulerFunction(), newSchedulerVersion.NewScheduler)
 			}).


### PR DESCRIPTION
### What ❓ 
Normalize operations struct names

### Why 🤔 
After updating our package names, we must update some struct names to match its package name and remove redundancy