### PR TITLE
Refact healthcontroller names

### DIFF
--- a/e2e/suites/list_operations_test.go
+++ b/e2e/suites/list_operations_test.go
@@ -181,7 +181,7 @@ func TestListOperations(t *testing.T) {
 }
 
 func assertHealthControllerTookAction(t *testing.T, redisClient *redis.Client, scheduler *maestroApiV1.Scheduler, finishedOp *maestroApiV1.ListOperationItem) {
-	healthControllerDef := healthcontroller.SchedulerHealthControllerDefinition{}
+	healthControllerDef := healthcontroller.Definition{}
 	definitionContents, err := redisClient.HGet(context.Background(), fmt.Sprintf("operations:%s:%s", scheduler.Name, finishedOp.Id), "definitionContents").Result()
 	require.NoError(t, err)
 	err = healthControllerDef.Unmarshal([]byte(definitionContents))

--- a/internal/adapters/storage/redis/operation/operation_storage_redis.go
+++ b/internal/adapters/storage/redis/operation/operation_storage_redis.go
@@ -419,7 +419,7 @@ func (r *redisOperationStorage) updateOperationInSortedSet(ctx context.Context, 
 
 func operationHasAction(op *operation.Operation) (bool, error) {
 	if op.DefinitionName == healthcontroller.OperationName {
-		def := healthcontroller.SchedulerHealthControllerDefinition{}
+		def := healthcontroller.Definition{}
 		err := def.Unmarshal(op.Input)
 		if err != nil {
 			return false, err

--- a/internal/adapters/storage/redis/operation/operation_storage_redis_test.go
+++ b/internal/adapters/storage/redis/operation/operation_storage_redis_test.go
@@ -668,7 +668,7 @@ func TestUpdateOperationStatus(t *testing.T) {
 			op.Status = operation.StatusInProgress
 			op.DefinitionName = healthcontroller.OperationName
 			tookAction := false
-			definition := &healthcontroller.SchedulerHealthControllerDefinition{TookAction: &tookAction}
+			definition := &healthcontroller.Definition{TookAction: &tookAction}
 			op.Input = definition.Marshal()
 
 			// Create Operation hashmap and add it to active sorted set
@@ -748,7 +748,7 @@ func TestUpdateOperationDefinition(t *testing.T) {
 		operationsTTLMap := map[Definition]time.Duration{}
 		storage := NewRedisOperationStorage(client, clock, operationsTTLMap)
 		tookAction := true
-		definition := healthcontroller.SchedulerHealthControllerDefinition{TookAction: &tookAction}
+		definition := healthcontroller.Definition{TookAction: &tookAction}
 
 		err := client.HSet(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID), map[string]interface{}{
 			idRedisKey:                 op.ID,
@@ -764,7 +764,7 @@ func TestUpdateOperationDefinition(t *testing.T) {
 		require.NoError(t, err)
 
 		resultMap := client.HGetAll(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID)).Val()
-		updatedDefinition := healthcontroller.SchedulerHealthControllerDefinition{}
+		updatedDefinition := healthcontroller.Definition{}
 		definitionContents := resultMap[definitionContentsRedisKey]
 		err = updatedDefinition.Unmarshal([]byte(definitionContents))
 		require.NoError(t, err)
@@ -777,7 +777,7 @@ func TestUpdateOperationDefinition(t *testing.T) {
 		operationsTTLMap := map[Definition]time.Duration{}
 		storage := NewRedisOperationStorage(client, clock, operationsTTLMap)
 		tookAction := true
-		definition := healthcontroller.SchedulerHealthControllerDefinition{TookAction: &tookAction}
+		definition := healthcontroller.Definition{TookAction: &tookAction}
 
 		err := client.HSet(context.Background(), storage.buildSchedulerOperationKey(op.SchedulerName, op.ID), map[string]interface{}{
 			idRedisKey:                 op.ID,

--- a/internal/core/operations/healthcontroller/definition.go
+++ b/internal/core/operations/healthcontroller/definition.go
@@ -33,19 +33,19 @@ import (
 
 const OperationName = "health_controller"
 
-type SchedulerHealthControllerDefinition struct {
+type Definition struct {
 	TookAction *bool `json:"took_action,omitempty"`
 }
 
-func (def *SchedulerHealthControllerDefinition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
+func (def *Definition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
 	return true
 }
 
-func (def *SchedulerHealthControllerDefinition) Name() string {
+func (def *Definition) Name() string {
 	return OperationName
 }
 
-func (def *SchedulerHealthControllerDefinition) Marshal() []byte {
+func (def *Definition) Marshal() []byte {
 	bytes, err := json.Marshal(def)
 	if err != nil {
 		zap.L().With(zap.Error(err)).Error("error marshalling update scheduler operation definition")
@@ -55,7 +55,7 @@ func (def *SchedulerHealthControllerDefinition) Marshal() []byte {
 	return bytes
 }
 
-func (def *SchedulerHealthControllerDefinition) Unmarshal(raw []byte) error {
+func (def *Definition) Unmarshal(raw []byte) error {
 	err := json.Unmarshal(raw, def)
 	if err != nil {
 		return fmt.Errorf("error marshalling update scheduler operation definition: %w", err)

--- a/internal/core/operations/healthcontroller/executor.go
+++ b/internal/core/operations/healthcontroller/executor.go
@@ -79,7 +79,7 @@ func (ex *SchedulerHealthControllerExecutor) Execute(ctx context.Context, op *op
 		zap.String(logs.LogFieldOperationPhase, "Execute"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
-	def := definition.(*SchedulerHealthControllerDefinition)
+	def := definition.(*Definition)
 
 	gameRoomIDs, instances, scheduler, err := ex.loadActualState(ctx, op, logger)
 	if err != nil {
@@ -165,7 +165,7 @@ func (ex *SchedulerHealthControllerExecutor) tryEnsureCorrectRoomsOnStorage(ctx 
 	}
 }
 
-func (ex *SchedulerHealthControllerExecutor) ensureDesiredAmountOfInstances(ctx context.Context, op *operation.Operation, def *SchedulerHealthControllerDefinition, logger *zap.Logger, actualAmount, desiredAmount int) error {
+func (ex *SchedulerHealthControllerExecutor) ensureDesiredAmountOfInstances(ctx context.Context, op *operation.Operation, def *Definition, logger *zap.Logger, actualAmount, desiredAmount int) error {
 	var msgToAppend string
 	var tookAction bool
 
@@ -307,7 +307,7 @@ func (ex *SchedulerHealthControllerExecutor) mapExistentAndNonExistentGameRooms(
 	return nonexistentGameRoomsIDs, existentGameRoomsInstancesMap
 }
 
-func (ex *SchedulerHealthControllerExecutor) setTookAction(def *SchedulerHealthControllerDefinition, tookAction bool) {
+func (ex *SchedulerHealthControllerExecutor) setTookAction(def *Definition, tookAction bool) {
 	if def.TookAction != nil && *def.TookAction {
 		return
 	}

--- a/internal/core/operations/healthcontroller/executor.go
+++ b/internal/core/operations/healthcontroller/executor.go
@@ -47,8 +47,8 @@ type Config struct {
 	RoomDeletionTimeout       time.Duration
 }
 
-// SchedulerHealthControllerExecutor holds dependencies to execute SchedulerHealthControllerExecutor.
-type SchedulerHealthControllerExecutor struct {
+// Executor holds dependencies to execute Executor.
+type Executor struct {
 	autoscaler       ports.Autoscaler
 	roomStorage      ports.RoomStorage
 	instanceStorage  ports.GameRoomInstanceStorage
@@ -57,11 +57,11 @@ type SchedulerHealthControllerExecutor struct {
 	config           Config
 }
 
-var _ operations.Executor = (*SchedulerHealthControllerExecutor)(nil)
+var _ operations.Executor = (*Executor)(nil)
 
-// NewExecutor creates a new instance of SchedulerHealthControllerExecutor.
-func NewExecutor(roomStorage ports.RoomStorage, instanceStorage ports.GameRoomInstanceStorage, schedulerStorage ports.SchedulerStorage, operationManager ports.OperationManager, autoscaler ports.Autoscaler, config Config) *SchedulerHealthControllerExecutor {
-	return &SchedulerHealthControllerExecutor{
+// NewExecutor creates a new instance of Executor.
+func NewExecutor(roomStorage ports.RoomStorage, instanceStorage ports.GameRoomInstanceStorage, schedulerStorage ports.SchedulerStorage, operationManager ports.OperationManager, autoscaler ports.Autoscaler, config Config) *Executor {
+	return &Executor{
 		autoscaler:       autoscaler,
 		roomStorage:      roomStorage,
 		instanceStorage:  instanceStorage,
@@ -72,7 +72,7 @@ func NewExecutor(roomStorage ports.RoomStorage, instanceStorage ports.GameRoomIn
 }
 
 // Execute run the operation health_controller.
-func (ex *SchedulerHealthControllerExecutor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
+func (ex *Executor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
@@ -118,16 +118,16 @@ func (ex *SchedulerHealthControllerExecutor) Execute(ctx context.Context, op *op
 }
 
 // Rollback does not execute anything when a rollback executes.
-func (ex *SchedulerHealthControllerExecutor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
+func (ex *Executor) Rollback(ctx context.Context, op *operation.Operation, definition operations.Definition, executeErr error) error {
 	return nil
 }
 
 // Name return the name of the operation.
-func (ex *SchedulerHealthControllerExecutor) Name() string {
+func (ex *Executor) Name() string {
 	return OperationName
 }
 
-func (ex *SchedulerHealthControllerExecutor) loadActualState(ctx context.Context, op *operation.Operation, logger *zap.Logger) (gameRoomIDs []string, instances []*game_room.Instance, scheduler *entities.Scheduler, err error) {
+func (ex *Executor) loadActualState(ctx context.Context, op *operation.Operation, logger *zap.Logger) (gameRoomIDs []string, instances []*game_room.Instance, scheduler *entities.Scheduler, err error) {
 	gameRoomIDs, err = ex.roomStorage.GetAllRoomIDs(ctx, op.SchedulerName)
 	if err != nil {
 		logger.Error("error fetching game rooms")
@@ -146,7 +146,7 @@ func (ex *SchedulerHealthControllerExecutor) loadActualState(ctx context.Context
 	return
 }
 
-func (ex *SchedulerHealthControllerExecutor) tryEnsureCorrectRoomsOnStorage(ctx context.Context, op *operation.Operation, logger *zap.Logger, nonexistentGameRoomIDs []string) {
+func (ex *Executor) tryEnsureCorrectRoomsOnStorage(ctx context.Context, op *operation.Operation, logger *zap.Logger, nonexistentGameRoomIDs []string) {
 	for _, gameRoomID := range nonexistentGameRoomIDs {
 		roomStorageErr := ex.roomStorage.DeleteRoom(ctx, op.SchedulerName, gameRoomID)
 		instanceStorageErr := ex.instanceStorage.DeleteInstance(ctx, op.SchedulerName, gameRoomID)
@@ -165,7 +165,7 @@ func (ex *SchedulerHealthControllerExecutor) tryEnsureCorrectRoomsOnStorage(ctx 
 	}
 }
 
-func (ex *SchedulerHealthControllerExecutor) ensureDesiredAmountOfInstances(ctx context.Context, op *operation.Operation, def *Definition, logger *zap.Logger, actualAmount, desiredAmount int) error {
+func (ex *Executor) ensureDesiredAmountOfInstances(ctx context.Context, op *operation.Operation, def *Definition, logger *zap.Logger, actualAmount, desiredAmount int) error {
 	var msgToAppend string
 	var tookAction bool
 
@@ -201,7 +201,7 @@ func (ex *SchedulerHealthControllerExecutor) ensureDesiredAmountOfInstances(ctx 
 	return nil
 }
 
-func (ex *SchedulerHealthControllerExecutor) findAvailableAndExpiredRooms(ctx context.Context, op *operation.Operation, existentGameRoomsInstancesMap map[string]*game_room.Instance) (availableRoomsIDs, expiredRoomsIDs []string) {
+func (ex *Executor) findAvailableAndExpiredRooms(ctx context.Context, op *operation.Operation, existentGameRoomsInstancesMap map[string]*game_room.Instance) (availableRoomsIDs, expiredRoomsIDs []string) {
 	for gameRoomId, instance := range existentGameRoomsInstancesMap {
 		if instance.Status.Type == game_room.InstancePending {
 			availableRoomsIDs = append(availableRoomsIDs, gameRoomId)
@@ -232,27 +232,27 @@ func (ex *SchedulerHealthControllerExecutor) findAvailableAndExpiredRooms(ctx co
 	return availableRoomsIDs, expiredRoomsIDs
 }
 
-func (ex *SchedulerHealthControllerExecutor) isInitializingRoomExpired(room *game_room.GameRoom) bool {
+func (ex *Executor) isInitializingRoomExpired(room *game_room.GameRoom) bool {
 	timeDurationInPendingState := time.Since(room.CreatedAt)
 	return (ex.isRoomStatus(room, game_room.GameStatusPending) || ex.isRoomStatus(room, game_room.GameStatusUnready)) &&
 		timeDurationInPendingState > ex.config.RoomInitializationTimeout
 }
 
-func (ex *SchedulerHealthControllerExecutor) isRoomPingExpired(room *game_room.GameRoom) bool {
+func (ex *Executor) isRoomPingExpired(room *game_room.GameRoom) bool {
 	timeDurationWithoutPing := time.Since(room.LastPingAt)
 	return !ex.isRoomStatus(room, game_room.GameStatusPending) && timeDurationWithoutPing > ex.config.RoomPingTimeout
 }
 
-func (ex *SchedulerHealthControllerExecutor) isRoomTerminatingExpired(room *game_room.GameRoom) bool {
+func (ex *Executor) isRoomTerminatingExpired(room *game_room.GameRoom) bool {
 	timeDurationWithoutPing := time.Since(room.LastPingAt)
 	return ex.isRoomStatus(room, game_room.GameStatusTerminating) && timeDurationWithoutPing > ex.config.RoomDeletionTimeout
 }
 
-func (ex *SchedulerHealthControllerExecutor) isRoomStatus(room *game_room.GameRoom, status game_room.GameRoomStatus) bool {
+func (ex *Executor) isRoomStatus(room *game_room.GameRoom, status game_room.GameRoomStatus) bool {
 	return room.Status == status
 }
 
-func (ex *SchedulerHealthControllerExecutor) enqueueRemoveExpiredRooms(ctx context.Context, op *operation.Operation, logger *zap.Logger, expiredRoomsIDs []string) error {
+func (ex *Executor) enqueueRemoveExpiredRooms(ctx context.Context, op *operation.Operation, logger *zap.Logger, expiredRoomsIDs []string) error {
 	removeOperation, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &remove.Definition{
 		RoomsIDs: expiredRoomsIDs,
 	})
@@ -267,7 +267,7 @@ func (ex *SchedulerHealthControllerExecutor) enqueueRemoveExpiredRooms(ctx conte
 	return nil
 }
 
-func (ex *SchedulerHealthControllerExecutor) getDesiredNumberOfRooms(ctx context.Context, logger *zap.Logger, scheduler *entities.Scheduler) (int, error) {
+func (ex *Executor) getDesiredNumberOfRooms(ctx context.Context, logger *zap.Logger, scheduler *entities.Scheduler) (int, error) {
 	if scheduler.Autoscaling != nil && scheduler.Autoscaling.Enabled {
 		desiredNumberOfRooms, err := ex.autoscaler.CalculateDesiredNumberOfRooms(ctx, scheduler)
 		if err != nil {
@@ -281,7 +281,7 @@ func (ex *SchedulerHealthControllerExecutor) getDesiredNumberOfRooms(ctx context
 	return scheduler.RoomsReplicas, nil
 }
 
-func (ex *SchedulerHealthControllerExecutor) mapExistentAndNonExistentGameRooms(gameRoomIDs []string, instances []*game_room.Instance) ([]string, map[string]*game_room.Instance) {
+func (ex *Executor) mapExistentAndNonExistentGameRooms(gameRoomIDs []string, instances []*game_room.Instance) ([]string, map[string]*game_room.Instance) {
 	roomIdCountMap := make(map[string]int)
 	nonexistentGameRoomsIDs := make([]string, 0)
 	existentGameRoomsInstancesMap := make(map[string]*game_room.Instance)
@@ -307,7 +307,7 @@ func (ex *SchedulerHealthControllerExecutor) mapExistentAndNonExistentGameRooms(
 	return nonexistentGameRoomsIDs, existentGameRoomsInstancesMap
 }
 
-func (ex *SchedulerHealthControllerExecutor) setTookAction(def *Definition, tookAction bool) {
+func (ex *Executor) setTookAction(def *Definition, tookAction bool) {
 	if def.TookAction != nil && *def.TookAction {
 		return
 	}

--- a/internal/core/operations/healthcontroller/executor_test.go
+++ b/internal/core/operations/healthcontroller/executor_test.go
@@ -69,7 +69,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		Parameters: autoscaling.PolicyParameters{},
 	}}
 
-	definition := &healthcontroller.SchedulerHealthControllerDefinition{}
+	definition := &healthcontroller.Definition{}
 	genericSchedulerNoAutoscaling := newValidScheduler(nil)
 	genericSchedulerAutoscalingDisabled := newValidScheduler(&autoscalingDisabled)
 	genericSchedulerAutoscalingEnabled := newValidScheduler(&autoscalingEnabled)
@@ -78,12 +78,12 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 
 	testCases := []struct {
 		title      string
-		definition *healthcontroller.SchedulerHealthControllerDefinition
+		definition *healthcontroller.Definition
 		executionPlan
 	}{
 		{
 			title:      "nothing to do, no operations enqueued",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -103,7 +103,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "game room status pending with no initialization timeout found, considered available, so nothing to do, no operations enqueued",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -158,7 +158,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "game room status pending with initialization timeout found, considered expired, remove room operation enqueued",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -219,7 +219,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "game room status unready with initialization timeout found, considered expired, remove room operation enqueued",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -280,7 +280,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "game room status unready and not expired found, considered available, so nothing to do, no operations enqueued",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -335,7 +335,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "nonexistent game room IDs found, deletes from game room and instance storage",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -377,7 +377,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "nonexistent game room IDs found but fails on first, keeps trying to delete",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -421,7 +421,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "expired room found, enqueue remove rooms with specified ID",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -479,7 +479,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "instance is still pending, do nothing",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: false,
 				planMocks: func(
@@ -509,7 +509,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "expired room found, enqueue remove rooms with specified ID fails, continues operation and enqueue new add rooms",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -568,7 +568,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "autoscaling not configured, have less available rooms than expected, enqueue add rooms",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -594,7 +594,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "autoscaling configured but disabled, have less available rooms than expected, enqueue add rooms",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -620,7 +620,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "autoscaling configured and enabled, have less available rooms than expected, enqueue add rooms",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -646,7 +646,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "enqueue add rooms fails, finish operation",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -671,7 +671,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "autoscaling not configured, have more available rooms than expected, enqueue remove rooms",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -713,7 +713,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "autoscaling configured but disabled, have more available rooms than expected, enqueue remove rooms",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -755,7 +755,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "autoscaling configured and enabled, have more available rooms than expected, enqueue remove rooms",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -797,7 +797,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "enqueue remove rooms fails, finish operation with error",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -838,7 +838,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "fails loading rooms, stops operation",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -855,7 +855,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "fails loading instances, stops operation",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -873,7 +873,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "fails loading scheduler, stops operation",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -892,7 +892,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "fails calculating the desired number of rooms with autoscaler, stops operation and return error",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -931,7 +931,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "fails on getRoom, consider room ignored and enqueues new add rooms",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -979,7 +979,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "room with status error, consider room ignored and enqueues new add rooms",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -1034,7 +1034,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "room with status terminating, and considered valid, consider room ignored and enqueues new add rooms",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(
@@ -1089,7 +1089,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		},
 		{
 			title:      "game room status terminating with terminating timeout found, considered expired, remove room operation enqueued",
-			definition: &healthcontroller.SchedulerHealthControllerDefinition{},
+			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
 				planMocks: func(

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -58,7 +58,7 @@ func ProvideDefinitionConstructors() map[string]operations.DefinitionConstructor
 		return &switchversion.Definition{}
 	}
 	definitionConstructors[healthcontroller.OperationName] = func() operations.Definition {
-		return &healthcontroller.SchedulerHealthControllerDefinition{}
+		return &healthcontroller.Definition{}
 	}
 	definitionConstructors[deletescheduler.OperationName] = func() operations.Definition {
 		return &deletescheduler.Definition{}

--- a/internal/core/worker/operationexecution/operation_execution_worker.go
+++ b/internal/core/worker/operationexecution/operation_execution_worker.go
@@ -261,7 +261,7 @@ func (w *OperationExecutionWorker) shouldEvictOperation(op *operation.Operation,
 }
 
 func (w *OperationExecutionWorker) createHealthControllerOperation(ctx context.Context) error {
-	_, err := w.operationManager.CreateOperation(ctx, w.scheduler.Name, &healthcontroller.SchedulerHealthControllerDefinition{})
+	_, err := w.operationManager.CreateOperation(ctx, w.scheduler.Name, &healthcontroller.Definition{})
 	if err != nil {
 		return fmt.Errorf("not able to schedule the 'health_controller' operation: %w", err)
 	}

--- a/internal/core/worker/operationexecution/operation_execution_worker_test.go
+++ b/internal/core/worker/operationexecution/operation_execution_worker_test.go
@@ -573,7 +573,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), gomock.Any()).Return(pendingOpsChan)
-		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, &healthcontroller.SchedulerHealthControllerDefinition{}).Return(&operation.Operation{}, nil).MaxTimes(5)
+		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, &healthcontroller.Definition{}).Return(&operation.Operation{}, nil).MaxTimes(5)
 
 		ctx, cancel := context.WithCancel(context.Background())
 
@@ -612,7 +612,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), gomock.Any()).Return(pendingOpsChan)
-		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, &healthcontroller.SchedulerHealthControllerDefinition{}).Return(nil, fmt.Errorf("Error on creating operation")).MaxTimes(5)
+		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, &healthcontroller.Definition{}).Return(nil, fmt.Errorf("Error on creating operation")).MaxTimes(5)
 
 		ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
This PR proposes to improve the names of the `healthcontroller` operation to be more golang way. They include changing the name of files to a more simple one, simplifying the operation definition from `SchedulerHealthControllerDefinition` to only `Definition` and the executor from `SchedulerHealthControllerExecutor` to `Executor`.