### PR TITLE
Implement storagecleanup operation executor

### DIFF
--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -31,6 +31,7 @@ import (
 	deletescheduler "github.com/topfreegames/maestro/internal/core/operations/schedulers/delete"
 	newversion "github.com/topfreegames/maestro/internal/core/operations/schedulers/newversion"
 	"github.com/topfreegames/maestro/internal/core/operations/schedulers/switchversion"
+	"github.com/topfreegames/maestro/internal/core/operations/storagecleanup"
 	"github.com/topfreegames/maestro/internal/core/operations/test"
 	"github.com/topfreegames/maestro/internal/core/ports"
 )
@@ -62,6 +63,9 @@ func ProvideDefinitionConstructors() map[string]operations.DefinitionConstructor
 	}
 	definitionConstructors[deletescheduler.OperationName] = func() operations.Definition {
 		return &deletescheduler.Definition{}
+	}
+	definitionConstructors[storagecleanup.OperationName] = func() operations.Definition {
+		return &storagecleanup.Definition{}
 	}
 
 	return definitionConstructors

--- a/internal/core/operations/storagecleanup/definition.go
+++ b/internal/core/operations/storagecleanup/definition.go
@@ -28,21 +28,29 @@ import (
 	"fmt"
 
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/operations"
 	"go.uber.org/zap"
 )
 
+// OperationName is the storage clean up operation name constant.
 const OperationName = "storage_clean_up"
 
+var _ operations.Definition = (*Definition)(nil)
+
+// Definition is the definition struct to storage clean up operation.
 type Definition struct{}
 
+// ShouldExecute returns true since every time the operation was called it will execute its function.
 func (d *Definition) ShouldExecute(_ context.Context, _ []*operation.Operation) bool {
 	return true
 }
 
+// Name returns the name of the operation.
 func (d *Definition) Name() string {
 	return OperationName
 }
 
+// Marshal format the definition as json byte array.
 func (d *Definition) Marshal() []byte {
 	bytes, err := json.Marshal(d)
 	if err != nil {
@@ -53,6 +61,7 @@ func (d *Definition) Marshal() []byte {
 	return bytes
 }
 
+// Unmarshal fill an storage clean-up operation from a byte array JSON.
 func (d *Definition) Unmarshal(raw []byte) error {
 	err := json.Unmarshal(raw, d)
 	if err != nil {
@@ -62,6 +71,7 @@ func (d *Definition) Unmarshal(raw []byte) error {
 	return nil
 }
 
+// HasNoAction returns if the operation has action to be logged on the operation history.
 func (d *Definition) HasNoAction() bool {
 	return true
 }

--- a/internal/core/operations/storagecleanup/executor.go
+++ b/internal/core/operations/storagecleanup/executor.go
@@ -1,0 +1,75 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package storagecleanup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/logs"
+	"github.com/topfreegames/maestro/internal/core/operations"
+	"github.com/topfreegames/maestro/internal/core/ports"
+	"go.uber.org/zap"
+)
+
+// Executor implements the interface operations.Executor with the storage clean up operation.
+type Executor struct {
+	operationStorage ports.OperationStorage
+}
+
+var _ operations.Executor = (*Executor)(nil)
+
+// NewExecutor returns a new instance of storagecleanup.Executor.
+func NewExecutor(operationStorage ports.OperationStorage) *Executor {
+	return &Executor{
+		operationStorage: operationStorage,
+	}
+}
+
+// Execute runs the operation storage clean up.
+func (e *Executor) Execute(ctx context.Context, op *operation.Operation, definition operations.Definition) error {
+	logger := zap.L().With(
+		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
+		zap.String(logs.LogFieldOperationDefinition, op.DefinitionName),
+		zap.String(logs.LogFieldOperationPhase, "Execute"),
+		zap.String(logs.LogFieldOperationID, op.ID),
+	)
+
+	if err := e.operationStorage.CleanOperationsHistory(ctx, op.SchedulerName); err != nil {
+		logger.Warn("failed to clean operation history on storage clean up operation", zap.Error(err))
+		return fmt.Errorf("failed to clean operation history on storage clean up operation: %w", err)
+	}
+
+	return nil
+}
+
+// Rollback will do nothing.
+func (e *Executor) Rollback(_ context.Context, _ *operation.Operation, _ operations.Definition, _ error) error {
+	return nil
+}
+
+// Name returns the name of the operation.
+func (e *Executor) Name() string {
+	return OperationName
+}

--- a/internal/core/operations/storagecleanup/executor.go
+++ b/internal/core/operations/storagecleanup/executor.go
@@ -56,9 +56,9 @@ func (e *Executor) Execute(ctx context.Context, op *operation.Operation, definit
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 
-	if err := e.operationStorage.CleanOperationsHistory(ctx, op.SchedulerName); err != nil {
-		logger.Warn("failed to clean operation history on storage clean up operation", zap.Error(err))
-		return fmt.Errorf("failed to clean operation history on storage clean up operation: %w", err)
+	if err := e.operationStorage.CleanExpiredOperations(ctx, op.SchedulerName); err != nil {
+		logger.Warn("failed to clean expired operations references on storage clean up operation", zap.Error(err))
+		return fmt.Errorf("failed to clean expired operations references on storage clean up operation: %w", err)
 	}
 
 	return nil

--- a/internal/core/operations/storagecleanup/executor_test.go
+++ b/internal/core/operations/storagecleanup/executor_test.go
@@ -1,0 +1,88 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build unit
+// +build unit
+
+package storagecleanup_test
+
+import (
+	"errors"
+
+	"github.com/topfreegames/maestro/internal/core/operations/storagecleanup"
+	"github.com/topfreegames/maestro/internal/core/ports"
+
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
+)
+
+func TestExecutor_Execute(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	operation := &operation.Operation{
+		SchedulerName: "scheduler-name",
+	}
+	definition := &storagecleanup.Definition{}
+
+	t.Run("should succeed", func(t *testing.T) {
+		t.Run("operation storage CleanOperationHistory return no error => return no error", func(t *testing.T) {
+			operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+
+			operationStorage.EXPECT().CleanOperationsHistory(context.Background(), operation.SchedulerName).Return(nil)
+
+			executor := storagecleanup.NewExecutor(operationStorage)
+			err := executor.Execute(context.Background(), operation, definition)
+
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("should fail", func(t *testing.T) {
+		t.Run("operation storage CleaOperationHistory fails return unexpected error", func(t *testing.T) {
+			operationStorage := mockports.NewMockOperationStorage(mockCtrl)
+
+			operationStorage.EXPECT().CleanOperationsHistory(context.Background(), operation.SchedulerName).Return(errors.New("error"))
+
+			executor := storagecleanup.NewExecutor(operationStorage)
+			err := executor.Execute(context.Background(), operation, definition)
+			require.ErrorContains(t, err, "failed to clean operation history on storage clean up operation: ")
+		})
+	})
+}
+
+func TestExecutor_Rollback(t *testing.T) {
+	operation := &operation.Operation{}
+	definition := &storagecleanup.Definition{}
+
+	t.Run("does nothing and return nil", func(t *testing.T) {
+		executor := storagecleanup.NewExecutor((ports.OperationStorage)(nil))
+
+		err := executor.Rollback(context.Background(), operation, definition, nil)
+		require.Nil(t, err)
+	})
+
+}

--- a/internal/core/operations/storagecleanup/executor_test.go
+++ b/internal/core/operations/storagecleanup/executor_test.go
@@ -49,10 +49,10 @@ func TestExecutor_Execute(t *testing.T) {
 	definition := &storagecleanup.Definition{}
 
 	t.Run("should succeed", func(t *testing.T) {
-		t.Run("operation storage CleanOperationHistory return no error => return no error", func(t *testing.T) {
+		t.Run("operation storage CleanExpiredOperations return no error => return no error", func(t *testing.T) {
 			operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 
-			operationStorage.EXPECT().CleanOperationsHistory(context.Background(), operation.SchedulerName).Return(nil)
+			operationStorage.EXPECT().CleanExpiredOperations(context.Background(), operation.SchedulerName).Return(nil)
 
 			executor := storagecleanup.NewExecutor(operationStorage)
 			err := executor.Execute(context.Background(), operation, definition)
@@ -62,14 +62,14 @@ func TestExecutor_Execute(t *testing.T) {
 	})
 
 	t.Run("should fail", func(t *testing.T) {
-		t.Run("operation storage CleaOperationHistory fails return unexpected error", func(t *testing.T) {
+		t.Run("operation storage CleanExpiredOperations fails return unexpected error", func(t *testing.T) {
 			operationStorage := mockports.NewMockOperationStorage(mockCtrl)
 
-			operationStorage.EXPECT().CleanOperationsHistory(context.Background(), operation.SchedulerName).Return(errors.New("error"))
+			operationStorage.EXPECT().CleanExpiredOperations(context.Background(), operation.SchedulerName).Return(errors.New("error"))
 
 			executor := storagecleanup.NewExecutor(operationStorage)
 			err := executor.Execute(context.Background(), operation, definition)
-			require.ErrorContains(t, err, "failed to clean operation history on storage clean up operation: ")
+			require.ErrorContains(t, err, "failed to clean expired operations references on storage clean up operation: ")
 		})
 	})
 }

--- a/internal/core/ports/mock/operation_ports_mock.go
+++ b/internal/core/ports/mock/operation_ports_mock.go
@@ -398,6 +398,20 @@ func (m *MockOperationStorage) EXPECT() *MockOperationStorageMockRecorder {
 	return m.recorder
 }
 
+// CleanExpiredOperations mocks base method.
+func (m *MockOperationStorage) CleanExpiredOperations(ctx context.Context, schedulerName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanExpiredOperations", ctx, schedulerName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanExpiredOperations indicates an expected call of CleanExpiredOperations.
+func (mr *MockOperationStorageMockRecorder) CleanExpiredOperations(ctx, schedulerName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanExpiredOperations", reflect.TypeOf((*MockOperationStorage)(nil).CleanExpiredOperations), ctx, schedulerName)
+}
+
 // CleanOperationsHistory mocks base method.
 func (m *MockOperationStorage) CleanOperationsHistory(ctx context.Context, schedulerName string) error {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/operation_ports.go
+++ b/internal/core/ports/operation_ports.go
@@ -100,6 +100,8 @@ type OperationStorage interface {
 	UpdateOperationExecutionHistory(ctx context.Context, op *operation.Operation) error
 	// CleanOperationsHistory clears the operation execution history.
 	CleanOperationsHistory(ctx context.Context, schedulerName string) error
+	// CleanExpiredOperations remove from storage all references to the expired operations.
+	CleanExpiredOperations(ctx context.Context, schedulerName string) error
 	// UpdateOperationDefinition updates the operation definition.
 	UpdateOperationDefinition(ctx context.Context, schedulerName string, operationID string, def operations.Definition) error
 }


### PR DESCRIPTION
This PR proposes to create the executor to the operation `storagecleanup`. It only calls the `operationstorage.CleanExpiredOperations` that executes all the logic.