### PR TITLE
Add game room transition from terminating to error

### DIFF
--- a/internal/core/entities/game_room/game_room.go
+++ b/internal/core/entities/game_room/game_room.go
@@ -162,7 +162,9 @@ var validStatusTransitions = map[GameRoomStatus]map[GameRoomStatus]struct{}{
 		GameStatusUnready:     struct{}{},
 		GameStatusReady:       struct{}{},
 	},
-	GameStatusTerminating: {},
+	GameStatusTerminating: {
+		GameStatusError: struct{}{},
+	},
 }
 
 // roomStatusComposition define what is the "final" game room status based on


### PR DESCRIPTION
This PR proposes to enable terminating game_room transit to error, it happens when during the finishing phase the process on runtime breaks.