### PR TITLE
Create DogStatsD client restart routine (v9)

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -43,6 +43,7 @@ reporters:
     host: "0.0.0.0:8125"
     prefix: "maestro."
     region: "region"
+    restartTimeout: 30m
   http:
     timeout: "5s"
     putURL: "http://localhost:8080"

--- a/reporters/dogstatsd.go
+++ b/reporters/dogstatsd.go
@@ -9,7 +9,9 @@ package reporters
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/extensions/dogstatsd"
@@ -19,9 +21,12 @@ import (
 
 // DogStatsD reports metrics to a dogstatsd.Client
 type DogStatsD struct {
-	client dogstatsd.Client
-	logger *logrus.Logger
-	region string
+	client         dogstatsd.Client
+	logger         *logrus.Logger
+	statsdClient   *statsd.Client
+	region         string
+	host           string
+	prefix         string
 }
 
 func toMapStringString(o map[string]interface{}) map[string]string {
@@ -63,6 +68,7 @@ func loadDefaultDogStatsDConfigs(c *viper.Viper) {
 	c.SetDefault("reporters.dogstatsd.host", "localhost:8125")
 	c.SetDefault("reporters.dogstatsd.prefix", "test.")
 	c.SetDefault("reporters.dogstatsd.region", "test")
+	c.SetDefault("reporters.dogstatsd.restartTimeout", time.Duration(0))
 }
 
 // NewDogStatsD creates a DogStatsD struct using host and prefix from config
@@ -74,8 +80,20 @@ func NewDogStatsD(config *viper.Viper, logger *logrus.Logger) (*DogStatsD, error
 	if err != nil {
 		return nil, err
 	}
+	
+	restartTimeout := config.GetDuration("reporters.dogstatsd.restartTimeout")
 	r := config.GetString("reporters.dogstatsd.region")
-	dogstatsdR := &DogStatsD{client: c, region: r}
+
+	dogstatsdR := &DogStatsD{
+		client:       c,
+		statsdClient: c.Client.(*statsd.Client),
+		logger:       logger,
+		region:       r,
+		host:         host,
+		prefix:       prefix,
+	}
+
+	dogstatsdR.scheduleRestart(restartTimeout)
 	return dogstatsdR, nil
 }
 
@@ -83,4 +101,26 @@ func NewDogStatsD(config *viper.Viper, logger *logrus.Logger) (*DogStatsD, error
 // dogstatsd.Client -- or a mock client
 func NewDogStatsDFromClient(c dogstatsd.Client, r string) *DogStatsD {
 	return &DogStatsD{client: c, region: r}
+}
+
+func (d *DogStatsD) scheduleRestart(timeout time.Duration) {
+	if timeout.Nanoseconds() > 0 {
+		time.AfterFunc(timeout, func() {
+			if d.client != nil {
+				if err := d.statsdClient.Close(); err != nil {
+					d.logger.Errorf("DogStatsD: failed to close statsd connection during restart: %s", err.Error())
+				}
+			}
+
+			c, err := dogstatsd.New(d.host, d.prefix)
+			if err == nil {
+				d.statsdClient = c.Client.(*statsd.Client)
+				d.client = c
+			} else {
+				d.logger.Errorf("DogStatsD: failed to recreate dogstatsd client during restart. %s", err.Error())
+				d.client = nil
+			}
+			d.scheduleRestart(timeout)
+		})
+	}
 }


### PR DESCRIPTION
# Context

Recent reports show that the `DogStatsD` client stops to send metrics to Datadog. This occurs especially on `ready_or_occupied` status. This behavior creates a bad experience for monitoring room status.

# Solution

Since Datadog uses a UDP connection, we can't detect when a packet is not sent. So the proposal in this PR is to create a routine that recreates the Datadog client for every defined time duration.

Another thing that was identified is that the logger was not set on `DogStatsD`.