### PR TITLE
Create DogStatsD client restart routine (v9)

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -43,6 +43,7 @@ reporters:
     host: "0.0.0.0:8125"
     prefix: "maestro."
     region: "region"
+    restartTimeout: 1m
   http:
     timeout: "5s"
     putURL: "http://localhost:8080"


### PR DESCRIPTION
# Context

Recent reports show that the `DogStatsD` client stops to send metrics to Datadog. This occurs especially on `ready_or_occupied` status. This behavior creates a bad experience for monitoring room status.

# Solution

Since Datadog uses a UDP connection, we can't detect when a packet is not sent. So the proposal in this PR is to create a routine that recreates the Datadog client for every defined time duration.

Another thing that was identified is that the logger was not set on `DogStatsD`.