### PR TITLE
Add logs to reporter and watcher

### DIFF
--- a/metadata/version.go
+++ b/metadata/version.go
@@ -8,7 +8,7 @@
 package metadata
 
 //Version of Maestro
-var Version = "9.6.1"
+var Version = "9.15.1"
 
 //KubeVersion is the desired Kubernetes version
 var KubeVersion = "v1.13.9"

--- a/reporters/dogstatsd/handlers.go
+++ b/reporters/dogstatsd/handlers.go
@@ -71,7 +71,10 @@ func GruStatusHandler(c dogstatsd.Client, event string,
 	if err != nil {
 		return err
 	}
-	return c.Gauge(fmt.Sprintf("gru.%s", opts["status"]), gauge, tags, 1)
+	if err := c.Gauge(fmt.Sprintf("gru.%s", opts["status"]), gauge, tags, 1); err != nil {
+		return fmt.Errorf("dogstatsd failed to GRU Status gauge %s: %w", opts["status"], err)
+	}
+	return nil
 }
 
 // GruTimingHandler calls dogstatsd.Client.Timing with tags formatted as key:value
@@ -134,5 +137,8 @@ func GaugeHandler(
 	if err != nil {
 		return err
 	}
-	return c.Gauge(event, gauge, tags, 1)
+	if err := c.Gauge(event, gauge, tags, 1); err != nil {
+		return fmt.Errorf("dogstatsd failed to gauge %s: %w", opts["status"], err)
+	}
+	return nil
 }

--- a/reporters/dogstatsd/handlers.go
+++ b/reporters/dogstatsd/handlers.go
@@ -71,8 +71,7 @@ func GruStatusHandler(c dogstatsd.Client, event string,
 	if err != nil {
 		return err
 	}
-	c.Gauge(fmt.Sprintf("gru.%s", opts["status"]), gauge, tags, 1)
-	return nil
+	return c.Gauge(fmt.Sprintf("gru.%s", opts["status"]), gauge, tags, 1)
 }
 
 // GruTimingHandler calls dogstatsd.Client.Timing with tags formatted as key:value
@@ -135,6 +134,5 @@ func GaugeHandler(
 	if err != nil {
 		return err
 	}
-	c.Gauge(event, gauge, tags, 1)
-	return nil
+	return c.Gauge(event, gauge, tags, 1)
 }

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -286,9 +286,11 @@ func (w *Watcher) reportRoomsStatusesRoutine() {
 		case <-podStateCountTicker.C:
 			w.PodStatesCount()
 		case <-roomStatusTicker.C:
+			w.Logger.Info("Start to report rooms status")
 			if err := w.ReportRoomsStatuses(); err != nil {
 				w.Logger.WithError(err).Error("failed to report room status")
 			}
+			w.Logger.Info("Finished to report rooms status")
 		}
 	}
 }
@@ -423,8 +425,6 @@ func (w *Watcher) ReportRoomsStatuses() error {
 		return nil
 	}
 
-	w.Logger.Info("Start to report RoomsStatuses")
-
 	var roomCountByStatus *models.RoomsStatusCount
 	err := w.MetricsReporter.WithSegment(models.SegmentGroupBy, func() error {
 		var err error
@@ -483,8 +483,6 @@ func (w *Watcher) ReportRoomsStatuses() error {
 			w.Logger.Infof("Finished to report status %s", r.Status)
 		}
 	}
-
-	w.Logger.Info("Finished to report RoomsStatuses")
 
 	return nil
 }


### PR DESCRIPTION
## Context

Add logging functions to reporters and to the watcher to allow us to identify if the `Report` functions are dispatching errors correctly.

Related to #545.