### PR TITLE
Ignore reporters errors (v9)

### DIFF
--- a/metadata/version.go
+++ b/metadata/version.go
@@ -8,7 +8,7 @@
 package metadata
 
 //Version of Maestro
-var Version = "9.15.1"
+var Version = "9.15.2"
 
 //KubeVersion is the desired Kubernetes version
 var KubeVersion = "v1.13.9"

--- a/reporters/constants/constants.go
+++ b/reporters/constants/constants.go
@@ -1,5 +1,9 @@
 package constants
 
+import (
+	"errors"
+)
+
 // Constants for event metrics possible of being reported
 const (
 	EventGruNew         = "gru.new"
@@ -67,4 +71,8 @@ const (
 	ValueGauge     = "gauge"
 	ValueHistogram = "histogram"
 	ValueName      = "name"
+)
+
+var (
+	ErrReportHandlerNotFound = errors.New("report handler not found")
 )

--- a/reporters/dogstatsd.go
+++ b/reporters/dogstatsd.go
@@ -49,13 +49,13 @@ func (d *DogStatsD) Report(event string, opts map[string]interface{}) error {
 	defer d.mutex.RUnlock()
 	handlerI, prs := handlers.Find(event)
 	if !prs {
-		return fmt.Errorf("reportHandler for %s doesn't exist", event)
+		return constants.ErrReportHandlerNotFound
 	}
 	opts[constants.TagRegion] = d.region
 	handler := handlerI.(func(dogstatsd.Client, string, map[string]string) error)
 	err := handler(d.client, event, toMapStringString(opts))
 	if err != nil {
-		return fmt.Errorf("failed to report event '%s': %w", event, err)
+		return fmt.Errorf("failed to call report handler with event '%s': %w", event, err)
 	}
 	return nil
 }

--- a/reporters/http.go
+++ b/reporters/http.go
@@ -14,6 +14,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/topfreegames/maestro/reporters/constants"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	httpExtensions "github.com/topfreegames/extensions/http"
@@ -77,7 +79,7 @@ func (c *HTTPClient) Send(opts map[string]interface{}) error {
 func (h *HTTP) Report(event string, opts map[string]interface{}) error {
 	handlerI, prs := handlers.Find(event)
 	if !prs {
-		return fmt.Errorf("reportHandler for %s doesn't exist", event)
+		return constants.ErrReportHandlerNotFound
 	}
 	tags := []string{"maestro", event, h.region}
 	if game, ok := opts["game"].(string); ok {
@@ -94,7 +96,7 @@ func (h *HTTP) Report(event string, opts map[string]interface{}) error {
 	handler := handlerI.(func(handlers.Client, map[string]interface{}) error)
 	err := handler(h.client, opts)
 	if err != nil {
-		return fmt.Errorf("failed to report %s: %w", event, err)
+		return fmt.Errorf("failed call report handler with event '%s': %w", event, err)
 	}
 	return nil
 }

--- a/reporters/reporter.go
+++ b/reporters/reporter.go
@@ -8,7 +8,6 @@
 package reporters
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 
@@ -52,15 +51,11 @@ func copyOpts(src map[string]interface{}) map[string]interface{} {
 
 // Report is Reporters' implementation of the Reporter interface
 func (r *Reporters) Report(event string, opts map[string]interface{}) error {
-	var aggregatedErrors []error
 	for _, reporter := range r.reporters {
-		if err := reporter.Report(event, copyOpts(opts)); err != nil {
-			aggregatedErrors = append(aggregatedErrors, err)
-		}
-	}
-
-	if len(aggregatedErrors) > 0 {
-		return fmt.Errorf("failed to report '%s' event: %v", event, aggregatedErrors)
+		// We ignore the reporter errors explicitly here for the following reason:
+		// if we return these errors, it could bring issues in the ping mechanism,
+		// and we would not be able to find any room.
+		_ = reporter.Report(event, copyOpts(opts))
 	}
 	return nil
 }

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -286,11 +286,9 @@ func (w *Watcher) reportRoomsStatusesRoutine() {
 		case <-podStateCountTicker.C:
 			w.PodStatesCount()
 		case <-roomStatusTicker.C:
-			w.Logger.Info("Start to report rooms status")
 			if err := w.ReportRoomsStatuses(); err != nil {
 				w.Logger.WithError(err).Error("failed to report room status")
 			}
-			w.Logger.Info("Finished to report rooms status")
 		}
 	}
 }
@@ -465,10 +463,6 @@ func (w *Watcher) ReportRoomsStatuses() error {
 	}
 
 	for _, r := range roomDataSlice {
-		w.Logger.
-			WithField("gauge", r.Gauge).
-			Infof("Start reporting %s", r.Status)
-
 		err := reporters.Report(reportersConstants.EventGruStatus, map[string]interface{}{
 			reportersConstants.TagGame:      w.GameName,
 			reportersConstants.TagScheduler: w.SchedulerName,
@@ -480,7 +474,7 @@ func (w *Watcher) ReportRoomsStatuses() error {
 				WithError(err).
 				Errorf("Finished to report status %s with error", r.Status)
 		} else {
-			w.Logger.Infof("Finished to report status %s", r.Status)
+			w.Logger.WithField("gauge", r.Gauge).Debugf("Finished to report status %s", r.Status)
 		}
 	}
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -286,9 +286,11 @@ func (w *Watcher) reportRoomsStatusesRoutine() {
 		case <-podStateCountTicker.C:
 			w.PodStatesCount()
 		case <-roomStatusTicker.C:
+			w.Logger.Info("Start to report rooms status")
 			if err := w.ReportRoomsStatuses(); err != nil {
 				w.Logger.WithError(err).Error("failed to report room status")
 			}
+			w.Logger.Info("Finished to report rooms status")
 		}
 	}
 }


### PR DESCRIPTION
## Context

The latest version (v9.15.1) has issues related to the ping mechanism.

## Solution

We need to ignore the reporter errors explicitly. The reason is if we return the reporter's errors, it could bring issues to the ping mechanism, and we would not be able to find any room.