### PR TITLE
Update events forwarder cache to run cleanup manually when cache expires

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ on: push
 jobs:
   unit:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Set up Go
       uses: actions/setup-go@v1
@@ -23,7 +23,7 @@ jobs:
       run: bash <(curl -s https://codecov.io/bash)
   integration:
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Set up Go
       uses: actions/setup-go@v1
@@ -44,7 +44,7 @@ jobs:
 
   runtime-integration:
     name: Runtime Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/internal/adapters/events/forwarder_client.go
+++ b/internal/adapters/events/forwarder_client.go
@@ -54,7 +54,7 @@ type ForwarderClient struct {
 
 // NewForwarderClient instantiate a new grpc forwarder client.
 func NewForwarderClient() *ForwarderClient {
-	cache := cache.New(24*time.Hour, 25*time.Hour)
+	cache := cache.New(24*time.Hour, 0)
 	cache.OnEvicted(func(_key string, clientFromCache interface{}) {
 		ForwarderClient := clientFromCache.(*grpc.ClientConn)
 		ForwarderClient.Close()
@@ -150,6 +150,7 @@ func (f *ForwarderClient) getGrpcClient(address Address) (pb.GRPCForwarderClient
 		if err != nil {
 			return nil, err
 		}
+		f.c.DeleteExpired()
 		f.c.Set(string(address), client, cache.DefaultExpiration)
 		return pb.NewGRPCForwarderClient(client), nil
 	}

--- a/internal/adapters/events/forwarder_client_test.go
+++ b/internal/adapters/events/forwarder_client_test.go
@@ -33,7 +33,6 @@ import (
 
 	"testing"
 
-	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
@@ -131,9 +130,6 @@ func TestSendRoomReSync(t *testing.T) {
 }
 
 func TestForwarderClient_SendRoomStatus(t *testing.T) {
-	type fields struct {
-		c *cache.Cache
-	}
 	type args struct {
 		ctx       context.Context
 		forwarder forwarder.Forwarder
@@ -142,7 +138,6 @@ func TestForwarderClient_SendRoomStatus(t *testing.T) {
 	tests := []struct {
 		name            string
 		requestStubFile string
-		fields          fields
 		args            args
 		want            *pb.Response
 		wantErr         assert.ErrorAssertionFunc
@@ -150,9 +145,6 @@ func TestForwarderClient_SendRoomStatus(t *testing.T) {
 		{
 			name:            "return response with code 200 when request succeeds",
 			requestStubFile: "../../../test/data/events_mock/events-forwarder-grpc-send-room-status-success.json",
-			fields: fields{
-				c: cache.New(time.Minute, time.Minute),
-			},
 			args: args{
 				ctx:       context.Background(),
 				forwarder: newForwarder(grpcMockAddress),
@@ -167,9 +159,6 @@ func TestForwarderClient_SendRoomStatus(t *testing.T) {
 		{
 			name:            "return response with code 500 when request fails",
 			requestStubFile: "../../../test/data/events_mock/events-forwarder-grpc-send-room-status-failure.json",
-			fields: fields{
-				c: cache.New(time.Minute, time.Minute),
-			},
 			args: args{
 				ctx:       context.Background(),
 				forwarder: newForwarder(grpcMockAddress),
@@ -184,9 +173,6 @@ func TestForwarderClient_SendRoomStatus(t *testing.T) {
 		{
 			name:            "return error when connection establishment fails",
 			requestStubFile: "",
-			fields: fields{
-				c: cache.New(time.Minute, time.Minute),
-			},
 			args: args{
 				ctx:       context.Background(),
 				forwarder: newForwarder(""),
@@ -204,9 +190,7 @@ func TestForwarderClient_SendRoomStatus(t *testing.T) {
 				)
 				require.NoError(t, err)
 			}
-			f := &ForwarderClient{
-				c: tt.fields.c,
-			}
+			f := NewForwarderClient()
 			got, err := f.SendRoomStatus(tt.args.ctx, tt.args.forwarder, &tt.args.in)
 			if !tt.wantErr(t, err, fmt.Sprintf("SendRoomStatus(%v, %v, %v)", tt.args.ctx, tt.args.forwarder, tt.args.in)) {
 				return


### PR DESCRIPTION
Relates to the following issue: https://github.com/patrickmn/go-cache/issues/141

**Description**
The caching dependency is not running the cleanup properly due to how the cache is implemented in the events forwarder client. 

The cache implementation only runs calls `OnEvict` each `cleanupInterval`, for each cache item that is expired. Whenever we try to use a cached connection that is expired, we create a new connection, which in turn uses a new expiration date.

If we try to access a cached connection that is expired but not properly evicted, we will end up replacing it before calling the `close()` procedure and we will end up with opened grpc connections. 

***

The pipeline change is necessary due to Github updating its [ubuntu-latest image to Ubuntu 22.04 ](https://github.com/actions/runner-images) and [Ubuntu 22.04 not being supported by K3s](https://pkg.go.dev/github.com/orlangure/gnomock/preset/k3s)
