### PR TITLE
Add game to forward player event

### DIFF
--- a/internal/adapters/events/events_forwarder.go
+++ b/internal/adapters/events/events_forwarder.go
@@ -162,6 +162,7 @@ func (f *eventsForwarder) buildPlayerEventMessage(eventAttributes events.PlayerE
 	event := pb.PlayerEvent{
 		PlayerId: eventAttributes.PlayerId,
 		Room: &pb.Room{
+			Game:   eventAttributes.Game,
 			RoomId: eventAttributes.RoomId,
 		},
 		EventType: fromPlayerEventTypeToGrpcPlayerEventType(eventAttributes.EventType),

--- a/internal/core/entities/events/player_event.go
+++ b/internal/core/entities/events/player_event.go
@@ -28,6 +28,7 @@ type PlayerEventAttributes struct {
 	RoomId    string
 	PlayerId  string
 	EventType PlayerEventType
+	Game      string
 	Other     map[string]interface{}
 }
 

--- a/internal/core/services/events/events_forwarder_service.go
+++ b/internal/core/services/events/events_forwarder_service.go
@@ -212,6 +212,7 @@ func (es *EventsForwarderService) forwardPlayerEvent(
 		RoomId:    event.RoomID,
 		PlayerId:  playerId,
 		EventType: playerEvent,
+		Game:      scheduler.Game,
 		Other:     event.Attributes,
 	}
 


### PR DESCRIPTION
### Fix

During the update from v9 to next, we stopped filling the game field to be sent by the events forwarder implementation.
In v9: https://github.com/topfreegames/maestro/blob/b20b9b51722b5333b6a53ae6033d6bd05ae9397c/eventforwarder/forward.go#L193

This change will instead of passing the game in the metadata, pass it using the room.Game field that is already available in the proto for player events.