### PR TITLE
Add error messages to create scheduler operation history

### DIFF
--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -89,7 +89,7 @@ func ProvideExecutors(
 ) map[string]operations.Executor {
 
 	executors := map[string]operations.Executor{}
-	executors[createscheduler.OperationName] = createscheduler.NewExecutor(runtime, schedulerManager)
+	executors[createscheduler.OperationName] = createscheduler.NewExecutor(runtime, schedulerManager, operationManager)
 	executors[addrooms.OperationName] = addrooms.NewExecutor(roomManager, schedulerStorage)
 	executors[removerooms.OperationName] = removerooms.NewExecutor(roomManager, roomStorage, operationManager)
 	executors[test.OperationName] = test.NewExecutor()


### PR DESCRIPTION
### Why
Nowadays the operation history does not persist why an operation has failed for most use cases. This change intends to add the error to the operation history for a create scheduler operation.