### PR TITLE
Add error messages to rooms operation history

### DIFF
--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -90,7 +90,7 @@ func ProvideExecutors(
 
 	executors := map[string]operations.Executor{}
 	executors[createscheduler.OperationName] = createscheduler.NewExecutor(runtime, schedulerManager)
-	executors[addrooms.OperationName] = addrooms.NewExecutor(roomManager, schedulerStorage)
+	executors[addrooms.OperationName] = addrooms.NewExecutor(roomManager, schedulerStorage, operationManager)
 	executors[removerooms.OperationName] = removerooms.NewExecutor(roomManager, roomStorage, operationManager)
 	executors[test.OperationName] = test.NewExecutor()
 	executors[switchversion.OperationName] = switchversion.NewExecutor(roomManager, schedulerManager, operationManager, roomStorage)

--- a/internal/core/operations/rooms/remove/executor.go
+++ b/internal/core/operations/rooms/remove/executor.go
@@ -58,6 +58,7 @@ func (e *Executor) Execute(ctx context.Context, op *operation.Operation, definit
 	logger := zap.L().With(
 		zap.String(logs.LogFieldSchedulerName, op.SchedulerName),
 		zap.String(logs.LogFieldOperationDefinition, definition.Name()),
+		zap.String(logs.LogFieldOperationPhase, "Execute"),
 		zap.String(logs.LogFieldOperationID, op.ID),
 	)
 
@@ -68,9 +69,9 @@ func (e *Executor) Execute(ctx context.Context, op *operation.Operation, definit
 		err := e.removeRoomsByIDs(ctx, op.SchedulerName, removeDefinition.RoomsIDs, op)
 		if err != nil {
 			reportDeletionFailedTotal(op.SchedulerName, op.ID)
-			logger.Warn("failed to remove rooms", zap.Error(err))
+			logger.Warn("error removing rooms", zap.Error(err))
 
-			return fmt.Errorf("failed to remove room by ids: %w", err)
+			return fmt.Errorf("error removing rooms by ids: %w", err)
 		}
 	}
 
@@ -79,9 +80,9 @@ func (e *Executor) Execute(ctx context.Context, op *operation.Operation, definit
 		err := e.removeRoomsByAmount(ctx, op.SchedulerName, removeDefinition.Amount, op)
 		if err != nil {
 			reportDeletionFailedTotal(op.SchedulerName, op.ID)
-			logger.Warn("failed to remove rooms", zap.Error(err))
+			logger.Warn("error removing rooms", zap.Error(err))
 
-			return fmt.Errorf("failed to remove room by amount: %w", err)
+			return fmt.Errorf("error removing rooms by amount: %w", err)
 		}
 	}
 


### PR DESCRIPTION
### Why
Nowadays the operation history does not persist why an operation has failed for most use cases. This change intends to add the error to the operation history for room operations.