### PR TITLE
Fix broken state transitions after room crashes

### DIFF
--- a/internal/core/entities/game_room/game_room.go
+++ b/internal/core/entities/game_room/game_room.go
@@ -163,9 +163,9 @@ var validStatusTransitions = map[GameRoomStatus]map[GameRoomStatus]struct{}{
 		GameStatusReady:       struct{}{},
 	},
 	GameStatusTerminating: {
-		GameStatusError: struct{}{},
-		GameStatusUnready:     struct{}{},
-		GameStatusReady:       struct{}{},
+		GameStatusError:   struct{}{},
+		GameStatusUnready: struct{}{},
+		GameStatusReady:   struct{}{},
 	},
 }
 

--- a/internal/core/entities/game_room/game_room.go
+++ b/internal/core/entities/game_room/game_room.go
@@ -164,6 +164,8 @@ var validStatusTransitions = map[GameRoomStatus]map[GameRoomStatus]struct{}{
 	},
 	GameStatusTerminating: {
 		GameStatusError: struct{}{},
+		GameStatusUnready:     struct{}{},
+		GameStatusReady:       struct{}{},
 	},
 }
 

--- a/internal/core/entities/game_room/game_room_test.go
+++ b/internal/core/entities/game_room/game_room_test.go
@@ -83,6 +83,6 @@ func TestValidateRoomStatusTransition_InvalidTransition(t *testing.T) {
 		SchedulerID: "S",
 		Status:      GameStatusTerminating,
 	}
-	err := gameRoom.ValidateRoomStatusTransition(GameStatusReady)
+	err := gameRoom.ValidateRoomStatusTransition(GameStatusPending)
 	require.Error(t, err)
 }

--- a/internal/core/services/rooms/room_manager_test.go
+++ b/internal/core/services/rooms/room_manager_test.go
@@ -376,6 +376,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 
 	t.Run("when the game room state transition is invalid then it returns proper error", func(t *testing.T) {
 		newGameRoomInvalidState := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusTerminating, PingStatus: game_room.GameRoomPingStatusReady}
+		currentInstance := &game_room.Instance{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.InstanceStatus{Type: game_room.InstancePending}}
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoomInvalidState).Return(nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoomInvalidState.SchedulerID, newGameRoomInvalidState.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoomInvalidState.SchedulerID, newGameRoomInvalidState.ID).Return(newGameRoomInvalidState, nil)
@@ -1177,7 +1178,7 @@ func TestUpdateGameRoomStatus(t *testing.T) {
 		room := &game_room.GameRoom{PingStatus: game_room.GameRoomPingStatusReady, Status: game_room.GameStatusTerminating}
 		roomStorage.EXPECT().GetRoom(context.Background(), schedulerName, roomId).Return(room, nil)
 
-		instance := &game_room.Instance{Status: game_room.InstanceStatus{Type: game_room.InstanceReady}}
+		instance := &game_room.Instance{Status: game_room.InstanceStatus{Type: game_room.InstancePending}}
 		instanceStorage.EXPECT().GetInstance(context.Background(), schedulerName, roomId).Return(instance, nil)
 
 		err := roomManager.UpdateGameRoomStatus(context.Background(), schedulerName, roomId)


### PR DESCRIPTION
Prevents scheduler from going into an unusable state after application crashes. Example error:
 "error": "failed to update game room status: state transition is invalid: cannot change game room status from terminating to ready",
  "stacktrace": "github.com/topfreegames/maestro/internal/api/handlers.(*RoomsHandler).UpdateRoomWithPing\n\t/build/internal/api/handlers/rooms_handler.go:97\ngithub.com/topfreegames/maestro/pkg/api/v1.local_request_RoomsService_UpdateRoomWithPing_0\n\t/build/pkg/api/v1/rooms.pb.gw.go:117\ngithub.com/topfreegames/maestro/pkg/api/v1.RegisterRoomsServiceHandlerServer.func1\n\t/build/pkg/api/v1/rooms.pb.gw.go:475\ngithub.com/grpc-ecosystem/grpc-gateway/v2/runtime.(*ServeMux).ServeHTTP\n\t/go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway/v2@v2.5.0/runtime/mux.go:251\ngithub.com/slok/go-http-metrics/middleware/std.Handler.func1.1\n\t/go/pkg/mod/github.com/slok/go-http-metrics@v0.9.0/middleware/std/std.go:27\ngithub.com/slok/go-http-metrics/middleware.Middleware.Measure\n\t/go/pkg/mod/github.com/slok/go-http-metrics@v0.9.0/middleware/middleware.go:117\ngithub.com/slok/go-http-metrics/middleware/std.Handler.func1\n\t/go/pkg/mod/github.com/slok/go-http-metrics@v0.9.0/middleware/std/std.go:26\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2084\ngithub.com/topfreegames/maestro/cmd/roomsapi.buildMuxWithMetricsMdlw.func1\n\t/build/cmd/roomsapi/rooms_api.go:150\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2084\nnet/http.(*ServeMux).ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2462\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2916\nnet/http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:1966"
}
