### PR TITLE
Update scheduler state to in-sync after creation

### DIFF
--- a/internal/core/operations/schedulers/create/executor_test.go
+++ b/internal/core/operations/schedulers/create/executor_test.go
@@ -49,7 +49,11 @@ func TestExecutor_Execute(t *testing.T) {
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationManager := mockports.NewMockOperationManager(mockCtrl)
 
-		definition := Definition{}
+		newScheduler := &entities.Scheduler{State: entities.StateCreating}
+		updatedScheduler := &entities.Scheduler{State: entities.StateInSync}
+		definition := Definition{
+			NewScheduler: newScheduler,
+		}
 		op := operation.Operation{
 			ID:             "some-op-id",
 			SchedulerName:  "zooba_blue:1.0.0",
@@ -58,6 +62,7 @@ func TestExecutor_Execute(t *testing.T) {
 		}
 
 		runtime.EXPECT().CreateScheduler(context.Background(), &entities.Scheduler{Name: op.SchedulerName}).Return(nil)
+		schedulerManager.EXPECT().UpdateScheduler(context.Background(), updatedScheduler)
 
 		err := NewExecutor(runtime, schedulerManager, operationManager).Execute(context.Background(), &op, &definition)
 		require.Nil(t, err)
@@ -71,7 +76,10 @@ func TestExecutor_Execute(t *testing.T) {
 		schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
 		operationManager := mockports.NewMockOperationManager(mockCtrl)
 
-		definition := Definition{}
+		newScheduler := &entities.Scheduler{State: entities.StateCreating}
+		definition := Definition{
+			NewScheduler: newScheduler,
+		}
 		op := operation.Operation{
 			ID:             "some-op-id",
 			SchedulerName:  "zooba_blue:1.0.0",

--- a/internal/core/operations/schedulers/newversion/executor.go
+++ b/internal/core/operations/schedulers/newversion/executor.go
@@ -118,6 +118,7 @@ func (ex *Executor) Execute(ctx context.Context, op *operation.Operation, defini
 		}
 	}
 
+	newScheduler.State = entities.StateCreating
 	switchOpID, err := ex.createNewSchedulerVersionAndEnqueueSwitchVersionOp(ctx, newScheduler, logger, isSchedulerMajorVersion)
 	if err != nil {
 		return err

--- a/internal/core/operations/schedulers/switchversion/executor.go
+++ b/internal/core/operations/schedulers/switchversion/executor.go
@@ -123,6 +123,7 @@ func (ex *Executor) Execute(ctx context.Context, op *operation.Operation, defini
 	}
 
 	logger.Sugar().Debugf("switching version to %v", scheduler.Spec.Version)
+	scheduler.State = entities.StateInSync
 	err = ex.schedulerManager.UpdateScheduler(ctx, scheduler)
 	if err != nil {
 		logger.Error("error updating scheduler with new active version")

--- a/internal/core/operations/schedulers/switchversion/executor_test.go
+++ b/internal/core/operations/schedulers/switchversion/executor_test.go
@@ -605,7 +605,7 @@ func newValidSchedulerV2() *entities.Scheduler {
 	return &entities.Scheduler{
 		Name:            "scheduler",
 		Game:            "game",
-		State:           entities.StateCreating,
+		State:           entities.StateInSync,
 		MaxSurge:        "5",
 		RollbackVersion: "",
 		Spec: game_room.Spec{


### PR DESCRIPTION
### Why

The scheduler state is not being updated after its creation, this change updates it to in-sync when the create scheduler operation finished. Also, when a new version operation is executed, it will set the scheduler to creating until the switch version operation finishes.