### PR TITLE
fix: downscale calculations for a low ready target

### DIFF
--- a/internal/core/services/autoscaler/autoscaler_test.go
+++ b/internal/core/services/autoscaler/autoscaler_test.go
@@ -228,7 +228,7 @@ func TestCanDownscale(t *testing.T) {
 			assert.True(t, allow)
 		})
 
-		t.Run("When the ready target is low", func(t *testing.T) {
+		t.Run("When the ready target is low it should trigger downscale", func(t *testing.T) {
 			mockRoomStorage := mock.NewMockRoomStorage(ctrl)
 
 			mockRoomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), scheduler.Name, game_room.GameStatusReady).Return(500, nil)

--- a/internal/core/services/autoscaler/policies/roomoccupancy/policy.go
+++ b/internal/core/services/autoscaler/policies/roomoccupancy/policy.go
@@ -123,7 +123,6 @@ func (p *Policy) CanDownscale(policyParameters autoscaling.PolicyParameters, cur
 		return false, fmt.Errorf("Error calculating the desired number of rooms: %w", err)
 	}
 
-	readyRooms = currentState[ReadyRoomsKey].(int)
 	desiredNumberOfReadyRooms := int(math.Ceil(float64(desiredNumberOfRooms) * readyTarget))
 
 	return (float64(desiredNumberOfReadyRooms) / float64(readyRooms)) <= downThreshold, nil

--- a/internal/core/services/autoscaler/policies/roomoccupancy/policy.go
+++ b/internal/core/services/autoscaler/policies/roomoccupancy/policy.go
@@ -123,7 +123,7 @@ func (p *Policy) CanDownscale(policyParameters autoscaling.PolicyParameters, cur
 		return false, fmt.Errorf("Error calculating the desired number of rooms: %w", err)
 	}
 
-	desiredNumberOfReadyRooms := int(math.Ceil(float64(desiredNumberOfRooms) * readyTarget))
+	desiredNumberOfReadyRooms := math.Ceil(float64(desiredNumberOfRooms) * readyTarget)
 
-	return (float64(desiredNumberOfReadyRooms) / float64(readyRooms)) <= downThreshold, nil
+	return (desiredNumberOfReadyRooms / float64(readyRooms)) <= downThreshold, nil
 }

--- a/internal/core/services/autoscaler/policies/roomoccupancy/policy_test.go
+++ b/internal/core/services/autoscaler/policies/roomoccupancy/policy_test.go
@@ -360,24 +360,6 @@ func TestCanDownscale(t *testing.T) {
 		assert.EqualError(t, err, "There are no readyRooms in the currentState")
 	})
 
-	t.Run("Fail case - when there is no OccupiedRooms", func(t *testing.T) {
-		schedulerState := policies.CurrentState{
-			roomoccupancy.ReadyRoomsKey: 10,
-		}
-
-		readyTarget := float64(0.3)
-		downThreshold := float64(0.3)
-		policyParams := autoscaling.PolicyParameters{
-			RoomOccupancy: &autoscaling.RoomOccupancyParams{
-				ReadyTarget:   readyTarget,
-				DownThreshold: downThreshold,
-			},
-		}
-
-		_, err := policy.CanDownscale(policyParams, schedulerState)
-		assert.EqualError(t, err, "There are no occupiedRooms in the currentState")
-	})
-
 	t.Run("Fail case - when down threshold is out of 0, 1 range", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
When having a low `readyTarget` (les than 0.5) the calculation that checks if maestro can downscale was returning wrong values. This was preventing maestro to downscale rooms properly. 