### PR TITLE
Allow rate limit changes for inCluster mode

### DIFF
--- a/docs/reference/Kubernetes.md
+++ b/docs/reference/Kubernetes.md
@@ -1,12 +1,8 @@
 ## Kubernetes usage
+Maestro uses kubernetes for orchestrating game room instances. It uses a unique **namespace** for each scheduler, and a unique **pod** for each game room instance.
 
-Maestro uses kubernetes for orchestrating game room instances. It uses a unique **namespace** for each scheduler, and a
-unique **pod** for each game room instance.
-
-We use [client-go](https://github.com/kubernetes/client-go) for communicating with kubernetes.
-The [Runtime](internal/core/ports/runtime.go) port
-is the interface used for managing resources, you can find all of the features we are using for managing k8s resources
-in it.
+We use [client-go](https://github.com/kubernetes/client-go) for communicating with kubernetes. The [Runtime](internal/core/ports/runtime.go) port
+is the interface used for managing resources, you can find all of the features we are using for managing k8s resources in it.
 
 The diagram below shows how maestro components interact with kubernetes for managing resources.
 
@@ -43,35 +39,27 @@ flowchart BT
 ```
 
 ### Runtime watcher
-
 The runtime watcher component maintains a worker process for each scheduler that keeps watching and processing _change
 events_ in pods resources. For doing that, it uses a [pods informer](https://pkg.go.dev/k8s.io/client-go/informers),
 binding handlers for **add**, **update** and **delete** events for all pods managed by it.
 
 This component is not responsible for updating/creating/deleting
-kubernetes resources, all it does is to watch for changes and update its game room instances internal representation
-using redis.
+kubernetes resources, all it does is to watch for changes and update its game room instances internal representation using redis.
 
 ### Operation execution worker
-
-The worker uses kubernetes for managing pods and namespaces. It executes several [operations](Operations.md) that,
-alongside other side effects, will need to create, update, and delete namespaces and pods.
+The worker uses kubernetes for managing pods and namespaces. It executes several [operations](Operations.md) that, alongside other side effects, will need to create, update, and delete namespaces and pods.
 
 > **Currently, maestro does not check for HostPort conflict while creating new rooms**
+> 
+>One important note regarding how maestro creates pods: each new requested game room instance will be assigned to a pseudo-random port to be used as **HostPort**.
 >
->One important note regarding how maestro creates pods: each new requested game room instance will be assigned to a
-> pseudo-random port to be used as **HostPort**.
->
-> Maestro uses the scheduler **PortRange** to generate the pseudo-random port. Currently, maestro does not check for
-> HostPort conflict while creating new rooms. The final address
-> of the game room will be composed of the **Node** address and the game room container assigned **HostPort**. That's the
-> reason why
-> maestro needs access for reading the Node addresses.
+> Maestro uses the scheduler **PortRange** to generate the pseudo-random port. Currently, maestro does not check for HostPort conflict while creating new rooms. The final address
+of the game room will be composed of the **Node** address and the game room container assigned **HostPort**. That's the reason why
+maestro needs access for reading the Node addresses.
 
 ## Configuring cluster access
 
 Maestro needs the following permissions for managing resources in a kubernetes cluster:
-
 - nodes: read (we need to use the node address to compose the game room address);
 - pods: read, create, update, delete;
 - namespace: read, create, update, delete.
@@ -79,9 +67,7 @@ Maestro needs the following permissions for managing resources in a kubernetes c
 Maestro provides two ways for configuring kubernetes cluster access.
 
 ### Using inCluster mode
-
-Set `adapters.runtime.kubernetes.inCluster` config value to true or use its env var equivalent, the kubernetes client
-will be configured
+Set `adapters.runtime.kubernetes.inCluster` config value to true or use its env var equivalent, the kubernetes client will be configured 
 automatically using the same _service account_ of the maestro component running pod.
 
 The kubernetes client has a default rate limiter which implements a token bucket approach.
@@ -92,9 +78,7 @@ This mode is recommended to be used when running maestro components in the same 
 in which the schedulers and rooms will be managed.
 
 ### Using kubeconfig mode
-
-Populate `adapters.runtime.kubernetes.kubeconfig` and `adapters.runtime.kubernetes.masterUrl` configs or use its env var
-equivalent, the kubernetes client
+Populate `adapters.runtime.kubernetes.kubeconfig` and `adapters.runtime.kubernetes.masterUrl` configs or use its env var equivalent, the kubernetes client
 will be configured using the provided kubeconfig file and master url.
 
 

--- a/docs/reference/Kubernetes.md
+++ b/docs/reference/Kubernetes.md
@@ -1,8 +1,12 @@
 ## Kubernetes usage
-Maestro uses kubernetes for orchestrating game room instances. It uses a unique **namespace** for each scheduler, and a unique **pod** for each game room instance.
 
-We use [client-go](https://github.com/kubernetes/client-go) for communicating with kubernetes. The [Runtime](internal/core/ports/runtime.go) port
-is the interface used for managing resources, you can find all of the features we are using for managing k8s resources in it.
+Maestro uses kubernetes for orchestrating game room instances. It uses a unique **namespace** for each scheduler, and a
+unique **pod** for each game room instance.
+
+We use [client-go](https://github.com/kubernetes/client-go) for communicating with kubernetes.
+The [Runtime](internal/core/ports/runtime.go) port
+is the interface used for managing resources, you can find all of the features we are using for managing k8s resources
+in it.
 
 The diagram below shows how maestro components interact with kubernetes for managing resources.
 
@@ -39,27 +43,35 @@ flowchart BT
 ```
 
 ### Runtime watcher
+
 The runtime watcher component maintains a worker process for each scheduler that keeps watching and processing _change
 events_ in pods resources. For doing that, it uses a [pods informer](https://pkg.go.dev/k8s.io/client-go/informers),
 binding handlers for **add**, **update** and **delete** events for all pods managed by it.
 
 This component is not responsible for updating/creating/deleting
-kubernetes resources, all it does is to watch for changes and update its game room instances internal representation using redis.
+kubernetes resources, all it does is to watch for changes and update its game room instances internal representation
+using redis.
 
 ### Operation execution worker
-The worker uses kubernetes for managing pods and namespaces. It executes several [operations](Operations.md) that, alongside other side effects, will need to create, update, and delete namespaces and pods.
+
+The worker uses kubernetes for managing pods and namespaces. It executes several [operations](Operations.md) that,
+alongside other side effects, will need to create, update, and delete namespaces and pods.
 
 > **Currently, maestro does not check for HostPort conflict while creating new rooms**
-> 
->One important note regarding how maestro creates pods: each new requested game room instance will be assigned to a pseudo-random port to be used as **HostPort**.
 >
-> Maestro uses the scheduler **PortRange** to generate the pseudo-random port. Currently, maestro does not check for HostPort conflict while creating new rooms. The final address
-of the game room will be composed of the **Node** address and the game room container assigned **HostPort**. That's the reason why
-maestro needs access for reading the Node addresses.
+>One important note regarding how maestro creates pods: each new requested game room instance will be assigned to a
+> pseudo-random port to be used as **HostPort**.
+>
+> Maestro uses the scheduler **PortRange** to generate the pseudo-random port. Currently, maestro does not check for
+> HostPort conflict while creating new rooms. The final address
+> of the game room will be composed of the **Node** address and the game room container assigned **HostPort**. That's the
+> reason why
+> maestro needs access for reading the Node addresses.
 
 ## Configuring cluster access
 
 Maestro needs the following permissions for managing resources in a kubernetes cluster:
+
 - nodes: read (we need to use the node address to compose the game room address);
 - pods: read, create, update, delete;
 - namespace: read, create, update, delete.
@@ -67,14 +79,22 @@ Maestro needs the following permissions for managing resources in a kubernetes c
 Maestro provides two ways for configuring kubernetes cluster access.
 
 ### Using inCluster mode
-Set `adapters.runtime.kubernetes.inCluster` config value to true or use its env var equivalent, the kubernetes client will be configured 
+
+Set `adapters.runtime.kubernetes.inCluster` config value to true or use its env var equivalent, the kubernetes client
+will be configured
 automatically using the same _service account_ of the maestro component running pod.
+
+The kubernetes client has a default rate limiter which implements a token bucket approach.
+The inCluster mode allows rate limit changes via `adapters.runtime.kubernetes.qps` 
+and `adapters.runtime.kubernetes.burst` configs.
 
 This mode is recommended to be used when running maestro components in the same cluster
 in which the schedulers and rooms will be managed.
 
 ### Using kubeconfig mode
-Populate `adapters.runtime.kubernetes.kubeconfig` and `adapters.runtime.kubernetes.masterUrl` configs or use its env var equivalent, the kubernetes client
+
+Populate `adapters.runtime.kubernetes.kubeconfig` and `adapters.runtime.kubernetes.masterUrl` configs or use its env var
+equivalent, the kubernetes client
 will be configured using the provided kubeconfig file and master url.
 
 

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -58,6 +58,7 @@ import (
 	"github.com/topfreegames/maestro/internal/core/services/schedulers"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -67,6 +68,8 @@ const (
 	runtimeKubernetesMasterURLPath  = "adapters.runtime.kubernetes.masterUrl"
 	runtimeKubernetesKubeconfigPath = "adapters.runtime.kubernetes.kubeconfig"
 	runtimeKubernetesInClusterPath  = "adapters.runtime.kubernetes.inCluster"
+	runtimeKubernetesQPS            = "adapters.runtime.kubernetes.qps"
+	runtimeKubernetesBurst          = "adapters.runtime.kubernetes.burst"
 	// Redis operation storage
 	operationStorageRedisURLPath      = "adapters.operationStorage.redis.url"
 	operationLeaseStorageRedisURLPath = "adapters.operationLeaseStorage.redis.url"
@@ -115,14 +118,23 @@ func NewEventsForwarder(c config.Config) (ports.EventsForwarder, error) {
 func NewRuntimeKubernetes(c config.Config) (ports.Runtime, error) {
 	var masterURL string
 	var kubeConfigPath string
+	var qps int
+	var burst int
 
 	inCluster := c.GetBool(runtimeKubernetesInClusterPath)
-	if !inCluster {
+	if inCluster {
+		qps = c.GetInt(runtimeKubernetesQPS)
+		burst = c.GetInt(runtimeKubernetesBurst)
+	} else {
 		masterURL = c.GetString(runtimeKubernetesMasterURLPath)
 		kubeConfigPath = c.GetString(runtimeKubernetesKubeconfigPath)
 	}
 
-	clientSet, err := createKubernetesClient(masterURL, kubeConfigPath)
+	clientSet, err := createKubernetesClient(masterURL, kubeConfigPath, func(conf *rest.Config) *rest.Config {
+		conf.QPS = float32(qps)
+		conf.Burst = burst
+		return conf
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Kubernetes runtime: %w", err)
 	}
@@ -275,12 +287,16 @@ func connectToPostgres(url string) (*pg.Options, error) {
 	return opts, nil
 }
 
-func createKubernetesClient(masterURL, kubeconfigPath string) (kubernetes.Interface, error) {
+func createKubernetesClient(masterURL, kubeconfigPath string, opts ...func(*rest.Config) *rest.Config) (kubernetes.Interface, error) {
 	// NOTE: if neither masterURL or kubeconfigPath are not passed, this will
 	// fallback to in cluster config.
 	kubeconfig, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct kubernetes config: %w", err)
+	}
+
+	for _, opt := range opts {
+		kubeconfig = opt(kubeconfig)
 	}
 
 	client, err := kubernetes.NewForConfig(kubeconfig)


### PR DESCRIPTION
### What does this PR do?

Allow rate limit changes for inCluster mode:

- With this change, users can tune the default values for rate limit even in inCluster mode.
- This is not a breaking change as the configs are inserted externally, e.g. env vars.
- No test can be added without major changes to the methods' signatures as the kubernetes client will attempt to get configs and certificates from env vars and files that are not easily mocked. 