### PR TITLE
Dynamic PDB to Game Room Namespaces

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -59,6 +59,10 @@ workers:
 reporter:
   metrics:
     intervalMillis: 10000
+runtimeWatcher:
+  disruptionWorker:
+    intervalSeconds: 5
+    safetyPercentage: 0.05
 
 services:
   roomManager:

--- a/docs/reference/Architecture.md
+++ b/docs/reference/Architecture.md
@@ -46,7 +46,8 @@ You could find all operations at [Operations section](Operations.md#available-op
 
 > Note: In Maestro a worker is a collection of routines that executes a flow related to one and only one **Scheduler** each.
 
-Runtime Watcher Worker listens to runtime events related to the **Scheduler** and reflects the changes in **Maestro**. Currently, it listens for Game Rooms creation, deletion, and update.
+Runtime Watcher Worker listens to runtime events related to the **Scheduler** and reflects the changes in **Maestro**. Currently, it mitigate disruptions by looking at the current
+amount of occupied rooms, and it listens for Game Rooms creation, deletion, and update.
 
 ![Runtime Watcher Worker IMAGE](../images/Architecture-Runtime-Watcher-Worker.jpg)
 

--- a/internal/adapters/runtime/kubernetes/kubernetes.go
+++ b/internal/adapters/runtime/kubernetes/kubernetes.go
@@ -23,7 +23,9 @@
 package kubernetes
 
 import (
+	"github.com/topfreegames/maestro/internal/core/logs"
 	"github.com/topfreegames/maestro/internal/core/ports"
+	"go.uber.org/zap"
 	kube "k8s.io/client-go/kubernetes"
 )
 
@@ -31,8 +33,12 @@ var _ ports.Runtime = (*kubernetes)(nil)
 
 type kubernetes struct {
 	clientSet kube.Interface
+	logger    *zap.Logger
 }
 
 func New(clientSet kube.Interface) *kubernetes {
-	return &kubernetes{clientSet}
+	return &kubernetes{
+		clientSet: clientSet,
+		logger:    zap.L().With(zap.String(logs.LogFieldRuntime, "kubernetes")),
+	}
 }

--- a/internal/adapters/runtime/kubernetes/scheduler_test.go
+++ b/internal/adapters/runtime/kubernetes/scheduler_test.go
@@ -28,6 +28,7 @@ package kubernetes
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/topfreegames/maestro/internal/core/entities"
@@ -187,5 +188,143 @@ func TestPDBCreationAndDeletion(t *testing.T) {
 
 		_, err = client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
 		require.True(t, kerrors.IsNotFound(err))
+	})
+}
+
+func TestMitigateDisruption(t *testing.T) {
+	ctx := context.Background()
+	client := test.GetKubernetesClientSet(t, kubernetesContainer)
+	kubernetesRuntime := New(client)
+
+	t.Run("should not mitigate disruption if scheduler is nil", func(t *testing.T) {
+		err := kubernetesRuntime.MitigateDisruption(ctx, nil, 0, 0.0)
+		require.ErrorIs(t, errors.ErrInvalidArgument, err)
+	})
+
+	t.Run("should create PDB on mitigatation if not created before", func(t *testing.T) {
+		if !kubernetesRuntime.isPDBSupported() {
+			t.Log("Kubernetes version does not support PDB, skipping")
+			t.SkipNow()
+		}
+
+		scheduler := &entities.Scheduler{Name: "scheduler-pdb-mitigation-create"}
+		namespace := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: scheduler.Name,
+			},
+		}
+
+		_, err := client.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		err = kubernetesRuntime.MitigateDisruption(ctx, scheduler, 0, 0.0)
+		require.NoError(t, err)
+
+		pdb, err := client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, pdb)
+		require.Equal(t, pdb.Name, scheduler.Name)
+		require.Equal(t, pdb.Spec.MinAvailable.IntVal, int32(0))
+	})
+
+	t.Run("should update PDB on mitigatation if not equal to current minAvailable", func(t *testing.T) {
+		if !kubernetesRuntime.isPDBSupported() {
+			t.Log("Kubernetes version does not support PDB, skipping")
+			t.SkipNow()
+		}
+
+		scheduler := &entities.Scheduler{
+			Name: "scheduler-pdb-mitigation-update",
+			Autoscaling: &autoscaling.Autoscaling{
+				Enabled: true,
+				Min:     100,
+				Max:     200,
+				Policy: autoscaling.Policy{
+					Type: autoscaling.RoomOccupancy,
+					Parameters: autoscaling.PolicyParameters{
+						RoomOccupancy: &autoscaling.RoomOccupancyParams{
+							ReadyTarget: 0.1,
+						},
+					},
+				},
+			},
+		}
+		err := kubernetesRuntime.CreateScheduler(ctx, scheduler)
+		if err != nil {
+			require.ErrorIs(t, errors.ErrAlreadyExists, err)
+		}
+
+		defer func() {
+			err := kubernetesRuntime.DeleteScheduler(ctx, scheduler)
+			if err != nil {
+				require.ErrorIs(t, errors.ErrNotFound, err)
+			}
+		}()
+
+		pdb, err := client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, pdb)
+		require.Equal(t, pdb.Name, scheduler.Name)
+		require.Equal(t, pdb.Spec.MinAvailable.IntVal, int32(scheduler.Autoscaling.Min))
+
+		err = kubernetesRuntime.MitigateDisruption(ctx, scheduler, scheduler.Autoscaling.Min, 0.0)
+		require.NoError(t, err)
+
+		pdb, err = client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, pdb)
+		require.Equal(t, pdb.Name, scheduler.Name)
+
+		incSafetyPercentage := 1.0 + DefaultDisruptionSafetyPercentage
+		newRoomAmount := int32(float64(scheduler.Autoscaling.Min) * incSafetyPercentage)
+		require.Equal(t, pdb.Spec.MinAvailable.IntVal, newRoomAmount)
+	})
+
+	t.Run("should default safety percentage if invalid value", func(t *testing.T) {
+		if !kubernetesRuntime.isPDBSupported() {
+			t.Log("Kubernetes version does not support PDB, skipping")
+			t.SkipNow()
+		}
+
+		scheduler := &entities.Scheduler{
+			Name: "scheduler-pdb-mitigation-no-update",
+			Autoscaling: &autoscaling.Autoscaling{
+				Enabled: true,
+				Min:     100,
+				Max:     200,
+				Policy: autoscaling.Policy{
+					Type: autoscaling.RoomOccupancy,
+					Parameters: autoscaling.PolicyParameters{
+						RoomOccupancy: &autoscaling.RoomOccupancyParams{
+							ReadyTarget: 0.1,
+						},
+					},
+				},
+			},
+		}
+		err := kubernetesRuntime.CreateScheduler(ctx, scheduler)
+		if err != nil {
+			require.ErrorIs(t, errors.ErrAlreadyExists, err)
+		}
+
+		defer func() {
+			err := kubernetesRuntime.DeleteScheduler(ctx, scheduler)
+			if err != nil {
+				require.ErrorIs(t, errors.ErrNotFound, err)
+			}
+		}()
+
+		time.Sleep(time.Millisecond * 100)
+		newValue := 100
+		err = kubernetesRuntime.MitigateDisruption(ctx, scheduler, newValue, 0.0)
+		require.NoError(t, err)
+
+		pdb, err := client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, pdb)
+		require.Equal(t, pdb.Name, scheduler.Name)
+
+		incSafetyPercentage := 1.0 + DefaultDisruptionSafetyPercentage
+		require.Equal(t, int32(float64(newValue)*incSafetyPercentage), pdb.Spec.MinAvailable.IntVal)
 	})
 }

--- a/internal/core/logs/logs.go
+++ b/internal/core/logs/logs.go
@@ -34,4 +34,5 @@ const (
 	LogFieldExecutorName        = "executor_name"
 	LogFieldHandlerName         = "handler_name"
 	LogFieldOperationPhase      = "operation_phase"
+	LogFieldRuntime             = "runtime"
 )

--- a/internal/core/ports/mock/runtime_mock.go
+++ b/internal/core/ports/mock/runtime_mock.go
@@ -109,6 +109,20 @@ func (mr *MockRuntimeMockRecorder) DeleteScheduler(ctx, scheduler interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScheduler", reflect.TypeOf((*MockRuntime)(nil).DeleteScheduler), ctx, scheduler)
 }
 
+// MitigateDisruption mocks base method.
+func (m *MockRuntime) MitigateDisruption(ctx context.Context, scheduler *entities.Scheduler, roomAmount int, safetyPercentage float64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MitigateDisruption", ctx, scheduler, roomAmount, safetyPercentage)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MitigateDisruption indicates an expected call of MitigateDisruption.
+func (mr *MockRuntimeMockRecorder) MitigateDisruption(ctx, scheduler, roomAmount, safetyPercentage interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MitigateDisruption", reflect.TypeOf((*MockRuntime)(nil).MitigateDisruption), ctx, scheduler, roomAmount, safetyPercentage)
+}
+
 // WatchGameRoomInstances mocks base method.
 func (m *MockRuntime) WatchGameRoomInstances(ctx context.Context, scheduler *entities.Scheduler) (ports.RuntimeWatcher, error) {
 	m.ctrl.T.Helper()

--- a/internal/core/ports/runtime.go
+++ b/internal/core/ports/runtime.go
@@ -45,6 +45,8 @@ type Runtime interface {
 	WatchGameRoomInstances(ctx context.Context, scheduler *entities.Scheduler) (RuntimeWatcher, error)
 	// Create a name to the room.
 	CreateGameRoomName(ctx context.Context, scheduler entities.Scheduler) (string, error)
+	// Apply changes to runtime to mitigate disruptions looking at current number of rooms
+	MitigateDisruption(ctx context.Context, scheduler *entities.Scheduler, roomAmount int, safetyPercentage float64) error
 }
 
 // RuntimeWatcher defines a process of watcher, it will have a chan with the

--- a/internal/core/worker/config/runtime_watcher_config.go
+++ b/internal/core/worker/config/runtime_watcher_config.go
@@ -1,0 +1,30 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package config
+
+import "time"
+
+type RuntimeWatcherConfig struct {
+	DisruptionWorkerIntervalSeconds time.Duration
+	DisruptionSafetyPercentage      float64
+}

--- a/internal/core/worker/worker.go
+++ b/internal/core/worker/worker.go
@@ -55,6 +55,7 @@ type WorkerOptions struct {
 	RoomStorage           ports.RoomStorage
 	InstanceStorage       ports.GameRoomInstanceStorage
 	MetricsReporterConfig *config.MetricsReporterConfig
+	RuntimeWatcherConfig  *config.RuntimeWatcherConfig
 }
 
 // Configuration holds all worker configuration parameters.


### PR DESCRIPTION
### What does this MR do?

- Add a goroutine to Runtime Watcher that runs every X seconds. The routine checks for the number of occupied rooms and apply `MitigateDisruption`
- Add `MititageDisruption` to runtime. For Kubernetes, this means that we set a PDB on the scheduler's namespace configuring `minAvailable` equals to the number of occupied rooms

### Progress

- [x] Feature
- [x] Integration Tests
- [x] Unit Tests
- [ ] Documentation