### PR TITLE
Add selector and labels to PDB

### DIFF
--- a/docs/reference/Kubernetes.md
+++ b/docs/reference/Kubernetes.md
@@ -58,6 +58,9 @@ runtimeWatcher:
     safetyPercentage: 0.05
 ```
 
+We should always allow node consolidation to happen, thus if the total number of rooms
+is 1, then we set PDB's `minAvailable: 0`.
+
 #### Pod Change Events Worker
 
 For this type of worker, runtime watcher spawns multiple goroutines, maintaining a worker

--- a/internal/adapters/runtime/kubernetes/scheduler.go
+++ b/internal/adapters/runtime/kubernetes/scheduler.go
@@ -97,6 +97,11 @@ func (k *kubernetes) createPDBFromScheduler(ctx context.Context, scheduler *enti
 				Type:   intstr.Int,
 				IntVal: int32(0),
 			},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"maestro-scheduler": scheduler.Name,
+				},
+			},
 		},
 	}
 

--- a/internal/adapters/runtime/kubernetes/scheduler.go
+++ b/internal/adapters/runtime/kubernetes/scheduler.go
@@ -108,13 +108,6 @@ func (k *kubernetes) createPDBFromScheduler(ctx context.Context, scheduler *enti
 		},
 	}
 
-	if scheduler.Autoscaling != nil && scheduler.Autoscaling.Enabled {
-		pdbSpec.Spec.MinAvailable = &intstr.IntOrString{
-			Type:   intstr.Int,
-			IntVal: int32(scheduler.Autoscaling.Min),
-		}
-	}
-
 	pdb, err := k.clientSet.PolicyV1().PodDisruptionBudgets(scheduler.Name).Create(ctx, pdbSpec, metav1.CreateOptions{})
 	if err != nil && !kerrors.IsAlreadyExists(err) {
 		k.logger.Warn("error creating pdb", zap.String("scheduler", scheduler.Name), zap.Error(err))

--- a/internal/adapters/runtime/kubernetes/scheduler.go
+++ b/internal/adapters/runtime/kubernetes/scheduler.go
@@ -91,6 +91,9 @@ func (k *kubernetes) createPDBFromScheduler(ctx context.Context, scheduler *enti
 	pdbSpec := &v1Policy.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: scheduler.Name,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "maestro",
+			},
 		},
 		Spec: v1Policy.PodDisruptionBudgetSpec{
 			MinAvailable: &intstr.IntOrString{

--- a/internal/adapters/runtime/kubernetes/scheduler_test.go
+++ b/internal/adapters/runtime/kubernetes/scheduler_test.go
@@ -124,6 +124,8 @@ func TestPDBCreationAndDeletion(t *testing.T) {
 		require.Equal(t, pdb.Spec.MinAvailable.IntVal, int32(0))
 		require.Contains(t, pdb.Spec.Selector.MatchLabels, "maestro-scheduler")
 		require.Contains(t, pdb.Spec.Selector.MatchLabels["maestro-scheduler"], scheduler.Name)
+		require.Contains(t, pdb.Labels, "app.kubernetes.io/managed-by")
+		require.Contains(t, pdb.Labels["app.kubernetes.io/managed-by"], "maestro")
 	})
 
 	t.Run("create pdb from scheduler with autoscaling", func(t *testing.T) {

--- a/internal/adapters/runtime/kubernetes/scheduler_test.go
+++ b/internal/adapters/runtime/kubernetes/scheduler_test.go
@@ -118,8 +118,12 @@ func TestPDBCreationAndDeletion(t *testing.T) {
 		pdb, err := client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, pdb)
+		require.NotNil(t, pdb.Spec)
+		require.NotNil(t, pdb.Spec.Selector)
 		require.Equal(t, pdb.Name, scheduler.Name)
 		require.Equal(t, pdb.Spec.MinAvailable.IntVal, int32(0))
+		require.Contains(t, pdb.Spec.Selector.MatchLabels, "maestro-scheduler")
+		require.Contains(t, pdb.Spec.Selector.MatchLabels["maestro-scheduler"], scheduler.Name)
 	})
 
 	t.Run("create pdb from scheduler with autoscaling", func(t *testing.T) {
@@ -319,6 +323,7 @@ func TestMitigateDisruption(t *testing.T) {
 		err = kubernetesRuntime.MitigateDisruption(ctx, scheduler, newValue, 0.0)
 		require.NoError(t, err)
 
+		time.Sleep(time.Millisecond * 100)
 		pdb, err := client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, pdb)

--- a/internal/core/worker/runtimewatcher/runtime_watcher_worker_test.go
+++ b/internal/core/worker/runtimewatcher/runtime_watcher_worker_test.go
@@ -264,6 +264,7 @@ func TestRuntimeWatcher_Start(t *testing.T) {
 		runtimeWatcher.EXPECT().Stop()
 
 		runtime.EXPECT().MitigateDisruption(gomock.Any(), gomock.Any(), 0, 0.0).Return(nil).MinTimes(0)
+		roomStorage.EXPECT().GetRoomCount(gomock.Any(), gomock.Any()).Return(2, nil).MinTimes(0)
 		roomStorage.EXPECT().GetRoomCountByStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(0, nil).MinTimes(0)
 
 		ctx, cancelFunc := context.WithCancel(context.Background())


### PR DESCRIPTION
### What does this MR do?

- Add a selector to the PDB created on game room namespaces. The selector will match the label `maestro-scheduler` by looking at the scheduler name in its values
- Add a label for `app.kubernetes.io/managed-by` so runtime administrators can filter by and integrate with maestro created resources
- Reset PDB mitigation to `minAvailable: 0` if total number of rooms is 1

### Progress

- [x] Feature
- [x] Integration Tests