### PR TITLE
fix(runtime): check maxUnavailable in existing PDB

### DIFF
--- a/internal/adapters/runtime/kubernetes/scheduler_test.go
+++ b/internal/adapters/runtime/kubernetes/scheduler_test.go
@@ -36,8 +36,10 @@ import (
 	"github.com/topfreegames/maestro/internal/core/ports/errors"
 	"github.com/topfreegames/maestro/test"
 	v1 "k8s.io/api/core/v1"
+	v1Policy "k8s.io/api/policy/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestSchedulerCreation(t *testing.T) {
@@ -321,5 +323,62 @@ func TestMitigateDisruption(t *testing.T) {
 
 		incSafetyPercentage := 1.0 + DefaultDisruptionSafetyPercentage
 		require.Equal(t, int32(float64(newValue)*incSafetyPercentage), pdb.Spec.MinAvailable.IntVal)
+	})
+
+	t.Run("should clear maxUnavailable and set minAvailable if existing PDB uses maxUnavailable", func(t *testing.T) {
+		if !kubernetesRuntime.isPDBSupported() {
+			t.Log("Kubernetes version does not support PDB, skipping")
+			t.SkipNow()
+		}
+		scheduler := &entities.Scheduler{
+			Name: "scheduler-pdb-max-unavailable",
+		}
+		pdbSpec := &v1Policy.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: scheduler.Name,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "maestro",
+				},
+			},
+			Spec: v1Policy.PodDisruptionBudgetSpec{
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: int32(10),
+				},
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"maestro-scheduler": scheduler.Name,
+					},
+				},
+			},
+		}
+		namespace := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: scheduler.Name,
+			},
+		}
+
+		_, err := client.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		pdb, err := client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Create(ctx, pdbSpec, metav1.CreateOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, pdb)
+		require.Equal(t, pdb.Spec.MaxUnavailable.IntVal, int32(10))
+
+		occupiedRooms := 100
+		err = kubernetesRuntime.MitigateDisruption(ctx, scheduler, occupiedRooms, 0.0)
+		require.NoError(t, err)
+
+		pdb, err = client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, pdb)
+		require.Equal(t, pdb.Name, scheduler.Name)
+
+		incSafetyPercentage := 1.0 + DefaultDisruptionSafetyPercentage
+		newRoomAmount := int32(float64(occupiedRooms) * incSafetyPercentage)
+		require.Equal(t, pdb.Spec.MinAvailable.IntVal, newRoomAmount)
+		require.Nil(t, pdb.Spec.MaxUnavailable)
+
 	})
 }


### PR DESCRIPTION
### What does this MR do?

- If there's an existing PDB in the namespace that has set maxUnavailable, we need to reset and set minAvailable

### Progress

- [x] Feature
- [x] Integration Tests