### PR TITLE
test(runtime): fix concurrency in disruption tests

### DIFF
--- a/internal/adapters/runtime/kubernetes/scheduler_test.go
+++ b/internal/adapters/runtime/kubernetes/scheduler_test.go
@@ -310,13 +310,19 @@ func TestMitigateDisruption(t *testing.T) {
 			}
 		}()
 
+		pdb, err := client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, pdb)
+		require.Equal(t, pdb.Name, scheduler.Name)
+		require.Equal(t, pdb.Spec.MinAvailable.IntVal, int32(0))
+
 		time.Sleep(time.Millisecond * 100)
 		newValue := 100
 		err = kubernetesRuntime.MitigateDisruption(ctx, scheduler, newValue, 0.0)
 		require.NoError(t, err)
 
 		time.Sleep(time.Millisecond * 100)
-		pdb, err := client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
+		pdb, err = client.PolicyV1().PodDisruptionBudgets(scheduler.Name).Get(ctx, scheduler.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, pdb)
 		require.Equal(t, pdb.Name, scheduler.Name)


### PR DESCRIPTION
Fix concurrency on runtime's mitigate disruption tests. We need to fetch the latest PDB resource prior to passing it to the `MitigateDisruption` in tests, otherwise, k8s API will throw an error:

https://github.com/topfreegames/maestro/actions/runs/8330220573/job/22798261290