### PR TITLE
fix(autoscale): do not cap max if set to -1

### DIFF
--- a/internal/core/services/autoscaler/autoscaler.go
+++ b/internal/core/services/autoscaler/autoscaler.go
@@ -106,7 +106,7 @@ func (a *Autoscaler) CanDownscale(ctx context.Context, scheduler *entities.Sched
 func ensureDesiredNumberIsBetweenMinAndMax(autoscaling *autoscaling.Autoscaling, desiredNumberOfRooms int) int {
 	if desiredNumberOfRooms < autoscaling.Min {
 		desiredNumberOfRooms = autoscaling.Min
-	} else if desiredNumberOfRooms > autoscaling.Max {
+	} else if autoscaling.Max >= 0 && desiredNumberOfRooms > autoscaling.Max {
 		desiredNumberOfRooms = autoscaling.Max
 	}
 


### PR DESCRIPTION
When a scheduler is created with `max` set to `-1`, already valid in current API, we need to skip the check for capping desired number of rooms within the max.