### PR TITLE
tests: fix cancel msg on operation worker

### DIFF
--- a/internal/core/worker/operationexecution/operation_execution_worker_test.go
+++ b/internal/core/worker/operationexecution/operation_execution_worker_test.go
@@ -234,7 +234,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		operationExecutor.EXPECT().Rollback(gomock.Any(), expectedOperation, operationDefinition, executionErr).Do(
 			func(ctx, operation, definition, executeErr interface{}) {},
 		).Return(nil)
-		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "operation canceled by the user")
+		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "operation execution failed")
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Starting operation rollback")
 		operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), expectedOperation, "Operation rollback flow execution finished with success")
 


### PR DESCRIPTION
Fixing failed run by changing the expected cancel string: https://github.com/topfreegames/maestro/actions/runs/9384998563/job/25842068782