### PR TITLE
[v9.17.0] Maestro v9 to coexist with other Game Room providers

### DIFF
--- a/metadata/version.go
+++ b/metadata/version.go
@@ -7,8 +7,8 @@
 
 package metadata
 
-//Version of Maestro
-var Version = "9.15.2"
+// Version of Maestro
+var Version = "9.16.0"
 
-//KubeVersion is the desired Kubernetes version
+// KubeVersion is the desired Kubernetes version
 var KubeVersion = "v1.13.9"

--- a/metadata/version.go
+++ b/metadata/version.go
@@ -8,7 +8,7 @@
 package metadata
 
 // Version of Maestro
-var Version = "9.16.0"
+var Version = "9.17.0"
 
 // KubeVersion is the desired Kubernetes version
 var KubeVersion = "v1.13.9"

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -1701,6 +1701,7 @@ func (w *Watcher) podEventHandler(key string) error {
 	}
 
 	kubePod, err := w.Lister.Get(name)
+	w.Logger.Infof("[podEventHandler]: name=%s, kubePod=%s, err=%s", name, kubePod, err)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err


### PR DESCRIPTION
* refactor(controller): do not fail scheduler if namespace exists

When creating a scheduler, we fail if the namespace already exists. This is problematic if there are other GR providers running at the same namespace, like maestro v10 for example. Thus, don't fail scheduler creation if namespace exists.

* refactor(controller): do not delete namespace on scheduler delete

There can be other GR providers running into the same namespace, thus we don't want to cascade delete the k8s namespace on scheduler deletion

* refactor(watcher): filter pod events by heritage label

There can be other resources/pods running in the namespace that are not managed by Maestro. In that case, we want to filter the watcher to only receive pod events from the ones created by v9