### PR TITLE
fix(forwarder): port v9 keepalive configs

### DIFF
--- a/internal/adapters/events/forwarder_client.go
+++ b/internal/adapters/events/forwarder_client.go
@@ -38,6 +38,7 @@ import (
 	pb "github.com/topfreegames/protos/maestro/grpc/generated"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 // Address represent a host:port to a grpc server that understand Event messages.
@@ -169,6 +170,7 @@ func (f *ForwarderClient) createGRPCConnection(address string) (*grpc.ClientConn
 	conn, err := grpc.Dial(
 		address,
 		dialOption,
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: 30 * time.Second, Timeout: 10 * time.Second, PermitWithoutStream: true}),
 		grpc.WithUnaryInterceptor(otgrpc.OpenTracingClientInterceptor(tracer)),
 	)
 	if err != nil {


### PR DESCRIPTION
The forwarder will use KeepAlive params from GRPC, that uses HTTP/2 ping frames, to check for broken connections and refresh. If not used, we'll default to whatever the underlying OS is using to manage the port - which is around 15-20 minutes.

Porting the work of #600