### PR TITLE
[Add Rooms] configure a limit of rooms added per operation

### DIFF
--- a/cmd/worker/wire.go
+++ b/cmd/worker/wire.go
@@ -52,6 +52,7 @@ func initializeWorker(c config.Config, builder *worker.WorkerBuilder) (*workerss
 		service.NewWorkersConfig,
 		service.NewCreateSchedulerVersionConfig,
 		service.NewHealthControllerConfig,
+		service.NewOperationRoomsAddConfig,
 		service.NewRoomManagerConfig,
 		service.NewRoomManager,
 		service.NewOperationManagerConfig,

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -80,7 +80,8 @@ func initializeWorker(c config.Config, builder *worker.WorkerBuilder) (*workers.
 	autoscaler := service.NewAutoscaler(policyMap)
 	newversionConfig := service.NewCreateSchedulerVersionConfig(c)
 	healthcontrollerConfig := service.NewHealthControllerConfig(c)
-	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager, roomStorage, schedulerManager, gameRoomInstanceStorage, schedulerCache, operationStorage, operationManager, autoscaler, newversionConfig, healthcontrollerConfig)
+	addConfig := service.NewOperationRoomsAddConfig(c)
+	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager, roomStorage, schedulerManager, gameRoomInstanceStorage, schedulerCache, operationStorage, operationManager, autoscaler, newversionConfig, healthcontrollerConfig, addConfig)
 	configuration, err := service.NewWorkersConfig(c)
 	if err != nil {
 		return nil, err

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,6 +64,11 @@ runtimeWatcher:
     intervalSeconds: 5
     safetyPercentage: 0.05
 
+operations:
+  rooms:
+    add:
+      limit: 1000
+
 services:
   roomManager:
     roomPingTimeoutMillis: 240000

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -25,6 +25,7 @@ package providers
 import (
 	"github.com/topfreegames/maestro/internal/core/operations"
 	"github.com/topfreegames/maestro/internal/core/operations/healthcontroller"
+	"github.com/topfreegames/maestro/internal/core/operations/rooms/add"
 	addrooms "github.com/topfreegames/maestro/internal/core/operations/rooms/add"
 	removerooms "github.com/topfreegames/maestro/internal/core/operations/rooms/remove"
 	createscheduler "github.com/topfreegames/maestro/internal/core/operations/schedulers/create"
@@ -86,11 +87,12 @@ func ProvideExecutors(
 	autoscaler ports.Autoscaler,
 	newSchedulerVersionConfig newversion.Config,
 	healthControllerConfig healthcontroller.Config,
+	addRoomsConfig add.Config,
 ) map[string]operations.Executor {
 
 	executors := map[string]operations.Executor{}
 	executors[createscheduler.OperationName] = createscheduler.NewExecutor(runtime, schedulerManager, operationManager)
-	executors[addrooms.OperationName] = addrooms.NewExecutor(roomManager, schedulerStorage, operationManager)
+	executors[addrooms.OperationName] = addrooms.NewExecutor(roomManager, schedulerStorage, operationManager, addRoomsConfig)
 	executors[removerooms.OperationName] = removerooms.NewExecutor(roomManager, roomStorage, operationManager)
 	executors[test.OperationName] = test.NewExecutor()
 	executors[switchversion.OperationName] = switchversion.NewExecutor(roomManager, schedulerManager, operationManager, roomStorage)

--- a/internal/core/worker/operationexecution/operation_execution_worker.go
+++ b/internal/core/worker/operationexecution/operation_execution_worker.go
@@ -68,6 +68,7 @@ type OperationExecutionWorker struct {
 	operationsToAbort       chan OperationExecutionInstance
 	isStopping              *atomic.Bool
 	abortingOperationsGroup *sync.WaitGroup
+	addRoomsLimit           int
 
 	logger *zap.Logger
 }
@@ -81,6 +82,7 @@ type OperationExecutionInstance struct {
 // NewOperationExecutionWorker instantiate a new OperationExecutionWorker to a specified scheduler.
 func NewOperationExecutionWorker(scheduler *entities.Scheduler, opts *worker.WorkerOptions) worker.Worker {
 	return &OperationExecutionWorker{
+		addRoomsLimit:                     opts.Configuration.AddRoomsLimit,
 		healthControllerExecutionInterval: opts.Configuration.HealthControllerExecutionInterval,
 		storagecleanupExecutionInterval:   opts.Configuration.StorageCleanupExecutionInterval,
 		operationManager:                  opts.OperationManager,

--- a/internal/core/worker/worker.go
+++ b/internal/core/worker/worker.go
@@ -63,6 +63,7 @@ type Configuration struct {
 	HealthControllerExecutionInterval time.Duration
 	StorageCleanupExecutionInterval   time.Duration
 	WorkersStopTimeoutDuration        time.Duration
+	AddRoomsLimit                     int
 }
 
 // ProvideWorkerOptions instantiate an WorkerOptions structure.

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -25,6 +25,7 @@ package service
 import (
 	"time"
 
+	"github.com/topfreegames/maestro/internal/core/operations/rooms/add"
 	"github.com/topfreegames/maestro/internal/core/operations/schedulers/newversion"
 	"github.com/topfreegames/maestro/internal/core/services/events"
 	operationmanager "github.com/topfreegames/maestro/internal/core/services/operations"
@@ -46,6 +47,7 @@ const (
 	roomDeletionTimeoutMillisConfigPath         = "services.roomManager.roomDeletionTimeoutMillis"
 	operationLeaseTTLMillisConfigPath           = "services.operationManager.operationLeaseTTLMillis"
 	schedulerCacheTTLMillisConfigPath           = "services.eventsForwarder.schedulerCacheTTLMillis"
+	operationsRoomsAddLimitConfigPath           = "operations.rooms.add.limit"
 )
 
 // NewCreateSchedulerVersionConfig instantiate a new CreateSchedulerVersionConfig to be used by the NewSchedulerVersion operation to customize its configuration.
@@ -74,6 +76,17 @@ func NewHealthControllerConfig(c config.Config) healthcontroller.Config {
 		RoomInitializationTimeout: initializationTimeout,
 		RoomPingTimeout:           pingTimeout,
 		RoomDeletionTimeout:       deletionTimeout,
+	}
+
+	return config
+}
+
+// NewOperationRoomsAddConfig instantiate a new add.Config to be used by the rooms add operation.
+func NewOperationRoomsAddConfig(c config.Config) add.Config {
+	operationsRoomsAddLimit := int32(c.GetInt(operationsRoomsAddLimitConfigPath))
+
+	config := add.Config{
+		AmountLimit: operationsRoomsAddLimit,
 	}
 
 	return config


### PR DESCRIPTION
Adds a configuration to the rooms' add operation to limit the amount of rooms created at once. This is useful when runtimes have limitations to the number of nodes/c-plane load that the number of additional rooms generate in the system.

The autoscale operations of _health_controller_ shouldn't be impacted. What will happen is that upscale might decide to add 1000 rooms and configured limit is 150, then, on the next _health_controller_ execution, 850 rooms will be asked to be created, and so on. Thus, the only impact would be a higher amount of _health_controller_ loops to reach the desired target.