### PR TITLE
feat(forwarder): configs for KeepAlive params

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -49,6 +49,10 @@ adapters:
       inCluster: false
       masterUrl: "https://127.0.0.1:6443"
       kubeconfig: "./kubeconfig/kubeconfig.yaml"
+  grpc:
+    keepAlive:
+      time: 30s
+      timeout: 5s
 workers:
   syncInterval: 10s
   stopTimeoutDuration: 2m

--- a/internal/adapters/events/forwarder_client_test.go
+++ b/internal/adapters/events/forwarder_client_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/topfreegames/maestro/internal/core/entities/forwarder"
 	"github.com/topfreegames/maestro/test"
+	"google.golang.org/grpc/keepalive"
 
 	pb "github.com/topfreegames/protos/maestro/grpc/generated"
 )
@@ -190,7 +191,7 @@ func TestForwarderClient_SendRoomStatus(t *testing.T) {
 				)
 				require.NoError(t, err)
 			}
-			f := NewForwarderClient()
+			f := NewForwarderClient(keepalive.ClientParameters{})
 			got, err := f.SendRoomStatus(tt.args.ctx, tt.args.forwarder, &tt.args.in)
 			if !tt.wantErr(t, err, fmt.Sprintf("SendRoomStatus(%v, %v, %v)", tt.args.ctx, tt.args.forwarder, tt.args.in)) {
 				return
@@ -237,7 +238,7 @@ func TestSendPlayerEvent(t *testing.T) {
 }
 
 func basicArrangeForwarderClient(t *testing.T) {
-	forwarderClientAdapter = NewForwarderClient()
+	forwarderClientAdapter = NewForwarderClient(keepalive.ClientParameters{})
 }
 
 func newRoomEvent(mockIdentifier string) pb.RoomEvent {


### PR DESCRIPTION
The GRPC KeepAlive params can now be configured in the config.yaml and passed through the forwarder. By default, time is 30s, timeout 10s, and permit without stream is enabled by default