### PR TITLE
CI: migrate to dockerhub

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,13 +18,12 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAYIO_USERNAME }}
-          password: ${{ secrets.QUAYIO_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: quay.io/tfgco/maestro:${{ env.IMAGE_VERSION }}
+          tags: tfgco/maestro:${{ env.IMAGE_VERSION }}


### PR DESCRIPTION
As quay.io is deprecated by wildlife, we are migrating all projects to Docker Hub.

New repository: [Maestro](https://hub.docker.com/r/tfgco/maestro)