### PR TITLE
fix: rollout calculation to prevent drop all ready rooms

### DIFF
--- a/internal/core/operations/healthcontroller/executor_test.go
+++ b/internal/core/operations/healthcontroller/executor_test.go
@@ -1370,9 +1370,8 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					op := operation.New(newScheduler.Name, definition.Name(), nil)
 
 					// Perform rolling update
-					roomManager.EXPECT().SchedulerMaxSurge(gomock.Any(), newScheduler).Return(1, nil)
-					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), newScheduler.Name, &add.Definition{Amount: 1}).Return(op, nil)
-					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), newScheduler.Name, &add.Definition{Amount: 0}).Return(op, nil)
+					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
 					roomStorage.EXPECT().GetRoomIDsByStatus(gomock.Any(), newScheduler.Name, game_room.GameStatusOccupied).Return(gameRoomIDs, nil)
 					roomStorage.EXPECT().GetRoomIDsByStatus(gomock.Any(), newScheduler.Name, game_room.GameStatusReady).Return(gameRoomIDs, nil)
 					operationManager.EXPECT().CreateOperation(gomock.Any(), newScheduler.Name, &remove.Definition{RoomsIDs: gameRoomIDs, Reason: remove.RollingUpdateReplace}).Return(op, nil)
@@ -1465,5 +1464,87 @@ func newValidScheduler(autoscaling *autoscaling.Autoscaling) *entities.Scheduler
 		},
 		Forwarders:  forwarders,
 		Autoscaling: autoscaling,
+	}
+}
+
+func TestComputeRollingSurgeVariants(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		maxSurge             string
+		desiredNumberOfRooms int
+		totalRoomsAmount     int
+		expectedSurgeAmount  int
+		expectError          bool
+	}{
+		{
+			name:                 "Standard surge calculation",
+			maxSurge:             "10",
+			desiredNumberOfRooms: 20,
+			totalRoomsAmount:     15,
+			expectedSurgeAmount:  10,
+			expectError:          false,
+		},
+		{
+			name:                 "High amount of rooms above 1000",
+			maxSurge:             "30%",
+			desiredNumberOfRooms: 1500,
+			totalRoomsAmount:     1000,
+			expectedSurgeAmount:  450, // It can surge up to 950 but we cap to the maxSurge of 450
+			expectError:          false,
+		},
+		{
+			name:                 "Relative maxSurge with rooms above 1000",
+			maxSurge:             "25%",
+			desiredNumberOfRooms: 1200,
+			totalRoomsAmount:     1000,
+			expectedSurgeAmount:  300, // 25% of 1200 is 300
+			expectError:          false,
+		},
+		{
+			name:                 "Do not replace rooms during aggressive downscaling",
+			maxSurge:             "25%",
+			desiredNumberOfRooms: 1200,
+			totalRoomsAmount:     1500,
+			expectedSurgeAmount:  0,
+			expectError:          false,
+		},
+		{
+			name:                 "Respect the surge when downscaling",
+			maxSurge:             "25%",
+			desiredNumberOfRooms: 1200,
+			totalRoomsAmount:     1300,
+			expectedSurgeAmount:  200,
+			expectError:          false,
+		},
+		{
+			name:                 "Invalid maxSurge string format",
+			maxSurge:             "twenty%", // Invalid because it's not a number
+			desiredNumberOfRooms: 300,
+			totalRoomsAmount:     250,
+			expectedSurgeAmount:  1, // Expected to be 1 because the function should return an error
+			expectError:          true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheduler := &entities.Scheduler{
+				MaxSurge: tc.maxSurge,
+			}
+
+			surgeAmount, err := healthcontroller.ComputeRollingSurge(scheduler, tc.desiredNumberOfRooms, tc.totalRoomsAmount)
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if surgeAmount != tc.expectedSurgeAmount {
+					t.Errorf("expected surge amount to be %d, but got %d", tc.expectedSurgeAmount, surgeAmount)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR apply some changes in how maestro manages rollouts:
- It calculates the amount of rooms to surge based on the current total target of rooms, preventing health controller miscalculations;
- Cap the amount of rooms to surge, taking in consideration pending rooms, preventing creation loop;
- Take in count the ready target to drop rooms during rollouts;
- Rollout operations don't block health controller operations, allowing the health controller to handle changes faster;