### PR TITLE
refactor(healthcontroller): generate only one add/remove operation per cycle

### DIFF
--- a/internal/core/operations/healthcontroller/executor.go
+++ b/internal/core/operations/healthcontroller/executor.go
@@ -228,8 +228,10 @@ func (ex *Executor) ensureDesiredAmountOfInstances(ctx context.Context, op *oper
 	}
 
 	logger.Info(msgToAppend)
-	ex.operationManager.AppendOperationEventToExecutionHistory(ctx, op, msgToAppend)
 	ex.setTookAction(def, tookAction)
+	if tookAction {
+		ex.operationManager.AppendOperationEventToExecutionHistory(ctx, op, msgToAppend)
+	}
 	return nil
 }
 

--- a/internal/core/operations/healthcontroller/executor.go
+++ b/internal/core/operations/healthcontroller/executor.go
@@ -45,7 +45,9 @@ import (
 )
 
 const (
+	// TODO: refactor both maxSurge consts to SchedulerController
 	schedulerMaxSurgeRelativeSymbol = "%"
+	defaultMaxSurge                 = 1
 )
 
 // Config have the configs to execute healthcontroller.
@@ -125,24 +127,14 @@ func (ex *Executor) Execute(ctx context.Context, op *operation.Operation, defini
 		ex.setTookAction(def, true)
 	}
 
-	desiredNumberOfRooms, err := ex.getDesiredNumberOfRooms(ctx, logger, scheduler)
+	desiredNumberOfRooms, isRollingUpdating, err := GetDesiredNumberOfRooms(ctx, ex.autoscaler, ex.roomStorage, ex.schedulerStorage, logger, scheduler, availableRooms)
 	if err != nil {
 		logger.Error("error getting the desired number of rooms", zap.Error(err))
 		return err
 	}
 	reportDesiredNumberOfRooms(scheduler.Game, scheduler.Name, desiredNumberOfRooms)
 
-	// Check if the system is in a rollingUpdate by listing rooms that are not the current scheduler version
-	roomsPreviousSchedulerVersion, isRollingUpdate := ex.checkRollingUpdate(ctx, logger, scheduler, availableRooms)
-	if isRollingUpdate {
-		err = ex.performRollingUpdate(ctx, op, def, logger, scheduler, desiredNumberOfRooms, availableRooms, roomsPreviousSchedulerVersion)
-		if err != nil {
-			logger.Error("could not perform rolling update", zap.Error(err))
-			// Rolling update should not block the health controller
-		}
-	}
-
-	err = ex.ensureDesiredAmountOfInstances(ctx, op, def, scheduler, logger, len(availableRooms), desiredNumberOfRooms)
+	err = ex.ensureDesiredAmountOfInstances(ctx, op, def, scheduler, logger, len(availableRooms), desiredNumberOfRooms, isRollingUpdating)
 	if err != nil {
 		logger.Error("cannot ensure desired amount of instances", zap.Error(err))
 		return err
@@ -199,34 +191,27 @@ func (ex *Executor) tryEnsureCorrectRoomsOnStorage(ctx context.Context, op *oper
 	}
 }
 
-func (ex *Executor) ensureDesiredAmountOfInstances(ctx context.Context, op *operation.Operation, def *Definition, scheduler *entities.Scheduler, logger *zap.Logger, actualAmount, desiredAmount int) error {
+func (ex *Executor) ensureDesiredAmountOfInstances(ctx context.Context, op *operation.Operation, def *Definition, scheduler *entities.Scheduler, logger *zap.Logger, actualAmount, desiredAmount int, isRollingUpdating bool) error {
 	var msgToAppend string
 	var tookAction bool
 
 	logger = logger.With(zap.Int("actual", actualAmount), zap.Int("desired", desiredAmount))
 	switch {
 	case actualAmount > desiredAmount: // Need to scale down
-		can, msg := ex.canPerformDownscale(ctx, scheduler, logger)
-		if can {
-			scheduler.LastDownscaleAt = time.Now().UTC()
-			if err := ex.schedulerStorage.UpdateScheduler(ctx, scheduler); err != nil {
-				logger.Error("error updating scheduler", zap.Error(err))
-				return err
-			}
-			removeAmount := actualAmount - desiredAmount
-			removeOperation, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &remove.Definition{
-				Amount: removeAmount,
-				Reason: remove.ScaleDown,
-			})
-			if err != nil {
-				return err
-			}
-			tookAction = true
-			msgToAppend = fmt.Sprintf("created operation (id: %s) to remove %v rooms.", removeOperation.ID, removeAmount)
-		} else {
-			tookAction = false
-			msgToAppend = msg
+		removeAmount := actualAmount - desiredAmount
+		reason := remove.ScaleDown
+		if isRollingUpdating {
+			reason = remove.RollingUpdateReplace
 		}
+		removeOperation, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &remove.Definition{
+			Amount: removeAmount,
+			Reason: reason,
+		})
+		if err != nil {
+			return err
+		}
+		tookAction = true
+		msgToAppend = fmt.Sprintf("created operation (id: %s) to remove %v rooms.", removeOperation.ID, removeAmount)
 	case actualAmount < desiredAmount: // Need to scale up
 		addAmount := desiredAmount - actualAmount
 		addOperation, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &add.Definition{
@@ -325,20 +310,6 @@ func (ex *Executor) enqueueRemoveRooms(ctx context.Context, op *operation.Operat
 	return nil
 }
 
-func (ex *Executor) getDesiredNumberOfRooms(ctx context.Context, logger *zap.Logger, scheduler *entities.Scheduler) (int, error) {
-	if scheduler.Autoscaling != nil && scheduler.Autoscaling.Enabled {
-		desiredNumberOfRooms, err := ex.autoscaler.CalculateDesiredNumberOfRooms(ctx, scheduler)
-		if err != nil {
-			logger.Error("error using autoscaling policy to calculate the desired number of rooms", zap.Error(err))
-
-			return 0, err
-		}
-		return desiredNumberOfRooms, nil
-	}
-
-	return scheduler.RoomsReplicas, nil
-}
-
 func (ex *Executor) mapExistentAndNonExistentGameRooms(gameRoomIDs []string, instances []*game_room.Instance) ([]string, map[string]*game_room.Instance) {
 	roomIdCountMap := make(map[string]int)
 	nonexistentGameRoomsIDs := make([]string, 0)
@@ -372,8 +343,8 @@ func (ex *Executor) setTookAction(def *Definition, tookAction bool) {
 	def.TookAction = &tookAction
 }
 
-func (ex *Executor) canPerformDownscale(ctx context.Context, scheduler *entities.Scheduler, logger *zap.Logger) (bool, string) {
-	can, err := ex.autoscaler.CanDownscale(ctx, scheduler)
+func CanPerformDownscale(ctx context.Context, autoscaler ports.Autoscaler, scheduler *entities.Scheduler, logger *zap.Logger) (bool, string) {
+	can, err := autoscaler.CanDownscale(ctx, scheduler)
 	if err != nil {
 		logger.Error("error checking if scheduler can downscale", zap.Error(err))
 		return can, err.Error()
@@ -401,164 +372,123 @@ func (ex *Executor) canPerformDownscale(ctx context.Context, scheduler *entities
 	return can && !waitingCooldown, "ok"
 }
 
-func (ex *Executor) checkRollingUpdate(
+// TODO: refactor this logic into its own operation with its own deployment.
+// Responsible for:
+// 1. Get desired number of rooms from autoscaling or roomsReplica
+// 2. Check if we are in the middle of a rolling update
+// 3. Recalculate desired number of rooms if we are in a rolling update
+// Then, the healthcontroller operation will only be responsible for checking if the
+// desired number of rooms is correct and if not, create an operation to add or remove rooms.
+func GetDesiredNumberOfRooms(
+	// TODO: use context from SchedulerController execute once moved
 	ctx context.Context,
+	// TODO: get pors from SchedulerController operation once moved
+	autoscaler ports.Autoscaler,
+	roomStorage ports.RoomStorage,
+	schedulerStorage ports.SchedulerStorage,
+	logger *zap.Logger,
+	scheduler *entities.Scheduler,
+	availableRooms []string,
+) (desiredNumber int, isRollingUpdating bool, err error) {
+	desiredNumber = scheduler.RoomsReplicas
+	schedulerUpperLimit := scheduler.RoomsReplicas
+	if scheduler.Autoscaling != nil && scheduler.Autoscaling.Enabled {
+		schedulerUpperLimit = scheduler.Autoscaling.Max
+		desiredNumber, err = autoscaler.CalculateDesiredNumberOfRooms(ctx, scheduler)
+		if err != nil {
+			logger.Error("error using autoscaling policy to calculate the desired number of rooms, using roomsReplica", zap.Error(err), zap.Int("desired", desiredNumber))
+			return
+		}
+	}
+
+	// Check if we are rolling updating and need to recalculate the desired number of rooms
+	isRollingUpdating = IsRollingUpdating(ctx, roomStorage, schedulerStorage, logger, scheduler, availableRooms)
+	if isRollingUpdating {
+		// Recalculate desired number of rooms based on the MaxSurge
+		maxSurgeAmount, err := ComputeMaxSurge(scheduler, desiredNumber)
+		if err != nil || maxSurgeAmount <= 0 {
+			logger.Warn("failed to compute max surge, using default value", zap.Error(err), zap.Int("defaultMaxSurge", defaultMaxSurge))
+			maxSurgeAmount = 1
+		}
+		upperLimitOfRooms := int(math.Min(float64(desiredNumber+maxSurgeAmount), float64(schedulerUpperLimit)))
+		// If we have room to grow, we should grow to the upper limit. If not, set the desired calculated
+		if len(availableRooms) < upperLimitOfRooms {
+			desiredNumber = upperLimitOfRooms
+		}
+	}
+
+	if len(availableRooms) > desiredNumber {
+		willDownscale := true
+		if scheduler.Autoscaling != nil && scheduler.Autoscaling.Enabled {
+			canDownscale, msg := CanPerformDownscale(ctx, autoscaler, scheduler, logger)
+			if !canDownscale {
+				willDownscale = false
+				desiredNumber = len(availableRooms)
+				logger.Info("scheduler can't downscale, keeping the current number of rooms", zap.String("reason", msg))
+			}
+		}
+		if willDownscale {
+			scheduler.LastDownscaleAt = time.Now().UTC()
+			if err := schedulerStorage.UpdateScheduler(ctx, scheduler); err != nil {
+				logger.Error("error updating scheduler", zap.Error(err))
+			}
+		}
+	}
+
+	logger.Info("desired number of rooms: ", zap.Int("desired", desiredNumber), zap.Int("current", len(availableRooms)))
+
+	return
+}
+
+// TODO: refactor to SchedulerController execute
+func IsRollingUpdating(
+	// TODO: use context from SchedulerController execute once moved
+	ctx context.Context,
+	// TODO: get ports reference from the SchedulerController operation once moved
+	roomStorage ports.RoomStorage,
+	schedulerStorage ports.SchedulerStorage,
 	logger *zap.Logger,
 	scheduler *entities.Scheduler,
 	availableRoomsIDs []string,
-) ([]string, bool) {
+) bool {
 	logger.Debug("checking if system is in the middle of a rolling update of scheduler")
-	var roomsPreviousScheduler, occupiedRoomsPreviousScheduler []string
-	majorVersionComparison := make(map[string]bool)
-	var hasMajorVersionUpdate bool
 	// TODO: build this struct during findAvailableAndExpiredRooms() call
+	schedulerCache := make(map[string]*entities.Scheduler)
 	for _, roomID := range availableRoomsIDs {
-		room, err := ex.roomStorage.GetRoom(ctx, scheduler.Name, roomID)
+		room, err := roomStorage.GetRoom(ctx, scheduler.Name, roomID)
 		// if err != nil we will miss the room, the system can still recover itself in
 		// the next health_controller operation
 		if err != nil || room.Version == scheduler.Spec.Version {
 			continue
 		}
-
-		// Check against the cache to avoid unnecessary calls to the storage
-		if _, ok := majorVersionComparison[room.Version]; !ok {
-			// Defaults to false when creating the map
-			majorVersionComparison[room.Version] = false
-			roomScheduler, err := ex.schedulerStorage.GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
+		if _, ok := schedulerCache[room.Version]; !ok {
+			roomScheduler, err := schedulerStorage.GetSchedulerWithFilter(ctx, &filters.SchedulerFilter{
 				Name:    scheduler.Name,
 				Version: room.Version,
 			})
-			if err == nil {
-				majorVersionComparison[room.Version] = roomScheduler.IsMajorVersion(scheduler)
+			// if err != nil when getting the scheduler we will miss this room, same as above, continue
+			// we can get the next room of that scheduler and recover from the error
+			if err != nil {
+				continue
 			}
+			schedulerCache[room.Version] = roomScheduler
 		}
 
-		if majorVersionComparison[room.Version] {
-			hasMajorVersionUpdate = true
-			if room.Status == game_room.GameStatusOccupied {
-				occupiedRoomsPreviousScheduler = append(occupiedRoomsPreviousScheduler, roomID)
-			} else {
-				roomsPreviousScheduler = append(roomsPreviousScheduler, roomID)
-			}
+		if schedulerCache[room.Version].IsMajorVersion(scheduler) {
+			logger.Info(
+				"system has rooms with a major version of difference, rolling update",
+				zap.String("activeScheduler", scheduler.Spec.Version),
+				zap.String("nonActiveSchedulerFound", room.Version),
+			)
+			return true
 		}
 	}
-	if !hasMajorVersionUpdate {
-		logger.Info("system only has rooms in previous minor scheduler versions, skipping rolling update")
-		return []string{}, false
-	}
-	// Append occupied to the end so when deleting we prioritize non-occupied rooms
-	roomsPreviousScheduler = append(roomsPreviousScheduler, occupiedRoomsPreviousScheduler...)
-	logger.Info("rooms that did not match current scheduler versions", zap.Int("rooms", len(roomsPreviousScheduler)))
-	return roomsPreviousScheduler, len(roomsPreviousScheduler) != 0
+	logger.Info("system only has rooms in previous minor scheduler versions, skipping rolling update")
+	return false
 }
 
-func (ex *Executor) performRollingUpdate(
-	ctx context.Context,
-	op *operation.Operation,
-	def *Definition,
-	logger *zap.Logger,
-	scheduler *entities.Scheduler,
-	desiredNumberOfRooms int,
-	availableRoomsIDs []string,
-	roomsWithPreviousSchedulerVersion []string,
-) error {
-	logger.Info("performing rolling update", zap.String("scheduler.Version", scheduler.Spec.Version))
-	maxSurgeAmount, err := ComputeRollingSurge(scheduler, desiredNumberOfRooms, len(availableRoomsIDs))
-	if err != nil {
-		logger.Error("failed to perform rolling update while getting max surge amount of rooms", zap.Error(err))
-		return err
-	}
-
-	if len(roomsWithPreviousSchedulerVersion) < maxSurgeAmount {
-		maxSurgeAmount = len(roomsWithPreviousSchedulerVersion)
-	}
-
-	logger.Info(
-		"up scaling new rooms",
-		zap.Int("desired", desiredNumberOfRooms),
-		zap.Int("maxSurgeAmount", maxSurgeAmount),
-		zap.Int("available", len(availableRoomsIDs)),
-		zap.Int("oldRooms", len(roomsWithPreviousSchedulerVersion)),
-	)
-	addOp, err := ex.operationManager.CreatePriorityOperation(ctx, op.SchedulerName, &add.Definition{
-		Amount: int32(maxSurgeAmount),
-	})
-	if err != nil {
-		logger.Error("failed to enqueue add operation for rolling update", zap.Error(err))
-		return err
-	}
-	msgToAppend := fmt.Sprintf("created operation (id: %s) to surge %v rooms.", addOp.ID, maxSurgeAmount)
-	ex.operationManager.AppendOperationEventToExecutionHistory(ctx, op, msgToAppend)
-	ex.setTookAction(def, true)
-
-	roomsMarkedForDeletion, err := ex.markPreviousSchedulerRoomsForDeletion(
-		ctx,
-		logger,
-		scheduler,
-		roomsWithPreviousSchedulerVersion,
-		desiredNumberOfRooms,
-	)
-	if err != nil {
-		logger.Error("could not delete rooms with previous scheduler version", zap.Error(err))
-		return err
-	}
-	if len(roomsMarkedForDeletion) <= 0 {
-		logger.Info("no rooms marked for deletion", zap.Int("roomsMarkedForDeletion", len(roomsMarkedForDeletion)))
-		return nil
-	}
-	removeOp, err := ex.operationManager.CreateOperation(ctx, op.SchedulerName, &remove.Definition{
-		RoomsIDs: roomsMarkedForDeletion,
-		Reason:   remove.RollingUpdateReplace,
-	})
-	if err != nil {
-		logger.Error("failed to enqueue remove operation for rolling update", zap.Error(err))
-		return err
-	}
-	msgToAppend = fmt.Sprintf("created operation (id: %s) to remove rooms with previous scheduler version.", removeOp.ID)
-	ex.operationManager.AppendOperationEventToExecutionHistory(ctx, op, msgToAppend)
-	ex.setTookAction(def, true)
-
-	return nil
-}
-
-func (ex *Executor) markPreviousSchedulerRoomsForDeletion(
-	ctx context.Context,
-	logger *zap.Logger,
-	scheduler *entities.Scheduler,
-	roomsWithPreviousSchedulerVersion []string,
-	desiredNumberOfTotalRooms int,
-) ([]string, error) {
-	curReadyRooms, err := ex.roomStorage.GetRoomIDsByStatus(ctx, scheduler.Name, game_room.GameStatusReady)
-	if err != nil {
-		return []string{}, fmt.Errorf("failed to list scheduler rooms on ready status: %w", err)
-	}
-	curOccupiedRooms, err := ex.roomStorage.GetRoomIDsByStatus(ctx, scheduler.Name, game_room.GameStatusOccupied)
-	if err != nil {
-		return []string{}, fmt.Errorf("failed to list scheduler rooms on occupied status: %w", err)
-	}
-	desiredNumberOfReadyRooms := desiredNumberOfTotalRooms - len(curOccupiedRooms)
-	bufferRoomsToBeRemoved := len(curReadyRooms) - desiredNumberOfReadyRooms
-	logger = logger.With(
-		zap.Int("roomsWithPreviousSchedulerVersion", len(roomsWithPreviousSchedulerVersion)),
-		zap.Int("currentOccupiedRooms", len(curOccupiedRooms)),
-		zap.Int("currentReadyRooms", len(curReadyRooms)),
-		zap.Int("desiredNumberOfReadyRooms", desiredNumberOfReadyRooms),
-		zap.Int("desiredNumberOfTotalRooms", desiredNumberOfTotalRooms),
-		zap.Int("bufferRoomsToBeRemoved", bufferRoomsToBeRemoved),
-	)
-	if bufferRoomsToBeRemoved < 0 {
-		logger.Info("can not delete old rooms without offending maxUnavailable: 0")
-		return []string{}, nil
-	}
-	if bufferRoomsToBeRemoved > len(roomsWithPreviousSchedulerVersion) {
-		logger.Info("less rooms on previous scheduler version than the amount to delete, capping it")
-		return roomsWithPreviousSchedulerVersion, nil
-	}
-	logger.Sugar().Infof("successfully marked %d rooms for deletion", bufferRoomsToBeRemoved)
-	return roomsWithPreviousSchedulerVersion[:bufferRoomsToBeRemoved], nil
-}
-
-func ComputeRollingSurge(scheduler *entities.Scheduler, desiredNumberOfRooms, totalRoomsAmount int) (maxSurgeNum int, err error) {
+// TODO: refactor to SchedulerController execute
+func ComputeMaxSurge(scheduler *entities.Scheduler, desiredNumberOfRooms int) (maxSurgeNum int, err error) {
 	if scheduler.MaxSurge != "" {
 		isRelative := strings.HasSuffix(scheduler.MaxSurge, schedulerMaxSurgeRelativeSymbol)
 		maxSurgeNum, err = strconv.Atoi(strings.TrimSuffix(scheduler.MaxSurge, schedulerMaxSurgeRelativeSymbol))
@@ -566,13 +496,9 @@ func ComputeRollingSurge(scheduler *entities.Scheduler, desiredNumberOfRooms, to
 			return 0, fmt.Errorf("failed to parse max surge into a number: %w", err)
 		}
 		if isRelative {
-			maxSurgeNum = int(math.Round((float64(maxSurgeNum) / 100) * float64(desiredNumberOfRooms)))
+			maxSurgeNum = int(math.Ceil((float64(maxSurgeNum) / 100.0) * float64(desiredNumberOfRooms)))
 		}
 	}
-
-	// Capping the amount of rooms to surge
-	deviation := int(math.Max(float64(totalRoomsAmount-desiredNumberOfRooms), 0))
-	maxSurgeNum = int(math.Max(float64(maxSurgeNum-deviation), 0))
 
 	return maxSurgeNum, nil
 }

--- a/internal/core/operations/healthcontroller/executor_test.go
+++ b/internal/core/operations/healthcontroller/executor_test.go
@@ -28,6 +28,7 @@ package healthcontroller_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +48,7 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
 	"github.com/topfreegames/maestro/internal/core/entities/port"
 	"github.com/topfreegames/maestro/internal/core/operations/healthcontroller"
+	"github.com/topfreegames/maestro/internal/core/ports/mock"
 	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
 )
 
@@ -69,7 +71,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 		Parameters: autoscaling.PolicyParameters{},
 	}}
 
-	autoscalingEnabled := autoscaling.Autoscaling{Enabled: true, Min: 1, Max: 10, Cooldown: 60, Policy: autoscaling.Policy{
+	autoscalingEnabled := autoscaling.Autoscaling{Enabled: true, Min: 1, Max: 1000, Cooldown: 60, Policy: autoscaling.Policy{
 		Type: autoscaling.RoomOccupancy,
 		Parameters: autoscaling.PolicyParameters{
 			RoomOccupancy: &autoscaling.RoomOccupancyParams{
@@ -1338,7 +1340,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					newScheduler := newValidScheduler(&autoscaling.Autoscaling{
 						Enabled:  true,
 						Min:      2,
-						Max:      10,
+						Max:      1000,
 						Cooldown: 60,
 						Policy: autoscaling.Policy{
 							Type: autoscaling.RoomOccupancy,
@@ -1398,7 +1400,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 			},
 		},
 		{
-			title:      "start rolling update if there are rooms with a major difference in version",
+			title:      "run a complete rolling update if there are rooms with a major difference in version",
 			definition: &healthcontroller.Definition{},
 			executionPlan: executionPlan{
 				tookAction: true,
@@ -1442,7 +1444,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 						SchedulerID: genericSchedulerAutoscalingEnabled.Name,
 						Status:      game_room.GameStatusOccupied,
 						LastPingAt:  time.Now(),
-						Version:     genericSchedulerAutoscalingEnabled.Spec.Version,
+						Version:     newScheduler.Spec.Version,
 					}
 
 					// load
@@ -1450,15 +1452,14 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
 
 					// findAvailableAndExpiredRooms
-					roomStorage.EXPECT().GetRoom(gomock.Any(), newScheduler.Name, gameRoomIDs[0]).Return(gameRoom1, nil)
-					roomStorage.EXPECT().GetRoom(gomock.Any(), newScheduler.Name, gameRoomIDs[1]).Return(gameRoom2, nil)
+					roomStorage.EXPECT().GetRoom(gomock.Any(), newScheduler.Name, gameRoomIDs[0]).Return(gameRoom1, nil).MinTimes(1)
+					roomStorage.EXPECT().GetRoom(gomock.Any(), newScheduler.Name, gameRoomIDs[1]).Return(gameRoom2, nil).MinTimes(1)
 
 					// GetDesiredNumberOfRooms
 					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(newScheduler, nil)
 					autoscaler.EXPECT().CalculateDesiredNumberOfRooms(gomock.Any(), newScheduler).Return(2, nil)
 
 					// Check for rolling update
-					roomStorage.EXPECT().GetRoom(gomock.Any(), newScheduler.Name, gameRoomIDs[0]).Return(gameRoom1, nil)
 					schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), &filters.SchedulerFilter{
 						Name:    genericSchedulerAutoscalingEnabled.Name,
 						Version: genericSchedulerAutoscalingEnabled.Spec.Version,
@@ -1558,6 +1559,506 @@ func newValidScheduler(autoscaling *autoscaling.Autoscaling) *entities.Scheduler
 	}
 }
 
+func TestCompleteRollingUpdate(t *testing.T) {
+	// Consider maxSurge 25% and readyTarget 0.5
+	readyTarget := 0.5
+	autoscalingEnabled := autoscaling.Autoscaling{
+		Enabled:  true,
+		Min:      1,
+		Max:      1000,
+		Cooldown: 0,
+		Policy: autoscaling.Policy{
+			Type: autoscaling.RoomOccupancy,
+			Parameters: autoscaling.PolicyParameters{
+				RoomOccupancy: &autoscaling.RoomOccupancyParams{
+					ReadyTarget:   readyTarget,
+					DownThreshold: 0.99,
+				},
+			},
+		},
+	}
+	schedulerV1 := newValidScheduler(&autoscalingEnabled)
+	schedulerV1.MaxSurge = "25%"
+	schedulerV2 := newValidScheduler(&autoscalingEnabled)
+	schedulerV2.MaxSurge = "25%"
+	schedulerV2.Spec.TerminationGracePeriod = schedulerV1.Spec.TerminationGracePeriod + 1
+	schedulerV2.Spec.Version = "v2"
+
+	type RollingUpdateExecutionPlan struct {
+		currentTotalNumberOfRooms     int
+		currentRoomsInActiveVersion   int
+		autoscaleDesiredNumberOfRooms int
+		desiredNumberOfRoomsWithSurge int
+		expectedSurgeAmount           int
+		tookAction                    bool
+	}
+
+	completeRollingUpdatePlan := map[string][]RollingUpdateExecutionPlan{
+		"Occupancy stable during the update": []RollingUpdateExecutionPlan{
+			{
+				// Add 25 rooms on newer version
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   0,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Remove 25 rooms
+				currentTotalNumberOfRooms:     125,
+				currentRoomsInActiveVersion:   25,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 25 rooms
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   25,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Remove 25 rooms
+				currentTotalNumberOfRooms:     125,
+				currentRoomsInActiveVersion:   50,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 25 rooms
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   50,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Remove 25 rooms
+				currentTotalNumberOfRooms:     125,
+				currentRoomsInActiveVersion:   75,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 25 rooms
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   75,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Remove 25 rooms
+				currentTotalNumberOfRooms:     125,
+				currentRoomsInActiveVersion:   100,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 25 rooms
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   100,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    false,
+			},
+		},
+		"Occupancy increased during update": []RollingUpdateExecutionPlan{
+			{
+				// Add 25 rooms on newer version
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   0,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Occupancy changed, autoscale desired to 200, add 125 rooms
+				currentTotalNumberOfRooms:     125,
+				currentRoomsInActiveVersion:   25,
+				autoscaleDesiredNumberOfRooms: 200,
+				desiredNumberOfRoomsWithSurge: 250,
+				expectedSurgeAmount:           50,
+				tookAction:                    true,
+			},
+			{
+				// Remove 50 rooms
+				currentTotalNumberOfRooms:     250,
+				currentRoomsInActiveVersion:   150,
+				autoscaleDesiredNumberOfRooms: 200,
+				desiredNumberOfRoomsWithSurge: 250,
+				expectedSurgeAmount:           50,
+				tookAction:                    true,
+			},
+			{
+				// Occupancy changed, autoscale desired to 400, add 300 rooms
+				currentTotalNumberOfRooms:     200,
+				currentRoomsInActiveVersion:   150,
+				autoscaleDesiredNumberOfRooms: 400,
+				desiredNumberOfRoomsWithSurge: 500,
+				expectedSurgeAmount:           100,
+				tookAction:                    true,
+			},
+			{
+				// Remove 100 rooms
+				currentTotalNumberOfRooms:     500,
+				currentRoomsInActiveVersion:   450,
+				autoscaleDesiredNumberOfRooms: 400,
+				desiredNumberOfRoomsWithSurge: 500,
+				expectedSurgeAmount:           100,
+				tookAction:                    true,
+			},
+			{
+				currentTotalNumberOfRooms:     400,
+				currentRoomsInActiveVersion:   400,
+				autoscaleDesiredNumberOfRooms: 400,
+				desiredNumberOfRoomsWithSurge: 500,
+				expectedSurgeAmount:           100,
+				tookAction:                    false,
+			},
+		},
+		"Occupancy decreased during update": []RollingUpdateExecutionPlan{
+			{
+				// Add 25 rooms on newer version
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   0,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Occupancy changed, autoscale desired to 40, remove 85 rooms (15 old)
+				currentTotalNumberOfRooms:     125,
+				currentRoomsInActiveVersion:   25,
+				autoscaleDesiredNumberOfRooms: 40,
+				desiredNumberOfRoomsWithSurge: 50,
+				expectedSurgeAmount:           10,
+				tookAction:                    true,
+			},
+			{
+				// Add 10 rooms
+				currentTotalNumberOfRooms:     40,
+				currentRoomsInActiveVersion:   25,
+				autoscaleDesiredNumberOfRooms: 40,
+				desiredNumberOfRoomsWithSurge: 50,
+				expectedSurgeAmount:           10,
+				tookAction:                    true,
+			},
+			{
+				// Remove 10 rooms
+				currentTotalNumberOfRooms:     50,
+				currentRoomsInActiveVersion:   35,
+				autoscaleDesiredNumberOfRooms: 40,
+				desiredNumberOfRoomsWithSurge: 50,
+				expectedSurgeAmount:           10,
+				tookAction:                    true,
+			},
+			{
+				// Add 10 rooms
+				currentTotalNumberOfRooms:     40,
+				currentRoomsInActiveVersion:   35,
+				autoscaleDesiredNumberOfRooms: 40,
+				desiredNumberOfRoomsWithSurge: 50,
+				expectedSurgeAmount:           10,
+				tookAction:                    true,
+			},
+			{
+				// Remove 10 rooms, only 5 left from old versions, so this is the last update iteration
+				currentTotalNumberOfRooms:     50,
+				currentRoomsInActiveVersion:   45,
+				autoscaleDesiredNumberOfRooms: 40,
+				desiredNumberOfRoomsWithSurge: 50,
+				expectedSurgeAmount:           10,
+				tookAction:                    true,
+			},
+			{
+				// All rooms rolled out
+				currentTotalNumberOfRooms:     40,
+				currentRoomsInActiveVersion:   40,
+				autoscaleDesiredNumberOfRooms: 40,
+				desiredNumberOfRoomsWithSurge: 50,
+				expectedSurgeAmount:           10,
+				tookAction:                    false,
+			},
+		},
+		"Occupancy stable but only 75% of new rooms become active": []RollingUpdateExecutionPlan{
+			{
+				// Add 25 rooms on newer version, only 19 will become active
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   0,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 6 rooms, only 5 become active
+				currentTotalNumberOfRooms:     119,
+				currentRoomsInActiveVersion:   19,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 1 rooms, reach limit, start removing on next iteration
+				currentTotalNumberOfRooms:     124,
+				currentRoomsInActiveVersion:   24,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Remove 25 rooms
+				currentTotalNumberOfRooms:     125,
+				currentRoomsInActiveVersion:   25,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 25 rooms on newer version, only 19 will become active
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   25,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 6 rooms, only 5 become active
+				currentTotalNumberOfRooms:     119,
+				currentRoomsInActiveVersion:   44,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 1 rooms, reach limit, start removing on next iteration
+				currentTotalNumberOfRooms:     124,
+				currentRoomsInActiveVersion:   49,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Remove 25 rooms
+				currentTotalNumberOfRooms:     125,
+				currentRoomsInActiveVersion:   50,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 25 rooms on newer version, only 19 will become active
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   50,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 6 rooms, only 5 become active
+				currentTotalNumberOfRooms:     119,
+				currentRoomsInActiveVersion:   69,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 1 rooms, reach limit, start removing on next iteration
+				currentTotalNumberOfRooms:     124,
+				currentRoomsInActiveVersion:   74,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Remove 25 rooms
+				currentTotalNumberOfRooms:     125,
+				currentRoomsInActiveVersion:   75,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 25 rooms on newer version, only 19 will become active
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   75,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 6 rooms, only 5 become active
+				currentTotalNumberOfRooms:     119,
+				currentRoomsInActiveVersion:   94,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Add 1 rooms, reach limit, start removing on next iteration
+				currentTotalNumberOfRooms:     124,
+				currentRoomsInActiveVersion:   99,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				// Remove 25 rooms
+				currentTotalNumberOfRooms:     125,
+				currentRoomsInActiveVersion:   100,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    true,
+			},
+			{
+				currentTotalNumberOfRooms:     100,
+				currentRoomsInActiveVersion:   100,
+				autoscaleDesiredNumberOfRooms: 100,
+				desiredNumberOfRoomsWithSurge: 125,
+				expectedSurgeAmount:           25,
+				tookAction:                    false,
+			},
+		},
+	}
+
+	createRoomMocks := func(roomsStorage *mock.MockRoomStorage, totalRooms, desiredAmount, roomsInOldVersions int) ([]string, []*game_room.Instance, []*game_room.GameRoom) {
+		var roomIDs []string
+		var instances []*game_room.Instance
+		var gameRooms []*game_room.GameRoom
+		occupiedAmount := int(float64(desiredAmount) * (1 - readyTarget))
+		for i := 0; i < totalRooms; i++ {
+			id := fmt.Sprintf("room-%d", i)
+			roomIDs = append(roomIDs, id)
+			instanceStatus := game_room.InstanceStatus{Type: game_room.InstanceReady}
+			grStatus := game_room.GameStatusReady
+			if i < occupiedAmount {
+				grStatus = game_room.GameStatusOccupied
+			}
+			roomVersion := schedulerV1.Spec.Version
+			if i < roomsInOldVersions {
+				roomVersion = "v2"
+			}
+			instances = append(instances, &game_room.Instance{
+				ID:          id,
+				Status:      instanceStatus,
+				SchedulerID: schedulerV1.Name,
+			})
+			gameRooms = append(gameRooms, &game_room.GameRoom{
+				ID:          id,
+				SchedulerID: schedulerV1.Name,
+				Version:     roomVersion,
+				Status:      grStatus,
+				LastPingAt:  time.Now(),
+			})
+			roomsStorage.EXPECT().GetRoom(gomock.Any(), schedulerV1.Name, id).Return(gameRooms[i], nil).MinTimes(1)
+		}
+		return roomIDs, instances, gameRooms
+	}
+
+	for description, executionPlan := range completeRollingUpdatePlan {
+		for id, cycle := range executionPlan {
+			t.Run(fmt.Sprintf("%s %d", description, id+1), func(t *testing.T) {
+				mockCtrl := gomock.NewController(t)
+				roomsStorage := mockports.NewMockRoomStorage(mockCtrl)
+				roomManager := mockports.NewMockRoomManager(mockCtrl)
+				instanceStorage := mockports.NewMockGameRoomInstanceStorage(mockCtrl)
+				schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+				operationManager := mockports.NewMockOperationManager(mockCtrl)
+				autoscaler := mockports.NewMockAutoscaler(mockCtrl)
+				config := healthcontroller.Config{
+					RoomPingTimeout:           2 * time.Minute,
+					RoomInitializationTimeout: 4 * time.Minute,
+					RoomDeletionTimeout:       4 * time.Minute,
+				}
+				executor := healthcontroller.NewExecutor(roomsStorage, roomManager, instanceStorage, schedulerStorage, operationManager, autoscaler, config)
+				definition := &healthcontroller.Definition{}
+				op := operation.New(schedulerV2.Name, definition.Name(), nil)
+
+				roomIDs, instances, gameRooms := createRoomMocks(
+					roomsStorage,
+					cycle.currentTotalNumberOfRooms,
+					cycle.autoscaleDesiredNumberOfRooms,
+					cycle.currentRoomsInActiveVersion,
+				)
+
+				roomsStorage.EXPECT().GetAllRoomIDs(gomock.Any(), schedulerV2.Name).Return(roomIDs, nil).MinTimes(1)
+				instanceStorage.EXPECT().GetAllInstances(gomock.Any(), schedulerV2.Name).Return(instances, nil).MinTimes(1)
+				schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerV2.Name).Return(schedulerV2, nil).MinTimes(1)
+				autoscaler.EXPECT().CalculateDesiredNumberOfRooms(gomock.Any(), schedulerV2).Return(cycle.autoscaleDesiredNumberOfRooms, nil).MinTimes(1)
+				operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+
+				if cycle.currentRoomsInActiveVersion != cycle.currentTotalNumberOfRooms {
+					schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), &filters.SchedulerFilter{
+						Name:    gameRooms[len(gameRooms)-1].SchedulerID,
+						Version: gameRooms[len(gameRooms)-1].Version,
+					}).Return(schedulerV1, nil).MinTimes(1)
+					if cycle.currentTotalNumberOfRooms < cycle.desiredNumberOfRoomsWithSurge {
+						// Add
+						operationManager.EXPECT().CreatePriorityOperation(
+							gomock.Any(),
+							schedulerV2.Name,
+							&add.Definition{Amount: int32(cycle.desiredNumberOfRoomsWithSurge - cycle.currentTotalNumberOfRooms)},
+						).Return(op, nil)
+					} else {
+						// Remove
+						autoscaler.EXPECT().CanDownscale(gomock.Any(), schedulerV2).Return(true, nil).Times(1)
+						schedulerStorage.EXPECT().UpdateScheduler(gomock.Any(), gomock.Any()).Times(1)
+						reason := remove.ScaleDown
+						if cycle.currentRoomsInActiveVersion < cycle.currentTotalNumberOfRooms {
+							reason = remove.RollingUpdateReplace
+						}
+						operationManager.EXPECT().CreatePriorityOperation(
+							gomock.Any(),
+							schedulerV2.Name,
+							&remove.Definition{
+								Amount: int(cycle.currentTotalNumberOfRooms - cycle.autoscaleDesiredNumberOfRooms),
+								Reason: reason,
+							},
+						).Return(op, nil)
+					}
+				}
+				ctx := context.Background()
+				err := executor.Execute(ctx, op, definition)
+				assert.Nil(t, err)
+				assert.Equal(t, cycle.tookAction, *definition.TookAction)
+			})
+		}
+
+	}
+}
+
 // TODO: Refactor this tests to SchedulerController executor once it's implemented
 func TestComputeMaxSurgeVariants(t *testing.T) {
 	testCases := []struct {
@@ -1621,7 +2122,7 @@ func TestComputeMaxSurgeVariants(t *testing.T) {
 }
 
 func TestIsRollingUpdate(t *testing.T) {
-	autoscalingEnabled := autoscaling.Autoscaling{Enabled: true, Min: 1, Max: 10, Cooldown: 60, Policy: autoscaling.Policy{
+	autoscalingEnabled := autoscaling.Autoscaling{Enabled: true, Min: 1, Max: 1000, Cooldown: 60, Policy: autoscaling.Policy{
 		Type: autoscaling.RoomOccupancy,
 		Parameters: autoscaling.PolicyParameters{
 			RoomOccupancy: &autoscaling.RoomOccupancyParams{
@@ -1809,7 +2310,7 @@ func TestIsRollingUpdate(t *testing.T) {
 }
 
 func TestGetDesiredNumberOfRooms(t *testing.T) {
-	autoscalingEnabled := autoscaling.Autoscaling{Enabled: true, Min: 1, Max: 10, Cooldown: 60, Policy: autoscaling.Policy{
+	autoscalingEnabled := autoscaling.Autoscaling{Enabled: true, Min: 1, Max: 1000, Cooldown: 60, Policy: autoscaling.Policy{
 		Type: autoscaling.RoomOccupancy,
 		Parameters: autoscaling.PolicyParameters{
 			RoomOccupancy: &autoscaling.RoomOccupancyParams{

--- a/internal/core/operations/healthcontroller/executor_test.go
+++ b/internal/core/operations/healthcontroller/executor_test.go
@@ -110,7 +110,6 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), genericSchedulerNoAutoscaling.Name).Return([]string{}, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), genericSchedulerNoAutoscaling.Name).Return([]*game_room.Instance{}, nil)
 					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), genericSchedulerNoAutoscaling.Name).Return(genericSchedulerNoAutoscaling, nil)
-					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
 				},
 			},
 		},
@@ -146,7 +145,6 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
 					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(genericSchedulerNoAutoscaling, nil)
-					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
 
 					// Find game room
 					gameRoom := &game_room.GameRoom{
@@ -338,7 +336,6 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
 					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(genericSchedulerNoAutoscaling, nil)
-					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
 
 					// Find game room
 					gameRoom := &game_room.GameRoom{
@@ -394,7 +391,6 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), genericSchedulerNoAutoscaling.Name).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), genericSchedulerNoAutoscaling.Name).Return(instances, nil)
 					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), genericSchedulerNoAutoscaling.Name).Return(genericSchedulerNoAutoscaling, nil)
-					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
 
 					// Find game room
 					gameRoom := &game_room.GameRoom{
@@ -440,7 +436,6 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
 					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(genericSchedulerNoAutoscaling, nil)
-					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
 
 					// Find game room
 					gameRoom := &game_room.GameRoom{
@@ -494,7 +489,6 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					roomStorage.EXPECT().GetAllRoomIDs(gomock.Any(), gomock.Any()).Return(gameRoomIDs, nil)
 					instanceStorage.EXPECT().GetAllInstances(gomock.Any(), gomock.Any()).Return(instances, nil)
 					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(genericSchedulerNoAutoscaling, nil)
-					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
 
 					// Find existent game room
 					gameRoom := &game_room.GameRoom{
@@ -504,7 +498,7 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 						LastPingAt:  time.Now(),
 						Version:     genericSchedulerNoAutoscaling.Spec.Version,
 					}
-					roomStorage.EXPECT().GetRoom(gomock.Any(), genericSchedulerNoAutoscaling.Name, gameRoomIDs[0]).Return(gameRoom, nil)
+					roomStorage.EXPECT().GetRoom(gomock.Any(), genericSchedulerNoAutoscaling.Name, gameRoomIDs[0]).Return(gameRoom, nil).MinTimes(1)
 
 					// Find game room
 					expiredGameRoom := &game_room.GameRoom{
@@ -514,14 +508,11 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 						LastPingAt:  time.Now().Add(-time.Minute * 60),
 						Version:     genericSchedulerNoAutoscaling.Spec.Version,
 					}
-					roomStorage.EXPECT().GetRoom(gomock.Any(), genericSchedulerNoAutoscaling.Name, gameRoomIDs[1]).Return(expiredGameRoom, nil)
-
+					roomStorage.EXPECT().GetRoom(gomock.Any(), genericSchedulerNoAutoscaling.Name, gameRoomIDs[1]).Return(expiredGameRoom, nil).MinTimes(1)
 					genericSchedulerNoAutoscaling.RoomsReplicas = 1
 					op := operation.New(genericSchedulerNoAutoscaling.Name, definition.Name(), nil)
 					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
 					operationManager.EXPECT().CreatePriorityOperation(gomock.Any(), genericSchedulerNoAutoscaling.Name, &remove.Definition{RoomsIDs: []string{gameRoomIDs[1]}, Reason: remove.Expired}).Return(op, nil)
-
-					roomStorage.EXPECT().GetRoom(gomock.Any(), genericSchedulerNoAutoscaling.Name, gameRoomIDs[0]).Return(gameRoom, nil)
 				},
 			},
 		},
@@ -563,7 +554,6 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					roomStorage.EXPECT().GetRoom(gomock.Any(), genericSchedulerAutoscalingEnabled.Name, gameRoomIDs[0]).Return(gameRoom, nil)
 
 					autoscaler.EXPECT().CalculateDesiredNumberOfRooms(gomock.Any(), genericSchedulerAutoscalingEnabled).Return(1, nil)
-					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
 				},
 			},
 		},
@@ -920,8 +910,6 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 						Version:     genericSchedulerAutoscalingEnabled.Spec.Version,
 					}
 					roomStorage.EXPECT().GetRoom(gomock.Any(), genericSchedulerAutoscalingEnabled.Name, gameRoomIDs[0]).Return(gameRoom, nil)
-					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any())
-
 					roomStorage.EXPECT().GetRoom(gomock.Any(), genericSchedulerAutoscalingEnabled.Name, gameRoomIDs[0]).Return(gameRoom, nil)
 				},
 			},
@@ -1376,7 +1364,6 @@ func TestSchedulerHealthController_Execute(t *testing.T) {
 					// findAvailableAndExpiredRooms
 					roomStorage.EXPECT().GetRoom(gomock.Any(), newScheduler.Name, gameRoomIDs[0]).Return(gameRoom1, nil)
 					roomStorage.EXPECT().GetRoom(gomock.Any(), newScheduler.Name, gameRoomIDs[1]).Return(gameRoom2, nil)
-					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 					// GetDesiredNumberOfRooms
 					schedulerStorage.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(newScheduler, nil)
@@ -2017,7 +2004,9 @@ func TestCompleteRollingUpdate(t *testing.T) {
 				instanceStorage.EXPECT().GetAllInstances(gomock.Any(), schedulerV2.Name).Return(instances, nil).MinTimes(1)
 				schedulerStorage.EXPECT().GetScheduler(gomock.Any(), schedulerV2.Name).Return(schedulerV2, nil).MinTimes(1)
 				autoscaler.EXPECT().CalculateDesiredNumberOfRooms(gomock.Any(), schedulerV2).Return(cycle.autoscaleDesiredNumberOfRooms, nil).MinTimes(1)
-				operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				if cycle.tookAction {
+					operationManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				}
 
 				if cycle.currentRoomsInActiveVersion != cycle.currentTotalNumberOfRooms {
 					schedulerStorage.EXPECT().GetSchedulerWithFilter(gomock.Any(), &filters.SchedulerFilter{

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -93,7 +93,7 @@ func ProvideExecutors(
 	executors := map[string]operations.Executor{}
 	executors[createscheduler.OperationName] = createscheduler.NewExecutor(runtime, schedulerManager, operationManager)
 	executors[addrooms.OperationName] = addrooms.NewExecutor(roomManager, schedulerStorage, operationManager, addRoomsConfig)
-	executors[removerooms.OperationName] = removerooms.NewExecutor(roomManager, roomStorage, operationManager)
+	executors[removerooms.OperationName] = removerooms.NewExecutor(roomManager, roomStorage, operationManager, schedulerManager)
 	executors[test.OperationName] = test.NewExecutor()
 	executors[switchversion.OperationName] = switchversion.NewExecutor(schedulerManager, operationManager)
 	executors[newversion.OperationName] = newversion.NewExecutor(roomManager, schedulerManager, operationManager, newSchedulerVersionConfig)

--- a/internal/core/operations/rooms/remove/executor_test.go
+++ b/internal/core/operations/rooms/remove/executor_test.go
@@ -34,64 +34,107 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro/internal/core/entities"
 	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
 	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
 
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
 	"github.com/topfreegames/maestro/internal/core/entities/operation"
+	"github.com/topfreegames/maestro/internal/core/entities/port"
 )
 
 func TestExecutor_Execute(t *testing.T) {
 
 	t.Run("RemoveRoom by Amount", func(t *testing.T) {
-		t.Run("should succeed - no rooms to be removed => returns without error", func(t *testing.T) {
-			executor, _, roomsManager, _ := testSetup(t)
+		t.Run("should fail - if fails to get active scheduler => returns error", func(t *testing.T) {
+			executor, _, _, _, schedulerManager := testSetup(t)
 
-			schedulerName := uuid.NewString()
+			scheduler := newValidScheduler()
 			definition := &Definition{Amount: 2}
-			op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+			op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
 			ctx := context.Background()
 
-			emptyGameRoomSlice := []*game_room.GameRoom{}
-			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(emptyGameRoomSlice, nil)
+			schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), scheduler.Name).Return(nil, errors.New("error getting active scheduler"))
 
 			err := executor.Execute(ctx, op, definition)
-			require.Nil(t, err)
+			require.NotNil(t, err)
 		})
 
-		t.Run("should succeed - rooms are successfully removed => returns without error", func(t *testing.T) {
-			executor, _, roomsManager, _ := testSetup(t)
+		t.Run("should succeed and sort rooms by active scheduler version", func(t *testing.T) {
+			executor, _, roomsManager, _, schedulerManager := testSetup(t)
 
 			schedulerName := uuid.NewString()
-			definition := &Definition{Amount: 2}
+			schedulerV1 := &entities.Scheduler{
+				Name: schedulerName,
+				Spec: game_room.Spec{
+					Version: "v1",
+				},
+			}
+			schedulerV2 := &entities.Scheduler{
+				Name: schedulerName,
+				Spec: game_room.Spec{
+					Version: "v2",
+				},
+			}
+			definition := &Definition{Amount: 8}
 			op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
 			ctx := context.Background()
+			/*
+				Scheduler Versions and Rooms
+					Current Rooms: [Err1v1, Err2v2, P1v1, P2v2, R1v1, R2v2, O1v1, O2v2]
+					Expected List by Priority: [Err1v1, Err2v2, P1v1, R1v1, O1v1, P2v2, R2v2, O2v2]
+			*/
 			availableRooms := []*game_room.GameRoom{
-				{ID: "first-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
-				{ID: "second-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
+				{ID: "Err1v1", SchedulerID: schedulerName, Status: game_room.GameStatusError, Version: schedulerV1.Spec.Version},
+				{ID: "Err2v2", SchedulerID: schedulerName, Status: game_room.GameStatusError, Version: schedulerV2.Spec.Version},
+				{ID: "P1v1", SchedulerID: schedulerName, Status: game_room.GameStatusPending, Version: schedulerV1.Spec.Version},
+				{ID: "P2v2", SchedulerID: schedulerName, Status: game_room.GameStatusPending, Version: schedulerV2.Spec.Version},
+				{ID: "R1v1", SchedulerID: schedulerName, Status: game_room.GameStatusReady, Version: schedulerV1.Spec.Version},
+				{ID: "R2v2", SchedulerID: schedulerName, Status: game_room.GameStatusReady, Version: schedulerV2.Spec.Version},
+				{ID: "O1v1", SchedulerID: schedulerName, Status: game_room.GameStatusOccupied, Version: schedulerV1.Spec.Version},
+				{ID: "O2v2", SchedulerID: schedulerName, Status: game_room.GameStatusOccupied, Version: schedulerV2.Spec.Version},
 			}
-			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
-			roomsManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+			expectedSortedRoomsOrder := []*game_room.GameRoom{
+				availableRooms[0], // Err1v1
+				availableRooms[1], // Err2v2
+				availableRooms[2], // P1v1
+				availableRooms[4], // R1v1
+				availableRooms[6], // O1v1
+				availableRooms[3], // P2v2
+				availableRooms[5], // R2v2
+				availableRooms[7], // P2v2
+			}
+			schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), schedulerName).Return(schedulerV2, nil)
+			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), expectedSortedRoomsOrder[0], gomock.Any()).Times(1)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), expectedSortedRoomsOrder[1], gomock.Any()).Times(1)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), expectedSortedRoomsOrder[2], gomock.Any()).Times(1)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), expectedSortedRoomsOrder[3], gomock.Any()).Times(1)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), expectedSortedRoomsOrder[4], gomock.Any()).Times(1)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), expectedSortedRoomsOrder[5], gomock.Any()).Times(1)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), expectedSortedRoomsOrder[6], gomock.Any()).Times(1)
+			roomsManager.EXPECT().DeleteRoom(gomock.Any(), expectedSortedRoomsOrder[7], gomock.Any()).Times(1)
 			err := executor.Execute(ctx, op, definition)
 
 			require.Nil(t, err)
 		})
 
 		t.Run("when any room failed to delete with unexpected error it returns with error", func(t *testing.T) {
-			executor, _, roomsManager, operationManager := testSetup(t)
+			executor, _, roomsManager, operationManager, schedulerManager := testSetup(t)
 
-			schedulerName := uuid.NewString()
+			scheduler := newValidScheduler()
 			definition := &Definition{Amount: 2, Reason: "reason"}
-			op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+			op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
 			availableRooms := []*game_room.GameRoom{
-				{ID: "first-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
-				{ID: "second-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
+				{ID: "first-room", SchedulerID: scheduler.Name, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
+				{ID: "second-room", SchedulerID: scheduler.Name, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
 			}
 
-			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
+			schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), scheduler.Name).Return(scheduler, nil)
+			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
 
 			roomsManager.EXPECT().DeleteRoom(gomock.Any(), availableRooms[0], definition.Reason).Return(nil)
 
@@ -103,18 +146,19 @@ func TestExecutor_Execute(t *testing.T) {
 		})
 
 		t.Run("when any room failed to delete with timeout error it returns with error", func(t *testing.T) {
-			executor, _, roomsManager, operationManager := testSetup(t)
+			executor, _, roomsManager, operationManager, schedulerManager := testSetup(t)
 
-			schedulerName := uuid.NewString()
+			scheduler := newValidScheduler()
 			definition := &Definition{Amount: 2, Reason: "reason"}
-			op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+			op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
 			availableRooms := []*game_room.GameRoom{
-				{ID: "first-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
-				{ID: "second-room", SchedulerID: schedulerName, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
+				{ID: "first-room", SchedulerID: scheduler.Name, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
+				{ID: "second-room", SchedulerID: scheduler.Name, Status: game_room.GameStatusReady, Metadata: map[string]interface{}{}},
 			}
 
-			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
+			schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), scheduler.Name).Return(scheduler, nil)
+			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
 			roomsManager.EXPECT().DeleteRoom(gomock.Any(), availableRooms[0], definition.Reason).Return(nil)
 
 			roomsManager.EXPECT().DeleteRoom(gomock.Any(), availableRooms[1], definition.Reason).Return(serviceerrors.NewErrGameRoomStatusWaitingTimeout("some error"))
@@ -125,12 +169,14 @@ func TestExecutor_Execute(t *testing.T) {
 		})
 
 		t.Run("when list rooms has error returns with error", func(t *testing.T) {
-			executor, _, roomsManager, _ := testSetup(t)
+			executor, _, roomsManager, _, schedulerManager := testSetup(t)
 
+			scheduler := newValidScheduler()
 			definition := &Definition{Amount: 2}
-			op := &operation.Operation{ID: "random-uuid", SchedulerName: uuid.NewString()}
+			op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
-			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
+			schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), scheduler.Name).Return(scheduler, nil)
+			roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("error"))
 
 			err := executor.Execute(context.Background(), op, definition)
 			require.NotNil(t, err)
@@ -140,33 +186,33 @@ func TestExecutor_Execute(t *testing.T) {
 
 	t.Run("RemoveRoom by RoomsIDs", func(t *testing.T) {
 		t.Run("should succeed - no rooms to be removed => returns without error", func(t *testing.T) {
-			executor, _, _, _ := testSetup(t)
+			executor, _, _, _, _ := testSetup(t)
 
-			schedulerName := uuid.NewString()
+			scheduler := newValidScheduler()
 			definition := &Definition{RoomsIDs: []string{}}
-			op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+			op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
 			err := executor.Execute(context.Background(), op, definition)
 			require.Nil(t, err)
 		})
 
 		t.Run("should succeed - rooms are successfully removed => returns without error", func(t *testing.T) {
-			executor, _, roomsManager, _ := testSetup(t)
+			executor, _, roomsManager, _, _ := testSetup(t)
 
 			firstRoomID := "first-room-id"
 			secondRoomID := "second-room-id"
 
-			schedulerName := uuid.NewString()
+			scheduler := newValidScheduler()
 			definition := &Definition{RoomsIDs: []string{firstRoomID, secondRoomID}, Reason: "reason"}
-			op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+			op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
 			room := &game_room.GameRoom{
 				ID:          firstRoomID,
-				SchedulerID: schedulerName,
+				SchedulerID: scheduler.Name,
 			}
 			secondRoom := &game_room.GameRoom{
 				ID:          secondRoomID,
-				SchedulerID: schedulerName,
+				SchedulerID: scheduler.Name,
 			}
 
 			roomsManager.EXPECT().DeleteRoom(gomock.Any(), room, definition.Reason).Return(nil)
@@ -177,22 +223,22 @@ func TestExecutor_Execute(t *testing.T) {
 		})
 
 		t.Run("when any room failed to delete with unexpected error it returns with error", func(t *testing.T) {
-			executor, _, roomsManager, operationManager := testSetup(t)
+			executor, _, roomsManager, operationManager, _ := testSetup(t)
 
 			firstRoomID := "first-room-id"
 			secondRoomID := "second-room-id"
 
-			schedulerName := uuid.NewString()
+			scheduler := newValidScheduler()
 			definition := &Definition{RoomsIDs: []string{firstRoomID, secondRoomID}, Reason: "reason"}
-			op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+			op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
 			room := &game_room.GameRoom{
 				ID:          firstRoomID,
-				SchedulerID: schedulerName,
+				SchedulerID: scheduler.Name,
 			}
 			secondRoom := &game_room.GameRoom{
 				ID:          secondRoomID,
-				SchedulerID: schedulerName,
+				SchedulerID: scheduler.Name,
 			}
 
 			roomsManager.EXPECT().DeleteRoom(gomock.Any(), room, definition.Reason).Return(nil)
@@ -205,22 +251,22 @@ func TestExecutor_Execute(t *testing.T) {
 		})
 
 		t.Run("when any room returns not found on delete it is ignored and returns without error", func(t *testing.T) {
-			executor, _, roomsManager, operationManager := testSetup(t)
+			executor, _, roomsManager, operationManager, _ := testSetup(t)
 
 			firstRoomID := "first-room-id"
 			secondRoomID := "second-room-id"
 
-			schedulerName := uuid.NewString()
+			scheduler := newValidScheduler()
 			definition := &Definition{RoomsIDs: []string{firstRoomID, secondRoomID}}
-			op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+			op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
 			room := &game_room.GameRoom{
 				ID:          firstRoomID,
-				SchedulerID: schedulerName,
+				SchedulerID: scheduler.Name,
 			}
 			secondRoom := &game_room.GameRoom{
 				ID:          secondRoomID,
-				SchedulerID: schedulerName,
+				SchedulerID: scheduler.Name,
 			}
 
 			roomsManager.EXPECT().DeleteRoom(gomock.Any(), room, definition.Reason).Return(nil)
@@ -232,22 +278,22 @@ func TestExecutor_Execute(t *testing.T) {
 		})
 
 		t.Run("when any room failed to delete with timeout error it returns with error", func(t *testing.T) {
-			executor, _, roomsManager, operationManager := testSetup(t)
+			executor, _, roomsManager, operationManager, _ := testSetup(t)
 
 			firstRoomID := "first-room-id"
 			secondRoomID := "second-room-id"
 
-			schedulerName := uuid.NewString()
+			scheduler := newValidScheduler()
 			definition := &Definition{RoomsIDs: []string{firstRoomID, secondRoomID}, Reason: "reason"}
-			op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+			op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
 			room := &game_room.GameRoom{
 				ID:          firstRoomID,
-				SchedulerID: schedulerName,
+				SchedulerID: scheduler.Name,
 			}
 			secondRoom := &game_room.GameRoom{
 				ID:          secondRoomID,
-				SchedulerID: schedulerName,
+				SchedulerID: scheduler.Name,
 			}
 
 			roomsManager.EXPECT().DeleteRoom(gomock.Any(), room, definition.Reason).Return(nil)
@@ -261,61 +307,101 @@ func TestExecutor_Execute(t *testing.T) {
 	})
 
 	t.Run("should succeed - no rooms to be removed => returns without error", func(t *testing.T) {
-		executor, _, _, _ := testSetup(t)
+		executor, _, _, _, _ := testSetup(t)
 
-		schedulerName := uuid.NewString()
+		scheduler := newValidScheduler()
 		definition := &Definition{}
-		op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+		op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
 		err := executor.Execute(context.Background(), op, definition)
 		require.Nil(t, err)
 	})
 
 	t.Run("should succeed - there are ids and amount => return without error", func(t *testing.T) {
-		executor, _, roomsManager, _ := testSetup(t)
+		executor, _, roomsManager, _, schedulerManager := testSetup(t)
 
 		firstRoomID := "first-room-id"
 		secondRoomID := "second-room-id"
 		thirdRoomID := "third-room-id"
 		fourthRoomID := "fourth-room-id"
 
-		schedulerName := uuid.NewString()
+		scheduler := newValidScheduler()
 		definition := &Definition{
 			RoomsIDs: []string{firstRoomID, secondRoomID},
 			Amount:   2,
 			Reason:   "reason",
 		}
-		op := &operation.Operation{ID: "random-uuid", SchedulerName: schedulerName}
+		op := &operation.Operation{ID: "random-uuid", SchedulerName: scheduler.Name}
 
 		thirdRoom := &game_room.GameRoom{
 			ID:          thirdRoomID,
-			SchedulerID: schedulerName,
+			SchedulerID: scheduler.Name,
 			Status:      game_room.GameStatusReady,
 		}
 		fourthRoom := &game_room.GameRoom{
 			ID:          fourthRoomID,
-			SchedulerID: schedulerName,
+			SchedulerID: scheduler.Name,
 			Status:      game_room.GameStatusReady,
 		}
 
 		roomsManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any(), definition.Reason).Return(nil).Times(2)
 
 		availableRooms := []*game_room.GameRoom{thirdRoom, fourthRoom}
-		roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
+		schedulerManager.EXPECT().GetActiveScheduler(gomock.Any(), scheduler.Name).Return(scheduler, nil)
+		roomsManager.EXPECT().ListRoomsWithDeletionPriority(gomock.Any(), gomock.Any(), gomock.Any()).Return(availableRooms, nil)
 		roomsManager.EXPECT().DeleteRoom(gomock.Any(), gomock.Any(), definition.Reason).Return(nil).Times(2)
 
 		err := executor.Execute(context.Background(), op, definition)
 		require.Nil(t, err)
 	})
-
 }
 
-func testSetup(t *testing.T) (*Executor, *mockports.MockRoomStorage, *mockports.MockRoomManager, *mockports.MockOperationManager) {
+func testSetup(t *testing.T) (*Executor, *mockports.MockRoomStorage, *mockports.MockRoomManager, *mockports.MockOperationManager, *mockports.MockSchedulerManager) {
 	mockCtrl := gomock.NewController(t)
 
 	roomsStorage := mockports.NewMockRoomStorage(mockCtrl)
 	roomsManager := mockports.NewMockRoomManager(mockCtrl)
 	operationManager := mockports.NewMockOperationManager(mockCtrl)
-	executor := NewExecutor(roomsManager, roomsStorage, operationManager)
-	return executor, roomsStorage, roomsManager, operationManager
+	schedulerManager := mockports.NewMockSchedulerManager(mockCtrl)
+	executor := NewExecutor(roomsManager, roomsStorage, operationManager, schedulerManager)
+	return executor, roomsStorage, roomsManager, operationManager, schedulerManager
+}
+
+func newValidScheduler() *entities.Scheduler {
+	return &entities.Scheduler{
+		Name:            "scheduler",
+		Game:            "game",
+		State:           entities.StateCreating,
+		MaxSurge:        "5",
+		RollbackVersion: "",
+		Spec: game_room.Spec{
+			Version:                "v1.0.0",
+			TerminationGracePeriod: 60,
+			Toleration:             "toleration",
+			Affinity:               "affinity",
+			Containers: []game_room.Container{
+				{
+					Name:            "default",
+					Image:           "some-image:v1",
+					ImagePullPolicy: "IfNotPresent",
+					Command:         []string{"hello"},
+					Ports: []game_room.ContainerPort{
+						{Name: "tcp", Protocol: "tcp", Port: 80},
+					},
+					Requests: game_room.ContainerResources{
+						CPU:    "10m",
+						Memory: "100Mi",
+					},
+					Limits: game_room.ContainerResources{
+						CPU:    "10m",
+						Memory: "100Mi",
+					},
+				},
+			},
+		},
+		PortRange: &port.PortRange{
+			Start: 40000,
+			End:   60000,
+		},
+	}
 }

--- a/internal/core/ports/mock/rooms_ports_mock.go
+++ b/internal/core/ports/mock/rooms_ports_mock.go
@@ -7,7 +7,6 @@ package mock
 import (
 	context "context"
 	reflect "reflect"
-	sync "sync"
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
@@ -99,18 +98,18 @@ func (mr *MockRoomManagerMockRecorder) GetRoomInstance(ctx, scheduler, roomID in
 }
 
 // ListRoomsWithDeletionPriority mocks base method.
-func (m *MockRoomManager) ListRoomsWithDeletionPriority(ctx context.Context, schedulerName, ignoredVersion string, amount int, roomsBeingReplaced *sync.Map) ([]*game_room.GameRoom, error) {
+func (m *MockRoomManager) ListRoomsWithDeletionPriority(ctx context.Context, activeScheduler *entities.Scheduler, amount int) ([]*game_room.GameRoom, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRoomsWithDeletionPriority", ctx, schedulerName, ignoredVersion, amount, roomsBeingReplaced)
+	ret := m.ctrl.Call(m, "ListRoomsWithDeletionPriority", ctx, activeScheduler, amount)
 	ret0, _ := ret[0].([]*game_room.GameRoom)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListRoomsWithDeletionPriority indicates an expected call of ListRoomsWithDeletionPriority.
-func (mr *MockRoomManagerMockRecorder) ListRoomsWithDeletionPriority(ctx, schedulerName, ignoredVersion, amount, roomsBeingReplaced interface{}) *gomock.Call {
+func (mr *MockRoomManagerMockRecorder) ListRoomsWithDeletionPriority(ctx, activeScheduler, amount interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoomsWithDeletionPriority", reflect.TypeOf((*MockRoomManager)(nil).ListRoomsWithDeletionPriority), ctx, schedulerName, ignoredVersion, amount, roomsBeingReplaced)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoomsWithDeletionPriority", reflect.TypeOf((*MockRoomManager)(nil).ListRoomsWithDeletionPriority), ctx, activeScheduler, amount)
 }
 
 // SchedulerMaxSurge mocks base method.

--- a/internal/core/ports/room_ports.go
+++ b/internal/core/ports/room_ports.go
@@ -24,7 +24,6 @@ package ports
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/topfreegames/maestro/internal/core/entities"
@@ -42,8 +41,7 @@ type RoomManager interface {
 	// the number of rooms the scheduler has.
 	SchedulerMaxSurge(ctx context.Context, scheduler *entities.Scheduler) (int, error)
 	// ListRoomsWithDeletionPriority returns a specified number of rooms, following
-	// the priority of it being deleted and filtering the ignored version,
-	// the function will return rooms discarding such filter option.
+	// the priority of it being deleted
 	//
 	// The priority is:
 	//
@@ -55,7 +53,7 @@ type RoomManager interface {
 	//
 	// This function can return less rooms than the `amount` since it might not have
 	// enough rooms on the scheduler.
-	ListRoomsWithDeletionPriority(ctx context.Context, schedulerName, ignoredVersion string, amount int, roomsBeingReplaced *sync.Map) ([]*game_room.GameRoom, error)
+	ListRoomsWithDeletionPriority(ctx context.Context, activeScheduler *entities.Scheduler, amount int) ([]*game_room.GameRoom, error)
 	// CleanRoomState cleans the remaining state of a room. This function is
 	// intended to be used after a `DeleteRoom`, where the room instance is
 	// signaled to terminate.

--- a/internal/core/services/autoscaler/autoscaler.go
+++ b/internal/core/services/autoscaler/autoscaler.go
@@ -84,6 +84,10 @@ func (a *Autoscaler) CanDownscale(ctx context.Context, scheduler *entities.Sched
 		return false, errors.New("scheduler does not have autoscaling struct")
 	}
 
+	if !scheduler.Autoscaling.Enabled {
+		return false, errors.New("scheduler does not have autoscaling enabled")
+	}
+
 	if _, ok := a.policyMap[scheduler.Autoscaling.Policy.Type]; !ok {
 		return false, fmt.Errorf("error finding policy to scheduler %s", scheduler.Name)
 	}

--- a/internal/core/services/autoscaler/autoscaler_test.go
+++ b/internal/core/services/autoscaler/autoscaler_test.go
@@ -54,8 +54,9 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 	scheduler := &entities.Scheduler{
 		Name: "some-name",
 		Autoscaling: &autoscaling.Autoscaling{
-			Min: minimumNumberOfRooms,
-			Max: maximumNumberOfRooms,
+			Enabled: true,
+			Min:     minimumNumberOfRooms,
+			Max:     maximumNumberOfRooms,
 			Policy: autoscaling.Policy{
 				Type:       policyType,
 				Parameters: autoscaling.PolicyParameters{},
@@ -116,8 +117,9 @@ func TestCalculateDesiredNumberOfRooms(t *testing.T) {
 			scheduler := &entities.Scheduler{
 				Name: "some-name",
 				Autoscaling: &autoscaling.Autoscaling{
-					Min: minimumNumberOfRooms,
-					Max: -1,
+					Enabled: true,
+					Min:     minimumNumberOfRooms,
+					Max:     -1,
 					Policy: autoscaling.Policy{
 						Type:       policyType,
 						Parameters: autoscaling.PolicyParameters{},
@@ -196,8 +198,9 @@ func TestCanDownscale(t *testing.T) {
 	scheduler := &entities.Scheduler{
 		Name: "some-name",
 		Autoscaling: &autoscaling.Autoscaling{
-			Min: 1,
-			Max: 5,
+			Enabled: true,
+			Min:     1,
+			Max:     5,
 			Policy: autoscaling.Policy{
 				Type: policyType,
 				Parameters: autoscaling.PolicyParameters{

--- a/internal/core/services/rooms/room_manager.go
+++ b/internal/core/services/rooms/room_manager.go
@@ -29,7 +29,6 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
@@ -38,6 +37,7 @@ import (
 	"github.com/topfreegames/maestro/internal/core/logs"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/topfreegames/maestro/internal/core/entities"
 	"github.com/topfreegames/maestro/internal/core/entities/game_room"
@@ -201,30 +201,30 @@ func (m *RoomManager) CleanRoomState(ctx context.Context, schedulerName, roomId 
 	return nil
 }
 
-func (m *RoomManager) ListRoomsWithDeletionPriority(ctx context.Context, schedulerName, ignoredVersion string, amount int, roomsBeingReplaced *sync.Map) ([]*game_room.GameRoom, error) {
+func (m *RoomManager) ListRoomsWithDeletionPriority(ctx context.Context, activeScheduler *entities.Scheduler, amount int) ([]*game_room.GameRoom, error) {
 
 	var schedulerRoomsIDs []string
-	onErrorRoomIDs, err := m.RoomStorage.GetRoomIDsByStatus(ctx, schedulerName, game_room.GameStatusError)
+	onErrorRoomIDs, err := m.RoomStorage.GetRoomIDsByStatus(ctx, activeScheduler.Name, game_room.GameStatusError)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list scheduler rooms on error: %w", err)
 	}
 
-	oldLastPingRoomIDs, err := m.RoomStorage.GetRoomIDsByLastPing(ctx, schedulerName, time.Now().Add(m.Config.RoomPingTimeout*-1))
+	oldLastPingRoomIDs, err := m.RoomStorage.GetRoomIDsByLastPing(ctx, activeScheduler.Name, time.Now().Add(m.Config.RoomPingTimeout*-1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list scheduler rooms with old last ping datetime: %w", err)
 	}
 
-	pendingRoomIDs, err := m.RoomStorage.GetRoomIDsByStatus(ctx, schedulerName, game_room.GameStatusPending)
+	pendingRoomIDs, err := m.RoomStorage.GetRoomIDsByStatus(ctx, activeScheduler.Name, game_room.GameStatusPending)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list scheduler rooms on pending status: %w", err)
 	}
 
-	readyRoomIDs, err := m.RoomStorage.GetRoomIDsByStatus(ctx, schedulerName, game_room.GameStatusReady)
+	readyRoomIDs, err := m.RoomStorage.GetRoomIDsByStatus(ctx, activeScheduler.Name, game_room.GameStatusReady)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list scheduler rooms on ready status: %w", err)
 	}
 
-	occupiedRoomIDs, err := m.RoomStorage.GetRoomIDsByStatus(ctx, schedulerName, game_room.GameStatusOccupied)
+	occupiedRoomIDs, err := m.RoomStorage.GetRoomIDsByStatus(ctx, activeScheduler.Name, game_room.GameStatusOccupied)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list scheduler rooms on occupied status: %w", err)
 	}
@@ -234,24 +234,20 @@ func (m *RoomManager) ListRoomsWithDeletionPriority(ctx context.Context, schedul
 	schedulerRoomsIDs = append(schedulerRoomsIDs, pendingRoomIDs...)
 	schedulerRoomsIDs = append(schedulerRoomsIDs, readyRoomIDs...)
 	schedulerRoomsIDs = append(schedulerRoomsIDs, occupiedRoomIDs...)
+
 	schedulerRoomsIDs = removeDuplicateValues(schedulerRoomsIDs)
 
+	var activeVersionRoomPool []*game_room.GameRoom
 	var toDeleteRooms []*game_room.GameRoom
 	var terminatingRooms []*game_room.GameRoom
 	for _, roomID := range schedulerRoomsIDs {
-		room, err := m.RoomStorage.GetRoom(ctx, schedulerName, roomID)
+		room, err := m.RoomStorage.GetRoom(ctx, activeScheduler.Name, roomID)
 		if err != nil {
 			if !errors.Is(err, porterrors.ErrNotFound) {
 				return nil, fmt.Errorf("failed to fetch room information: %w", err)
 			}
 
-			room = &game_room.GameRoom{ID: roomID, SchedulerID: schedulerName, Status: game_room.GameStatusError}
-		}
-
-		_, roomIsBeingReplaced := roomsBeingReplaced.Load(room.ID)
-
-		if roomIsBeingReplaced {
-			continue
+			room = &game_room.GameRoom{ID: roomID, SchedulerID: activeScheduler.Name, Status: game_room.GameStatusError}
 		}
 
 		// Select Terminating rooms to be re-deleted. This is useful for fixing any desync state.
@@ -260,14 +256,27 @@ func (m *RoomManager) ListRoomsWithDeletionPriority(ctx context.Context, schedul
 			continue
 		}
 
-		if ignoredVersion != "" && ignoredVersion == room.Version {
-			continue
+		isRoomActive := room.Status == game_room.GameStatusOccupied || room.Status == game_room.GameStatusReady || room.Status == game_room.GameStatusPending
+		if isRoomActive && room.Version == activeScheduler.Spec.Version {
+			activeVersionRoomPool = append(activeVersionRoomPool, room)
+		} else {
+			toDeleteRooms = append(toDeleteRooms, room)
 		}
+	}
+	toDeleteRooms = append(toDeleteRooms, activeVersionRoomPool...)
 
-		toDeleteRooms = append(toDeleteRooms, room)
-		if len(toDeleteRooms) == amount {
-			break
-		}
+	m.Logger.Debug("toDeleteRooms",
+		zap.Array("toDeleteRooms uncapped", zapcore.ArrayMarshalerFunc(func(enc zapcore.ArrayEncoder) error {
+			for _, room := range toDeleteRooms {
+				enc.AppendString(fmt.Sprintf("%s-%s-%s", room.ID, room.Version, room.Status.String()))
+			}
+			return nil
+		})),
+		zap.Int("amount", amount),
+	)
+
+	if len(toDeleteRooms) > amount {
+		toDeleteRooms = toDeleteRooms[:amount]
 	}
 
 	result := append(toDeleteRooms, terminatingRooms...)

--- a/internal/core/worker/operationexecution/operation_execution_worker_test.go
+++ b/internal/core/worker/operationexecution/operation_execution_worker_test.go
@@ -603,7 +603,7 @@ func TestSchedulerOperationsExecutionLoop(t *testing.T) {
 		pendingOpsChan := make(chan string)
 
 		operationManager.EXPECT().PendingOperationsChan(gomock.Any(), gomock.Any()).Return(pendingOpsChan)
-		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, &healthcontroller.Definition{}).Return(&operation.Operation{}, nil).MaxTimes(5)
+		operationManager.EXPECT().CreateOperation(gomock.Any(), scheduler.Name, &healthcontroller.Definition{}).Return(&operation.Operation{}, nil).MaxTimes(6)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/proto/apidocs.swagger.json
+++ b/proto/apidocs.swagger.json
@@ -426,7 +426,7 @@
         "parameters": [
           {
             "name": "game",
-            "description": "Game name to filter schedulers\n\nMapped to URL query parameter `game`.",
+            "description": "Game name to filter schedulers",
             "in": "query",
             "required": false,
             "type": "string"


### PR DESCRIPTION
Currently, the health controller is performing both rolling updates and autoscaling. We can roughly divide these responsibilities among these functions executed by the operation:

1. performRollingUpdate: generates a pair of add and remove operations based on rolling update constraints (maxSurge and maxUnavailable = 0)
2. ensureDesiredAmountOfInstances: generates either an add or remove operation to move the current state equal to the desired

In a lot of cases, one cycle will generate conflicting operations: autoscale will try to remove X amount of rooms but rolling update only wants Y amount of rooms deleted. Moreover, autoscale deletion is based on its policy (currently only occupancy) but rolling update wants to delete based on the version of the scheduler. Thus, to streamline and simplify this process the refactor aims to split the responsibility and let only **one** piece of logic handle the creation or removal of rooms.

The work of this PR can be summarized in:

## 1. Split the logic, inside `healthcontroller/execute.go`

So that we have one logical abstraction to compute the desired number of rooms based on autoscaling **and** rolling update (if ongoing), and another logical abstraction responsible for fixing the drift between current and desired by enqueuing add or remove operations

All logic that is responsible for computing the desired amount can be refactored to a different operation, outside of execution worker, later on. All those methods are not receivers of the `Execute` and the dependency is injected by their arguments in the functions:

* GetDesiredNumberOfRooms
* IsRollingUpdating
* ComputeMaxSurge

## 2. Refactor the Remove Rooms operation to sort by version when deleting a number of game rooms

Currently, the system will sort by game room status, however, we want to take the sorted rooms and apply a sort by version on Pending, Ready, and Occupied rooms.

Given this set of rooms with their status + versions: [Error1v1, Error2v2, Pending1v1, Pending2v2, Ready1v1, Ready2v2, Occupied1v1, Occupied2v2]

Currently, the sort by priority/status will return the above list, however, we want to ensure old scheduler versions (v1) are deleted first (Kubernetes deletes pods based on creation time, so it will be similar). Thus, the new sorting version will become:

* Before: [Error1v1, Error2v2, Pending1v1, Pending2v2, Ready1v1, Ready2v2, Occupied1v1, Occupied2v2]
* **Now**: [Error1v1, Error2v2, Pending1v1, Ready1v1, Occupied1v1, Pending2v2, Ready2v2, Occupied2v2]

If there's only one active version of the scheduler in the system, then we skip the additional sort.

## 3. Simplified calculations of desired when autoscaling + rolling updating

As a baseline, the system will always use the desired from autoscaling (or roomsReplica if no autoscale is defined). However, if we have a **major** version of the difference between schedulers of current rooms in the system, then we are in a rolling update and we should consider the `maxSurge`.

![Maestro Rollout Strategy Design Doc](https://github.com/user-attachments/assets/86b62e8b-4142-4363-be64-6f49cea1c146)

## 4. Add unit tests with ALL rolling update cycles

Create a matrix of test cases with table tests, validated in spreadsheets and with the desired behavior that each health_controller operation should take during a rolling update. There are 4 base cases: stable occupancy, occupancy increased, occupancy decreased, and stable occupancy but only 75% of new rooms becoming active. 

Spreadsheet reference with the desired cases: https://docs.google.com/spreadsheets/d/13grNuk3os7mOesnpROqLOVTSWiGpgvi5JUgWUB3Z428/edit?usp=sharing
