### PR TITLE
fix(healthcontroller): rolling update without autoscaling

### DIFF
--- a/internal/core/operations/healthcontroller/executor_test.go
+++ b/internal/core/operations/healthcontroller/executor_test.go
@@ -2317,7 +2317,12 @@ func TestGetDesiredNumberOfRooms(t *testing.T) {
 	schedulerV2.Spec.TerminationGracePeriod = schedulerV1.Spec.TerminationGracePeriod + 1
 	schedulerV2.Spec.Version = "v2"
 	schedulerWithoutAutoScaling := newValidScheduler(&autoscalerDisabled)
-	schedulerWithoutAutoScaling.RoomsReplicas = 10
+	schedulerWithoutAutoScaling.RoomsReplicas = 1
+	schedulerWithoutAutoScaling.MaxSurge = "50%"
+	schedulerV2WithoutAutoScaling := newValidScheduler(&autoscalerDisabled)
+	schedulerV2WithoutAutoScaling.RoomsReplicas = 1
+	schedulerV2WithoutAutoScaling.MaxSurge = "50%"
+	schedulerV2WithoutAutoScaling.Spec.TerminationGracePeriod = schedulerWithoutAutoScaling.Spec.TerminationGracePeriod + 1
 	schedulerInvalidMaxSurge := newValidScheduler(&autoscalingEnabled)
 	schedulerInvalidMaxSurge.MaxSurge = "0"
 	schedulerInvalidMaxSurge.Spec.TerminationGracePeriod = schedulerV1.Spec.TerminationGracePeriod + 1
@@ -2342,6 +2347,23 @@ func TestGetDesiredNumberOfRooms(t *testing.T) {
 			rooms:               map[string]*game_room.GameRoom{},
 			desiredByAutoscaler: schedulerWithoutAutoScaling.RoomsReplicas,
 			expectedDesired:     schedulerWithoutAutoScaling.RoomsReplicas,
+			expectError:         false,
+		},
+		{
+			name:              "No autoscaling, on rolling update, return rooms replica + maxSurge",
+			activeScheduler:   schedulerV2WithoutAutoScaling,
+			availableRoomsIDs: []string{"room1v1"},
+			rooms: map[string]*game_room.GameRoom{
+				"room1v1": {
+					ID:          "room1v1",
+					SchedulerID: schedulerWithoutAutoScaling.Name,
+					Version:     schedulerWithoutAutoScaling.Spec.Version,
+					Status:      game_room.GameStatusOccupied,
+					LastPingAt:  time.Now(),
+				},
+			},
+			desiredByAutoscaler: schedulerV2WithoutAutoScaling.RoomsReplicas,
+			expectedDesired:     schedulerV2WithoutAutoScaling.RoomsReplicas + 1,
 			expectError:         false,
 		},
 		{

--- a/internal/core/operations/rooms/add/executor.go
+++ b/internal/core/operations/rooms/add/executor.go
@@ -103,6 +103,7 @@ func (ex *Executor) Execute(ctx context.Context, op *operation.Operation, defini
 		return executionErr
 	}
 
+	ex.operationManager.AppendOperationEventToExecutionHistory(ctx, op, fmt.Sprintf("added %d rooms", amount))
 	executionLogger.Info("finished adding rooms")
 	return nil
 }

--- a/internal/core/operations/rooms/add/executor_test.go
+++ b/internal/core/operations/rooms/add/executor_test.go
@@ -26,6 +26,7 @@
 package add
 
 import (
+	"fmt"
 	"time"
 
 	clock_mock "github.com/topfreegames/maestro/internal/core/ports/clock_mock.go"
@@ -99,6 +100,7 @@ func TestExecutor_Execute(t *testing.T) {
 
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), op.SchedulerName).Return(&scheduler, nil)
 		roomsManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(10)
+		operationsManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), &op, fmt.Sprintf("added %d rooms", definition.Amount))
 
 		executor := NewExecutor(roomsManager, schedulerStorage, operationsManager, config)
 		err := executor.Execute(context.Background(), &op, &definition)
@@ -156,6 +158,7 @@ func TestExecutor_Execute(t *testing.T) {
 
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), op.SchedulerName).Return(&scheduler, nil)
 		roomsManager.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), false).Return(&gameRoom, &gameRoomInstance, nil).Times(int(smallDefaultConfig.AmountLimit))
+		operationsManager.EXPECT().AppendOperationEventToExecutionHistory(gomock.Any(), &op, fmt.Sprintf("added %d rooms", smallDefaultConfig.AmountLimit))
 
 		executor := NewExecutor(roomsManager, schedulerStorage, operationsManager, smallDefaultConfig)
 		err := executor.Execute(context.Background(), &op, &bigAmountDefinition)

--- a/internal/core/operations/rooms/remove/executor.go
+++ b/internal/core/operations/rooms/remove/executor.go
@@ -77,6 +77,7 @@ func (e *Executor) Execute(ctx context.Context, op *operation.Operation, definit
 
 			return fmt.Errorf("error removing rooms by ids: %w", err)
 		}
+		e.operationManager.AppendOperationEventToExecutionHistory(ctx, op, fmt.Sprintf("removed rooms: %v", removeDefinition.RoomsIDs))
 	}
 
 	if removeDefinition.Amount > 0 {
@@ -88,6 +89,7 @@ func (e *Executor) Execute(ctx context.Context, op *operation.Operation, definit
 
 			return fmt.Errorf("error removing rooms by amount: %w", err)
 		}
+		e.operationManager.AppendOperationEventToExecutionHistory(ctx, op, fmt.Sprintf("removed %d rooms", removeDefinition.Amount))
 	}
 
 	logger.Info("finished deleting rooms")


### PR DESCRIPTION
Fix the bug that prevented going above roomsReplica instead of allowing roomsReplica + maxSurge