### PR TITLE
refactor(logger): debug on room pings and scheduler API

### DIFF
--- a/internal/api/handlers/rooms_handler.go
+++ b/internal/api/handlers/rooms_handler.go
@@ -86,7 +86,7 @@ func (h *RoomsHandler) ForwardPlayerEvent(ctx context.Context, message *api.Forw
 func (h *RoomsHandler) UpdateRoomWithPing(ctx context.Context, message *api.UpdateRoomWithPingRequest) (*api.UpdateRoomWithPingResponse, error) {
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldSchedulerName, message.SchedulerName), zap.String(logs.LogFieldRoomID, message.RoomName))
 	gameRoom, err := requestadapters.FromApiUpdateRoomRequestToEntity(message)
-	handlerLogger.Info("handling room ping request", zap.Any("message", message))
+	handlerLogger.Debug("handling room ping request", zap.Any("message", message))
 	if err != nil {
 		handlerLogger.Error("error parsing ping request", zap.Any("ping", message), zap.Error(err))
 		return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -98,7 +98,7 @@ func (h *RoomsHandler) UpdateRoomWithPing(ctx context.Context, message *api.Upda
 		return &api.UpdateRoomWithPingResponse{Success: false}, nil
 	}
 
-	handlerLogger.Info("Room updated with ping successfully")
+	handlerLogger.Debug("Room updated with ping successfully")
 	return &api.UpdateRoomWithPingResponse{Success: true}, nil
 }
 

--- a/internal/api/handlers/schedulers_handler.go
+++ b/internal/api/handlers/schedulers_handler.go
@@ -60,7 +60,7 @@ func ProvideSchedulersHandler(schedulerManager ports.SchedulerManager) *Schedule
 
 func (h *SchedulersHandler) ListSchedulers(ctx context.Context, message *api.ListSchedulersRequest) (*api.ListSchedulersResponse, error) {
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldGame, message.GetGame()), zap.String(logs.LogFieldSchedulerName, message.GetName()))
-	handlerLogger.Info("handling list schedulers request")
+	handlerLogger.Debug("handling list schedulers request")
 	schedulerFilter := &filters.SchedulerFilter{
 		Name:    message.GetName(),
 		Game:    message.GetGame(),
@@ -77,14 +77,14 @@ func (h *SchedulersHandler) ListSchedulers(ctx context.Context, message *api.Lis
 		schedulers[i] = requestadapters.FromEntitySchedulerToListResponse(entity)
 	}
 
-	handlerLogger.Info("finish handling list schedulers request")
+	handlerLogger.Debug("finish handling list schedulers request")
 
 	return &api.ListSchedulersResponse{Schedulers: schedulers}, nil
 }
 
 func (h *SchedulersHandler) GetScheduler(ctx context.Context, request *api.GetSchedulerRequest) (*api.GetSchedulerResponse, error) {
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldSchedulerName, request.GetSchedulerName()))
-	handlerLogger.Info(fmt.Sprintf("handling get scheduler request, scheduler version: %s", request.GetVersion()))
+	handlerLogger.Debug(fmt.Sprintf("handling get scheduler request, scheduler version: %s", request.GetVersion()))
 	var scheduler *entities.Scheduler
 	var err error
 
@@ -103,7 +103,7 @@ func (h *SchedulersHandler) GetScheduler(ctx context.Context, request *api.GetSc
 		}
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
-	handlerLogger.Info("finish handling get scheduler request")
+	handlerLogger.Debug("finish handling get scheduler request")
 
 	returnScheduler, err := requestadapters.FromEntitySchedulerToResponse(scheduler)
 	if err != nil {
@@ -116,7 +116,7 @@ func (h *SchedulersHandler) GetScheduler(ctx context.Context, request *api.GetSc
 
 func (h *SchedulersHandler) GetSchedulerVersions(ctx context.Context, request *api.GetSchedulerVersionsRequest) (*api.GetSchedulerVersionsResponse, error) {
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldSchedulerName, request.GetSchedulerName()))
-	handlerLogger.Info("handling get scheduler versions request")
+	handlerLogger.Debug("handling get scheduler versions request")
 	versions, err := h.schedulerManager.GetSchedulerVersions(ctx, request.GetSchedulerName())
 
 	if err != nil {
@@ -126,14 +126,14 @@ func (h *SchedulersHandler) GetSchedulerVersions(ctx context.Context, request *a
 		}
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
-	handlerLogger.Info("finish handling get scheduler versions request")
+	handlerLogger.Debug("finish handling get scheduler versions request")
 
 	return &api.GetSchedulerVersionsResponse{Versions: requestadapters.FromEntitySchedulerVersionListToResponse(versions)}, nil
 }
 
 func (h *SchedulersHandler) CreateScheduler(ctx context.Context, request *api.CreateSchedulerRequest) (*api.CreateSchedulerResponse, error) {
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldSchedulerName, request.GetName()), zap.String(logs.LogFieldGame, request.GetGame()))
-	handlerLogger.Info("handling create scheduler request")
+	handlerLogger.Debug("handling create scheduler request")
 	scheduler, err := requestadapters.FromApiCreateSchedulerRequestToEntity(request)
 	if err != nil {
 		apiValidationError := parseValidationError(err)
@@ -149,7 +149,7 @@ func (h *SchedulersHandler) CreateScheduler(ctx context.Context, request *api.Cr
 		}
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
-	handlerLogger.Info("finish handling create scheduler request")
+	handlerLogger.Debug("finish handling create scheduler request")
 
 	returnScheduler, err := requestadapters.FromEntitySchedulerToResponse(scheduler)
 	if err != nil {
@@ -161,7 +161,7 @@ func (h *SchedulersHandler) CreateScheduler(ctx context.Context, request *api.Cr
 
 func (h *SchedulersHandler) NewSchedulerVersion(ctx context.Context, request *api.NewSchedulerVersionRequest) (*api.NewSchedulerVersionResponse, error) {
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldSchedulerName, request.GetName()), zap.String(logs.LogFieldGame, request.GetGame()))
-	handlerLogger.Info("handling new scheduler version request")
+	handlerLogger.Debug("handling new scheduler version request")
 	scheduler, err := requestadapters.FromApiNewSchedulerVersionRequestToEntity(request)
 	if err != nil {
 		apiValidationError := parseValidationError(err)
@@ -178,14 +178,14 @@ func (h *SchedulersHandler) NewSchedulerVersion(ctx context.Context, request *ap
 		}
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
-	handlerLogger.Info("finish handling new scheduler version request")
+	handlerLogger.Debug("finish handling new scheduler version request")
 
 	return &api.NewSchedulerVersionResponse{OperationId: operation.ID}, nil
 }
 
 func (h *SchedulersHandler) PatchScheduler(ctx context.Context, request *api.PatchSchedulerRequest) (*api.PatchSchedulerResponse, error) {
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldSchedulerName, request.GetName()))
-	handlerLogger.Info("handling patch scheduler request")
+	handlerLogger.Debug("handling patch scheduler request")
 
 	patchMap := requestadapters.FromApiPatchSchedulerRequestToChangeMap(request)
 	if len(patchMap) == 0 {
@@ -205,14 +205,14 @@ func (h *SchedulersHandler) PatchScheduler(ctx context.Context, request *api.Pat
 
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
-	handlerLogger.Info("finish handling patch scheduler request")
+	handlerLogger.Debug("finish handling patch scheduler request")
 
 	return &api.PatchSchedulerResponse{OperationId: operation.ID}, nil
 }
 
 func (h *SchedulersHandler) SwitchActiveVersion(ctx context.Context, request *api.SwitchActiveVersionRequest) (*api.SwitchActiveVersionResponse, error) {
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldSchedulerName, request.GetSchedulerName()))
-	handlerLogger.Info("handling switch active version request")
+	handlerLogger.Debug("handling switch active version request")
 	operation, err := h.schedulerManager.EnqueueSwitchActiveVersionOperation(ctx, request.GetSchedulerName(), request.GetVersion())
 
 	if err != nil {
@@ -220,13 +220,13 @@ func (h *SchedulersHandler) SwitchActiveVersion(ctx context.Context, request *ap
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
 
-	handlerLogger.Info("finish handling switch active version request")
+	handlerLogger.Debug("finish handling switch active version request")
 	return &api.SwitchActiveVersionResponse{OperationId: operation.ID}, nil
 }
 
 func (h *SchedulersHandler) GetSchedulersInfo(ctx context.Context, request *api.GetSchedulersInfoRequest) (*api.GetSchedulersInfoResponse, error) {
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldGame, request.GetGame()))
-	handlerLogger.Info("handling get schedulers info request")
+	handlerLogger.Debug("handling get schedulers info request")
 	filter := filters.SchedulerFilter{Game: request.GetGame()}
 	schedulers, err := h.schedulerManager.GetSchedulersInfo(ctx, &filter)
 
@@ -242,7 +242,7 @@ func (h *SchedulersHandler) GetSchedulersInfo(ctx context.Context, request *api.
 	for i, scheduler := range schedulers {
 		schedulersResponse[i] = requestadapters.FromEntitySchedulerInfoToListResponse(scheduler)
 	}
-	handlerLogger.Info("finish handling get schedulers info request")
+	handlerLogger.Debug("finish handling get schedulers info request")
 
 	return &api.GetSchedulersInfoResponse{
 		Schedulers: schedulersResponse,
@@ -252,7 +252,7 @@ func (h *SchedulersHandler) GetSchedulersInfo(ctx context.Context, request *api.
 func (h *SchedulersHandler) DeleteScheduler(ctx context.Context, request *api.DeleteSchedulerRequest) (*api.DeleteSchedulerResponse, error) {
 	schedulerName := request.GetSchedulerName()
 	handlerLogger := h.logger.With(zap.String(logs.LogFieldSchedulerName, schedulerName))
-	handlerLogger.Info("handling delete scheduler request")
+	handlerLogger.Debug("handling delete scheduler request")
 	op, err := h.schedulerManager.EnqueueDeleteSchedulerOperation(ctx, schedulerName)
 
 	if err != nil {
@@ -262,6 +262,6 @@ func (h *SchedulersHandler) DeleteScheduler(ctx context.Context, request *api.De
 		}
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
-	handlerLogger.Info("finish handling delete scheduler request")
+	handlerLogger.Debug("finish handling delete scheduler request")
 	return &api.DeleteSchedulerResponse{OperationId: op.ID}, nil
 }

--- a/internal/core/services/operations/operation_manager.go
+++ b/internal/core/services/operations/operation_manager.go
@@ -75,7 +75,7 @@ func (om *OperationManager) CreateOperation(ctx context.Context, schedulerName s
 		om.Logger.Error(fmt.Sprintf("failed to enqueue %s operation to be executed", op.DefinitionName), zap.Error(err), zap.String(logs.LogFieldOperationID, op.ID), zap.String(logs.LogFieldSchedulerName, op.SchedulerName))
 		return nil, fmt.Errorf("failed to insert operation on flow: %w", err)
 	}
-	om.Logger.Info(fmt.Sprintf("operation %s created and enqueued to be executed", op.DefinitionName), zap.String(logs.LogFieldOperationID, op.ID), zap.String(logs.LogFieldSchedulerName, op.SchedulerName))
+	om.Logger.Debug(fmt.Sprintf("operation %s created and enqueued to be executed", op.DefinitionName), zap.String(logs.LogFieldOperationID, op.ID), zap.String(logs.LogFieldSchedulerName, op.SchedulerName))
 	return op, nil
 }
 
@@ -92,7 +92,7 @@ func (om *OperationManager) CreatePriorityOperation(ctx context.Context, schedul
 		om.Logger.Error(fmt.Sprintf("failed to enqueue (priority) %s operation to be executed", op.DefinitionName), zap.Error(err), zap.String(logs.LogFieldOperationID, op.ID), zap.String(logs.LogFieldSchedulerName, op.SchedulerName))
 		return nil, fmt.Errorf("failed to insert operation on flow: %w", err)
 	}
-	om.Logger.Info(fmt.Sprintf("operation (priority) %s created and enqueued on the top to be executed", op.DefinitionName), zap.String(logs.LogFieldOperationID, op.ID), zap.String(logs.LogFieldSchedulerName, op.SchedulerName))
+	om.Logger.Debug(fmt.Sprintf("operation (priority) %s created and enqueued on the top to be executed", op.DefinitionName), zap.String(logs.LogFieldOperationID, op.ID), zap.String(logs.LogFieldSchedulerName, op.SchedulerName))
 	return op, nil
 }
 

--- a/internal/core/worker/runtimewatcher/runtime_watcher_worker.go
+++ b/internal/core/worker/runtimewatcher/runtime_watcher_worker.go
@@ -212,7 +212,7 @@ func (w *runtimeWatcherWorker) processEvent(ctx context.Context, event game_room
 	eventLogger := w.logger.With(zap.String(logs.LogFieldInstanceID, event.Instance.ID))
 	switch event.Type {
 	case game_room.InstanceEventTypeAdded, game_room.InstanceEventTypeUpdated:
-		eventLogger.Info(fmt.Sprintf("processing %s event. Updating rooms instance. Instance Status: %v", event.Type.String(), event.Instance.Status.Type))
+		eventLogger.Debug(fmt.Sprintf("processing %s event. Updating rooms instance. Instance Status: %v", event.Type.String(), event.Instance.Status.Type))
 		if event.Instance == nil {
 			return fmt.Errorf("cannot process event since instance is nil")
 		}
@@ -222,7 +222,7 @@ func (w *runtimeWatcherWorker) processEvent(ctx context.Context, event game_room
 			return fmt.Errorf("failed to update room instance %s: %w", event.Instance.ID, err)
 		}
 	case game_room.InstanceEventTypeDeleted:
-		eventLogger.Info(fmt.Sprintf("processing %s event. Cleaning Room state", event.Type.String()))
+		eventLogger.Debug(fmt.Sprintf("processing %s event. Cleaning Room state", event.Type.String()))
 		if event.Instance == nil {
 			return fmt.Errorf("cannot process event since instance is nil")
 		}


### PR DESCRIPTION
Logging to info the room pings, scheduler API calls and some event handling on runtime watcher, causes a huge load on the system and we should move them to debug