### PR TITLE
fix(operations): ignore empty lease error when listing

### DIFF
--- a/internal/core/services/operations/operation_manager.go
+++ b/internal/core/services/operations/operation_manager.go
@@ -175,14 +175,14 @@ func (om *OperationManager) ListSchedulerPendingOperations(ctx context.Context, 
 func (om *OperationManager) ListSchedulerActiveOperations(ctx context.Context, schedulerName string) ([]*operation.Operation, error) {
 	ops, err := om.Storage.ListSchedulerActiveOperations(ctx, schedulerName)
 	if err != nil {
-		return nil, fmt.Errorf("failed get active operations list fort scheduler %s : %w", schedulerName, err)
+		return nil, fmt.Errorf("failed get active operations list for scheduler %s : %w", schedulerName, err)
 	}
 	if len(ops) == 0 {
 		return []*operation.Operation{}, err
 	}
 	err = om.addOperationsLeaseData(ctx, schedulerName, ops)
 	if err != nil {
-		return nil, err
+		om.Logger.With(zap.String(logs.LogFieldSchedulerName, schedulerName), zap.Error(err)).Warn("failed to add operations lease data")
 	}
 	return ops, nil
 }

--- a/internal/core/services/operations/operation_manager_test.go
+++ b/internal/core/services/operations/operation_manager_test.go
@@ -592,7 +592,7 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		require.Error(t, err, fmt.Errorf("failed get active operations list fort scheduler %s : %w", schedulerName, errors.New("some error")))
 	})
 
-	t.Run("it returns error when some error occurs in operation lease storage", func(t *testing.T) {
+	t.Run("it does not return error when some error occurs in operation lease storage", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		operationFlow := mockports.NewMockOperationFlow(mockCtrl)
@@ -613,7 +613,7 @@ func TestListSchedulerActiveOperations(t *testing.T) {
 		operationStorage.EXPECT().ListSchedulerActiveOperations(ctx, schedulerName).Return(operationsResult, nil)
 		operationLeaseStorage.EXPECT().FetchOperationsLease(ctx, schedulerName, operationsResult[0].ID, operationsResult[1].ID, operationsResult[2].ID).Return([]*operation.OperationLease{}, errors.New("some error"))
 		_, err := opManager.ListSchedulerActiveOperations(ctx, schedulerName)
-		require.Error(t, err, fmt.Errorf("failed to fetch operations lease for scheduler %s: %w", schedulerName, errors.New("some error")))
+		require.NoError(t, err)
 	})
 
 }


### PR DESCRIPTION
When listing active operations, the internal handler fetches operation leases to hydrate the operations with this info (useful for detecting when operation is about to finish/expire). However, when listing the lease might have expired thus it will throw an error that we don't want. Thus, ignoring lease not found when listing active operations