### PR TITLE
fix(policy): compute desired number of matches before rooms

### DIFF
--- a/internal/core/services/autoscaler/policies/roomoccupancy/policy.go
+++ b/internal/core/services/autoscaler/policies/roomoccupancy/policy.go
@@ -96,12 +96,12 @@ func (p *Policy) CalculateDesiredNumberOfRooms(policyParameters autoscaling.Poli
 		return -1, errors.New("There are no runningMatches in the currentState")
 	}
 
-	maxMatches := currentState[MaxMatchesKey].(int)
+	maxMatchesPerRoom := currentState[MaxMatchesKey].(int)
 
-	occupiedRooms := math.Ceil(float64(runningMatches) / float64(maxMatches))
-	desiredNumberOfRoom := int(math.Ceil(float64(occupiedRooms) / (float64(1) - readyTarget)))
+	desiredNumberOfMatches := math.Ceil(float64(runningMatches) / (float64(1) - readyTarget))
+	desiredNumberOfRooms := int(math.Ceil(desiredNumberOfMatches / float64(maxMatchesPerRoom)))
 
-	return desiredNumberOfRoom, nil
+	return desiredNumberOfRooms, nil
 }
 
 func (p *Policy) CanDownscale(policyParameters autoscaling.PolicyParameters, currentState policies.CurrentState) (bool, error) {

--- a/pkg/api/v1/rooms.pb.go
+++ b/pkg/api/v1/rooms.pb.go
@@ -228,7 +228,7 @@ type UpdateRoomStatusRequest struct {
 	Status string `protobuf:"bytes,4,opt,name=status,proto3" json:"status,omitempty"`
 	// Timestamp of the status update.
 	Timestamp int64 `protobuf:"varint,6,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	// The number of running_matches in the game room.
+	// The number of running matches in the game room.
 	RunningMatches int64 `protobuf:"varint,7,opt,name=running_matches,json=runningMatches,proto3" json:"running_matches,omitempty"`
 }
 

--- a/proto/api/v1/rooms.proto
+++ b/proto/api/v1/rooms.proto
@@ -98,7 +98,7 @@ message UpdateRoomStatusRequest {
   string status = 4;
   // Timestamp of the status update.
   int64 timestamp = 6;
-  // The number of running_matches in the game room.
+  // The number of running matches in the game room.
   int64 running_matches = 7;
 }
 

--- a/proto/apidocs.swagger.json
+++ b/proto/apidocs.swagger.json
@@ -800,7 +800,7 @@
         "runningMatches": {
           "type": "string",
           "format": "int64",
-          "description": "The number of running_matches in the game room."
+          "description": "The number of running matches in the game room."
         }
       },
       "description": "The player event request."


### PR DESCRIPTION
If we first divide the number of running matches per maxMatches we might end up with a number between 0 and 1, which is quirky when using math.Ceil because it would propagate the error to when computing number of desired rooms. To simplify and fix this, instead we now compute how many matches is the desired and then convert the final number to the amount of rooms/instances/pods needed to provide this number of matches:

1. How many running matches we have?
* Get the value from the redis: scheduler:<scheduler_name>:occupancy
2. How many matches do we need to have based on readyTarget?
* Divide running matches by 1 - readyTarget
3. How many game rooms are needed to provide this amount of matches?
* Get the desired number of matches and divide by the max number of matches per room as defined in the scheduler