### PR TITLE
fix(allocation): maxMatches limit to 100

### DIFF
--- a/internal/core/entities/allocation/allocation.go
+++ b/internal/core/entities/allocation/allocation.go
@@ -26,5 +26,5 @@ package allocation
 // allocation in the Game Rooms.
 type MatchAllocation struct {
 	// MaxMatches defined the maximum number of matches that a room can host.
-	MaxMatches int `validate:"required,min=1,max=30"`
+	MaxMatches int `validate:"required,min=1,max=35"`
 }


### PR DESCRIPTION
Some games might choose to run larger pod resources and increase number of matches running in each room/instance, thus increasing from 30 to 100. The limit in the max matches is useful so configuration stays in a sane number to help in autoscaling and roundings.