### PR TITLE
fix(runtime-watcher): do not exit disruption goroutine on errors

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -70,7 +70,7 @@ reporter:
     intervalMillis: 10000
 runtimeWatcher:
   disruptionWorker:
-    intervalSeconds: 5
+    intervalSeconds: 60
     safetyPercentage: 0.05
 
 operations:

--- a/internal/core/worker/runtimewatcher/runtime_watcher_worker.go
+++ b/internal/core/worker/runtimewatcher/runtime_watcher_worker.go
@@ -89,6 +89,7 @@ func (w *runtimeWatcherWorker) spawnUpdateRoomWatchers(resultChan chan game_room
 				case event, ok := <-resultChan:
 					if !ok {
 						w.logger.Warn("resultChan closed, finishing worker goroutine")
+						w.Stop(w.ctx)
 						return
 					}
 					err := w.processEvent(w.ctx, event)
@@ -115,7 +116,7 @@ func (w *runtimeWatcherWorker) mitigateDisruptions() error {
 			zap.String("scheduler", w.scheduler.Name),
 			zap.Error(err),
 		)
-		return nil
+		return err
 	}
 	mitigationQuota := 0
 	if totalRoomsAmount >= MinRoomsToApplyDisruption {
@@ -126,7 +127,7 @@ func (w *runtimeWatcherWorker) mitigateDisruptions() error {
 				zap.String("scheduler", w.scheduler.Name),
 				zap.Error(err),
 			)
-			return nil
+			return err
 		}
 	}
 	err = w.runtime.MitigateDisruption(w.ctx, w.scheduler, mitigationQuota, w.config.DisruptionSafetyPercentage)
@@ -196,9 +197,13 @@ func (w *runtimeWatcherWorker) Start(ctx context.Context) error {
 }
 
 func (w *runtimeWatcherWorker) Stop(_ context.Context) {
-	w.logger.Info("stopping runtime watcher", zap.String("scheduler", w.scheduler.Name))
 	if w.cancelFunc != nil {
-		w.cancelFunc()
+		w.logger.Info("stopping runtime watcher", zap.String("scheduler", w.scheduler.Name))
+		// To make this function idempotent, we need to set the cancelFunc to nil
+		// before calling it.
+		cancelFunc := w.cancelFunc
+		w.cancelFunc = nil
+		cancelFunc()
 	}
 }
 

--- a/internal/core/worker/runtimewatcher/runtime_watcher_worker.go
+++ b/internal/core/worker/runtimewatcher/runtime_watcher_worker.go
@@ -133,7 +133,7 @@ func (w *runtimeWatcherWorker) mitigateDisruptions() error {
 	if err != nil {
 		return err
 	}
-	w.logger.Debug(
+	w.logger.Info(
 		"mitigated disruption for occupied rooms",
 		zap.String("scheduler", w.scheduler.Name),
 		zap.Int("mitigationQuota", mitigationQuota),

--- a/internal/core/worker/runtimewatcher/runtime_watcher_worker.go
+++ b/internal/core/worker/runtimewatcher/runtime_watcher_worker.go
@@ -160,14 +160,12 @@ func (w *runtimeWatcherWorker) spawnDisruptionWatcher() {
 						zap.String("scheduler", w.scheduler.Name),
 						zap.Error(err),
 					)
-					return
 				}
 			case <-w.ctx.Done():
 				w.logger.Info("context closed, exiting disruption watcher")
 				return
 			}
 		}
-
 	}()
 }
 


### PR DESCRIPTION
Unerecoverable errors are normal when updating PDB, for instance k8s might be updating at the same time, or we get throttled by Kube API, or we simply fail to get from Redis. In either way, if we return/exit we don't close the watcher since there's another goroutine running, leaving to scenarios that watcher is running only game room events loop. For now, if disruption failed, we log and retry in the next loop

Also:

* fix(runtime-watcher): make Stop() indempotent
* fix(runtime-watcher): default disruption loop to 60s

    Previously the mitigate disruption loop that updates PDB was running
    every 5s, changing to 60s. Also, moved the logs to INFO so we can track
    this in production, one log entry per scheduler per min shouldn't spam
    the logs