### PR TITLE
fix: try create occupancy key to exsting rooms

### DIFF
--- a/internal/adapters/storage/redis/room/redis.go
+++ b/internal/adapters/storage/redis/room/redis.go
@@ -70,8 +70,10 @@ func (r redisStateStorage) GetRoom(ctx context.Context, scheduler, roomID string
 		SchedulerID: scheduler,
 	}
 
-	p := r.client.Pipeline()
 	roomHashCmd := r.client.HGetAll(ctx, getRoomRedisKey(room.SchedulerID, room.ID))
+
+	p := r.client.Pipeline()
+	_ = p.ZAddNX(ctx, getRoomOccupancyRedisKey(room.SchedulerID), &redis.Z{Member: room.ID, Score: float64(room.RunningMatches)})
 	statusCmd := p.ZScore(ctx, getRoomStatusSetRedisKey(room.SchedulerID), room.ID)
 	pingCmd := p.ZScore(ctx, getRoomPingRedisKey(room.SchedulerID), room.ID)
 	occupancyCmd := p.ZScore(ctx, getRoomOccupancyRedisKey(room.SchedulerID), room.ID)


### PR DESCRIPTION
The latest Maestro release introduced better control over games that run multiple matches per game server. To support this, a new key was added to the game room storage. However, these keys were not being created for existing game servers.

This fix ensures that the occupancy key is created when retrieving the room from storage. If the key already exists, no action will be taken.