### PR TITLE
fix(api): add cooldown to scheduler serialization

### DIFF
--- a/internal/api/handlers/requestadapters/schedulers.go
+++ b/internal/api/handlers/requestadapters/schedulers.go
@@ -548,10 +548,11 @@ func getSpec(spec game_room.Spec) *api.Spec {
 func getAutoscaling(autoscaling *autoscaling.Autoscaling) *api.Autoscaling {
 	if autoscaling != nil {
 		return &api.Autoscaling{
-			Enabled: autoscaling.Enabled,
-			Min:     int32(autoscaling.Min),
-			Max:     int32(autoscaling.Max),
-			Policy:  getAutoscalingPolicy(autoscaling.Policy),
+			Enabled:  autoscaling.Enabled,
+			Min:      int32(autoscaling.Min),
+			Max:      int32(autoscaling.Max),
+			Cooldown: int32(autoscaling.Cooldown),
+			Policy:   getAutoscalingPolicy(autoscaling.Policy),
 		}
 	}
 

--- a/internal/api/handlers/requestadapters/schedulers_test.go
+++ b/internal/api/handlers/requestadapters/schedulers_test.go
@@ -1465,9 +1465,10 @@ func TestFromEntitySchedulerToResponse(t *testing.T) {
 					MaxSurge:      maxSurgeValue,
 					RoomsReplicas: int(roomsReplicasValue),
 					Autoscaling: &autoscaling.Autoscaling{
-						Enabled: true,
-						Min:     1,
-						Max:     5,
+						Enabled:  true,
+						Min:      1,
+						Max:      5,
+						Cooldown: 300,
 						Policy: autoscaling.Policy{
 							Type: autoscaling.RoomOccupancy,
 							Parameters: autoscaling.PolicyParameters{
@@ -1560,9 +1561,10 @@ func TestFromEntitySchedulerToResponse(t *testing.T) {
 					MaxSurge:      maxSurgeValue,
 					RoomsReplicas: roomsReplicasValue,
 					Autoscaling: &api.Autoscaling{
-						Enabled: true,
-						Min:     int32(1),
-						Max:     int32(5),
+						Enabled:  true,
+						Min:      int32(1),
+						Max:      int32(5),
+						Cooldown: int32(300),
 						Policy: &api.AutoscalingPolicy{
 							Type: "roomOccupancy",
 							Parameters: &api.PolicyParameters{

--- a/internal/core/services/schedulers/patch/patch_scheduler.go
+++ b/internal/core/services/schedulers/patch/patch_scheduler.go
@@ -272,8 +272,8 @@ func patchAutoscaling(scheduler *entities.Scheduler, patchMap map[string]interfa
 		scheduler.Autoscaling.Max = int(max)
 	}
 
-	if intrefaceCoolDown, ok := patchMap[LabelAutoscalingCooldown]; ok {
-		cooldown, ok := intrefaceCoolDown.(int32)
+	if interfaceCoolDown, ok := patchMap[LabelAutoscalingCooldown]; ok {
+		cooldown, ok := interfaceCoolDown.(int32)
 		if !ok {
 			return fmt.Errorf("error parsing autoscaling: cooldown malformed")
 		}

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -232,7 +232,7 @@ func NewPortAllocatorRandom(c config.Config) (ports.PortAllocator, error) {
 	return portAllocatorRandom.NewRandomPortAllocator(portRange), nil
 }
 
-// NewSchedulerStoragePg instanteates a postgres connection as scheduler storage.
+// NewSchedulerStoragePg instantiates a postgres connection as scheduler storage.
 func NewSchedulerStoragePg(c config.Config) (ports.SchedulerStorage, error) {
 	opts, err := connectToPostgres(GetSchedulerStoragePostgresURL(c))
 	if err != nil {


### PR DESCRIPTION
Add Cooldown to serialization function so it returns the correct value in management API.