### PR TITLE
Add limit to remove rooms operation

### DIFF
--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -81,7 +81,8 @@ func initializeWorker(c config.Config, builder *worker.WorkerBuilder) (*workers.
 	newversionConfig := service.NewCreateSchedulerVersionConfig(c)
 	healthcontrollerConfig := service.NewHealthControllerConfig(c)
 	addConfig := service.NewOperationRoomsAddConfig(c)
-	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager, roomStorage, schedulerManager, gameRoomInstanceStorage, schedulerCache, operationStorage, operationManager, autoscaler, newversionConfig, healthcontrollerConfig, addConfig)
+	removeConfig := service.NewOperationRoomsRemoveConfig(c)
+	v2 := providers.ProvideExecutors(runtime, schedulerStorage, roomManager, roomStorage, schedulerManager, gameRoomInstanceStorage, schedulerCache, operationStorage, operationManager, autoscaler, newversionConfig, healthcontrollerConfig, addConfig, removeConfig)
 	configuration, err := service.NewWorkersConfig(c)
 	if err != nil {
 		return nil, err

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -78,7 +78,7 @@ operations:
     add:
       limit: 1000
     remove:
-      limit: 1000
+      limit: 50
 
 services:
   roomManager:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -77,6 +77,8 @@ operations:
   rooms:
     add:
       limit: 1000
+    remove:
+      limit: 1000
 
 services:
   roomManager:

--- a/internal/core/operations/providers/operation_providers.go
+++ b/internal/core/operations/providers/operation_providers.go
@@ -88,12 +88,13 @@ func ProvideExecutors(
 	newSchedulerVersionConfig newversion.Config,
 	healthControllerConfig healthcontroller.Config,
 	addRoomsConfig add.Config,
+	removeRoomsConfig removerooms.Config,
 ) map[string]operations.Executor {
 
 	executors := map[string]operations.Executor{}
 	executors[createscheduler.OperationName] = createscheduler.NewExecutor(runtime, schedulerManager, operationManager)
 	executors[addrooms.OperationName] = addrooms.NewExecutor(roomManager, schedulerStorage, operationManager, addRoomsConfig)
-	executors[removerooms.OperationName] = removerooms.NewExecutor(roomManager, roomStorage, operationManager, schedulerManager)
+	executors[removerooms.OperationName] = removerooms.NewExecutor(roomManager, roomStorage, operationManager, schedulerManager, removeRoomsConfig)
 	executors[test.OperationName] = test.NewExecutor()
 	executors[switchversion.OperationName] = switchversion.NewExecutor(schedulerManager, operationManager)
 	executors[newversion.OperationName] = newversion.NewExecutor(roomManager, schedulerManager, operationManager, newSchedulerVersionConfig)

--- a/internal/core/operations/rooms/add/executor.go
+++ b/internal/core/operations/rooms/add/executor.go
@@ -56,7 +56,7 @@ var _ operations.Executor = (*Executor)(nil)
 
 func NewExecutor(roomManager ports.RoomManager, storage ports.SchedulerStorage, operationManager ports.OperationManager, config Config) *Executor {
 	if config.AmountLimit <= 0 {
-		zap.L().Sugar().Infof("Amount limit wrongly configured with %d, using default value %d", config.AmountLimit, DefaultAmountLimit)
+		zap.L().Sugar().Infof("Add Executor - Amount limit wrongly configured with %d, using default value %d", config.AmountLimit, DefaultAmountLimit)
 		config.AmountLimit = DefaultAmountLimit
 	}
 	return &Executor{

--- a/internal/core/operations/rooms/remove/executor.go
+++ b/internal/core/operations/rooms/remove/executor.go
@@ -38,6 +38,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const DefaultAmountLimit = 1000
+
 type Config struct {
 	AmountLimit int
 }
@@ -53,6 +55,11 @@ var _ operations.Executor = (*Executor)(nil)
 
 // NewExecutor creates a new RemoveRoomExecutor
 func NewExecutor(roomManager ports.RoomManager, roomStorage ports.RoomStorage, operationManager ports.OperationManager, schedulerManager ports.SchedulerManager, config Config) *Executor {
+	if config.AmountLimit <= 0 {
+		zap.L().Sugar().Infof("Amount limit wrongly configured with %d, using default value %d", config.AmountLimit, DefaultAmountLimit)
+		config.AmountLimit = DefaultAmountLimit
+	}
+
 	return &Executor{
 		roomManager,
 		roomStorage,

--- a/internal/core/operations/rooms/remove/executor.go
+++ b/internal/core/operations/rooms/remove/executor.go
@@ -38,7 +38,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const DefaultAmountLimit = 1000
+const DefaultAmountLimit = 50
 
 type Config struct {
 	AmountLimit int
@@ -56,7 +56,7 @@ var _ operations.Executor = (*Executor)(nil)
 // NewExecutor creates a new RemoveRoomExecutor
 func NewExecutor(roomManager ports.RoomManager, roomStorage ports.RoomStorage, operationManager ports.OperationManager, schedulerManager ports.SchedulerManager, config Config) *Executor {
 	if config.AmountLimit <= 0 {
-		zap.L().Sugar().Infof("Amount limit wrongly configured with %d, using default value %d", config.AmountLimit, DefaultAmountLimit)
+		zap.L().Sugar().Infof("Remove Executor - Amount limit wrongly configured with %d, using default value %d", config.AmountLimit, DefaultAmountLimit)
 		config.AmountLimit = DefaultAmountLimit
 	}
 	return &Executor{

--- a/internal/core/operations/rooms/remove/executor.go
+++ b/internal/core/operations/rooms/remove/executor.go
@@ -59,7 +59,6 @@ func NewExecutor(roomManager ports.RoomManager, roomStorage ports.RoomStorage, o
 		zap.L().Sugar().Infof("Amount limit wrongly configured with %d, using default value %d", config.AmountLimit, DefaultAmountLimit)
 		config.AmountLimit = DefaultAmountLimit
 	}
-
 	return &Executor{
 		roomManager,
 		roomStorage,

--- a/internal/core/operations/rooms/remove/executor_test.go
+++ b/internal/core/operations/rooms/remove/executor_test.go
@@ -29,9 +29,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	clock_mock "github.com/topfreegames/maestro/internal/core/ports/clock_mock.go"
 	"testing"
 	"time"
+
+	clock_mock "github.com/topfreegames/maestro/internal/core/ports/clock_mock.go"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
@@ -238,13 +239,13 @@ func TestExecutor_Execute(t *testing.T) {
 		t.Run("use default amount limit if AmountLimit not set", func(t *testing.T) {
 			executor, _, _, _, _ := testSetup(t, Config{})
 			require.NotNil(t, executor)
-			require.Equal(t, executor.config.AmountLimit, int32(DefaultAmountLimit))
+			require.Equal(t, executor.config.AmountLimit, DefaultAmountLimit)
 		})
 
 		t.Run("use default amount limit if invalid AmountLimit value", func(t *testing.T) {
 			executor, _, _, _, _ := testSetup(t, Config{AmountLimit: -1})
 			require.NotNil(t, executor)
-			require.Equal(t, executor.config.AmountLimit, int32(DefaultAmountLimit))
+			require.Equal(t, executor.config.AmountLimit, DefaultAmountLimit)
 		})
 
 		t.Run("should succeed - cap to the default amount if asked to create more than whats configured", func(t *testing.T) {

--- a/internal/core/operations/rooms/remove/executor_test.go
+++ b/internal/core/operations/rooms/remove/executor_test.go
@@ -46,8 +46,6 @@ import (
 	"github.com/topfreegames/maestro/internal/core/entities/port"
 )
 
-const DefaultAmountLimit = 1000
-
 func TestExecutor_Execute(t *testing.T) {
 
 	clockMock := clock_mock.NewFakeClock(time.Now())

--- a/internal/core/operations/rooms/remove/executor_test.go
+++ b/internal/core/operations/rooms/remove/executor_test.go
@@ -30,6 +30,8 @@ import (
 	"errors"
 	"fmt"
 
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -40,7 +42,6 @@ import (
 	porterrors "github.com/topfreegames/maestro/internal/core/ports/errors"
 	mockports "github.com/topfreegames/maestro/internal/core/ports/mock"
 	serviceerrors "github.com/topfreegames/maestro/internal/core/services/errors"
-	"testing"
 )
 
 func TestExecutor_Execute(t *testing.T) {

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/topfreegames/maestro/internal/core/operations/rooms/add"
+	"github.com/topfreegames/maestro/internal/core/operations/rooms/remove"
 	"github.com/topfreegames/maestro/internal/core/operations/schedulers/newversion"
 	"github.com/topfreegames/maestro/internal/core/services/events"
 	operationmanager "github.com/topfreegames/maestro/internal/core/services/operations"
@@ -48,6 +49,7 @@ const (
 	operationLeaseTTLMillisConfigPath           = "services.operationManager.operationLeaseTTLMillis"
 	schedulerCacheTTLMillisConfigPath           = "services.eventsForwarder.schedulerCacheTTLMillis"
 	operationsRoomsAddLimitConfigPath           = "operations.rooms.add.limit"
+	operationsRoomsRemoveLimitConfigPath        = "operations.rooms.remove.limit"
 )
 
 // NewCreateSchedulerVersionConfig instantiate a new CreateSchedulerVersionConfig to be used by the NewSchedulerVersion operation to customize its configuration.
@@ -87,6 +89,17 @@ func NewOperationRoomsAddConfig(c config.Config) add.Config {
 
 	config := add.Config{
 		AmountLimit: operationsRoomsAddLimit,
+	}
+
+	return config
+}
+
+// NewOperationRoomsRemoveConfig instantiate a new remove.Config to be used by the rooms remove operation.
+func NewOperationRoomsRemoveConfig(c config.Config) remove.Config {
+	operationsRoomsRemoveLimit := c.GetInt(operationsRoomsRemoveLimitConfigPath)
+
+	config := remove.Config{
+		AmountLimit: operationsRoomsRemoveLimit,
 	}
 
 	return config


### PR DESCRIPTION
This change introduces limits to the remove room operation, enabling a smoother and more controlled room removal process during HPA.

While Maestro's calculations may occasionally recommend aggressive scaling down, such behavior can be detrimental to gameplay or system stability. By throttling the removal rate, this update mitigates the risk of overly aggressive HPAs and ensures a more gradual and game-friendly scaling process.