### PR TITLE
fix(kubernetes): treat k8s rate limit on rooms creation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -46,6 +46,8 @@ adapters:
       range: 60001-60010
   runtime:
     kubernetes:
+      qps: 100
+      burst: 200
       inCluster: false
       masterUrl: "https://127.0.0.1:6443"
       kubeconfig: "./kubeconfig/kubeconfig.yaml"


### PR DESCRIPTION
# Improve resilience over Kubernetes failure when adding rooms

## Summary

This PR addresses failures when adding rooms due to Kubernetes errors, like rate limit and others. It adds a retry interface (from k8s itself), retrying on retryable errors.

## Changes

### 🔧 Kubernetes Rate Limiting Improvements

**Problem**: The system was experiencing rate-limiting errors when creating game room instances, causing operations to fail with errors like:
```
"client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline"
```

**Solution**: Implemented proper retry logic using Kubernetes client-go best practices:

- **Added retry mechanism**: Created `createPodWithRetry()` function that uses `k8s.io/client-go/util/retry` for handling transient errors
- **Proper error detection**: Implemented `isRetryableError()` function that checks for retryable Kubernetes errors:
  - `TooManyRequests` (429 errors)
  - `ServerTimeout`
  - `InternalError`
  - `ServiceUnavailable`
  - `UnexpectedServerError`
- **Configuration**: Added QPS and burst settings to Kubernetes client configuration:
  ```yaml
  runtime:
    kubernetes:
      qps: 100
      burst: 200
  ```

### Kubernetes Retry Logic

The new retry mechanism uses Kubernetes' official `retry.OnError` function with `DefaultBackoff` strategy:

```go
err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
    return isRetryableError(err)
}, func() error {
    var createErr error
    createdPod, createErr = k.clientSet.CoreV1().Pods(scheduler.Name).Create(ctx, pod, metav1.CreateOptions{})
    return createErr
})
```

### Error Detection

Instead of fragile string matching, the solution uses proper Kubernetes error type checking:

```go
func isRetryableError(err error) bool {
    return kerrors.IsTooManyRequests(err) ||
           kerrors.IsServerTimeout(err) ||
           kerrors.IsInternalError(err) ||
           kerrors.IsServiceUnavailable(err) ||
           kerrors.IsUnexpectedServerError(err)
}
```

## Testing

- ✅ Added comprehensive unit tests for retry logic (`TestIsRetryableError`)
- ✅ Fixed existing metrics reporter tests to eliminate race conditions
- ✅ All unit tests pass consistently
- ✅ Improved test reliability and determinism

## Impact

- **Reduced operation failures**: Kubernetes rate limiting errors are now handled gracefully with automatic retries
- **Better user experience**: Room creation operations are more reliable under high load
- **Improved test stability**: CI/CD pipeline is more reliable with consistent test results
- **Follows best practices**: Uses official Kubernetes client-go patterns for error handling