### PR TITLE
feat(add): batch room creation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -79,6 +79,7 @@ operations:
   rooms:
     add:
       limit: 1000
+      batchSize: 40
     remove:
       limit: 50
 

--- a/internal/core/operations/rooms/add/executor.go
+++ b/internal/core/operations/rooms/add/executor.go
@@ -40,10 +40,14 @@ import (
 	"github.com/topfreegames/maestro/internal/core/operations"
 )
 
-const DefaultAmountLimit = 1000
+const (
+	DefaultAmountLimit = 1000
+	DefaultBatchSize   = 40
+)
 
 type Config struct {
 	AmountLimit int32
+	BatchSize   int32
 }
 
 type Executor struct {
@@ -59,6 +63,10 @@ func NewExecutor(roomManager ports.RoomManager, storage ports.SchedulerStorage, 
 	if config.AmountLimit <= 0 {
 		zap.L().Sugar().Infof("Add Executor - Amount limit wrongly configured with %d, using default value %d", config.AmountLimit, DefaultAmountLimit)
 		config.AmountLimit = DefaultAmountLimit
+	}
+	if config.BatchSize <= 0 {
+		zap.L().Sugar().Infof("Add Executor - Batch size wrongly configured with %d, using default value %d", config.BatchSize, DefaultBatchSize)
+		config.BatchSize = DefaultBatchSize
 	}
 	return &Executor{
 		roomManager,
@@ -85,33 +93,52 @@ func (ex *Executor) Execute(ctx context.Context, op *operation.Operation, defini
 	}
 
 	if amount > ex.config.AmountLimit {
-		executionLogger.Info("operation called with amount greater than limit, capping it", zap.Int32("calledAmount", amount), zap.Int32("limit", ex.config.AmountLimit))
+		executionLogger.Debug("operation called with amount greater than limit, capping it", zap.Int32("calledAmount", amount), zap.Int32("limit", ex.config.AmountLimit))
 		amount = ex.config.AmountLimit
 	}
 
-	var wg sync.WaitGroup
-	errsCh := make(chan error, amount)
-
-	for i := int32(1); i <= amount; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			defer cancel()
-
-			errsCh <- ex.createRoom(ctx, scheduler, executionLogger)
-		}()
-	}
-
-	wg.Wait()
-	close(errsCh)
+	executionLogger.Debug("starting batched room creation",
+		zap.Int32("totalAmount", amount),
+		zap.Int32("batchSize", ex.config.BatchSize))
 
 	var collectedErrors []error
-	for err := range errsCh {
-		if err != nil {
-			collectedErrors = append(collectedErrors, err)
+	remainingAmount := amount
+
+	for remainingAmount > 0 {
+		batchSize := min(remainingAmount, ex.config.BatchSize)
+
+		executionLogger.Debug("processing batch",
+			zap.Int32("batchSize", batchSize),
+			zap.Int32("remainingAmount", remainingAmount))
+
+		var wg sync.WaitGroup
+		errsCh := make(chan error, batchSize)
+
+		for range batchSize {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+
+				errsCh <- ex.createRoom(ctx, scheduler, executionLogger)
+			}()
 		}
+
+		wg.Wait()
+		close(errsCh)
+
+		for err := range errsCh {
+			if err != nil {
+				collectedErrors = append(collectedErrors, err)
+			}
+		}
+
+		remainingAmount -= batchSize
+		executionLogger.Debug("batch completed",
+			zap.Int32("batchSize", batchSize),
+			zap.Int32("remainingAmount", remainingAmount))
 	}
 
 	errCount := int32(len(collectedErrors))

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -49,6 +49,7 @@ const (
 	operationLeaseTTLMillisConfigPath           = "services.operationManager.operationLeaseTTLMillis"
 	schedulerCacheTTLMillisConfigPath           = "services.eventsForwarder.schedulerCacheTTLMillis"
 	operationsRoomsAddLimitConfigPath           = "operations.rooms.add.limit"
+	operationsRoomsAddBatchSizePath             = "operations.rooms.add.batchSize"
 	operationsRoomsRemoveLimitConfigPath        = "operations.rooms.remove.limit"
 )
 
@@ -86,9 +87,11 @@ func NewHealthControllerConfig(c config.Config) healthcontroller.Config {
 // NewOperationRoomsAddConfig instantiate a new add.Config to be used by the rooms add operation.
 func NewOperationRoomsAddConfig(c config.Config) add.Config {
 	operationsRoomsAddLimit := int32(c.GetInt(operationsRoomsAddLimitConfigPath))
+	operationsRoomsAddBatchSize := int32(c.GetInt(operationsRoomsAddBatchSizePath))
 
 	config := add.Config{
 		AmountLimit: operationsRoomsAddLimit,
+		BatchSize:   operationsRoomsAddBatchSize,
 	}
 
 	return config


### PR DESCRIPTION
Previously, add room operation created one goroutine to each room to be created. Depending on the amount we get rate limited by k8s or context cancellation from Redis. To mitigate that we operate the creation in batches so we can space out this process and avoid errors from exetrnal providers.

Main Changes:
- Implemented default batch size handling in the executor configuration.
- Added tests to verify batch processing behavior, including scenarios for default batch size, error handling, and varying amounts of rooms.
- Ensured that the executor correctly processes rooms in batches, handling both success and failure cases appropriately.