### PR TITLE
fix(metrics-reporter): prevent nil pointer panic in syncScheduler

### DIFF
--- a/internal/core/worker/metricsreporter/metrics_reporter_worker.go
+++ b/internal/core/worker/metricsreporter/metrics_reporter_worker.go
@@ -102,7 +102,12 @@ func (w *MetricsReporterWorker) IsRunning() bool {
 func (w *MetricsReporterWorker) syncScheduler(ctx context.Context) {
 	scheduler, err := w.schedulerCache.GetScheduler(ctx, w.scheduler.Name)
 	if err != nil {
-		w.logger.Error("Error loading scheduler", zap.Error(err))
+		w.logger.Error("Error loading scheduler from cache", zap.Error(err))
+		return
+	}
+
+	if scheduler == nil {
+		w.logger.Warn("Scheduler not found in cache, skipping sync", zap.String("scheduler", w.scheduler.Name))
 		return
 	}
 


### PR DESCRIPTION
Add nil check for scheduler returned from cache to prevent panic when scheduler is not found in cache (cache miss). The worker will now log a warning and skip sync instead of crashing, allowing metrics reporting to continue with existing scheduler data.

Fixes panic: runtime error: invalid memory address or nil pointer dereference at metrics_reporter_worker.go:109