### PR TITLE
fix: revert scheduler-storage to 2-label metrics and enhance error messages with operation context

### DIFF
--- a/internal/adapters/metrics/pg.go
+++ b/internal/adapters/metrics/pg.go
@@ -35,7 +35,6 @@ var (
 		Labels: []string{
 			monitoring.LabelStorage,
 			monitoring.LabelOperation,
-			monitoring.LabelScheduler,
 		},
 	})
 

--- a/internal/adapters/storage/postgres/scheduler/metrics.go
+++ b/internal/adapters/storage/postgres/scheduler/metrics.go
@@ -29,10 +29,24 @@ import (
 	"github.com/topfreegames/maestro/internal/core/monitoring"
 )
 
-const SchedulerStorageMetricLabel = "scheduler-storage"
+const (
+	SchedulerStorageMetricLabel = "scheduler-storage"
 
-func reportSchedulerStorageFailsCounterMetric(operation string, labels ...string) {
-	metrics.PostgresFailsCounterMetric.WithLabelValues(append([]string{SchedulerStorageMetricLabel, operation}, labels...)...).Inc()
+	// Operation constants
+	OpGetScheduler            = "GetScheduler"
+	OpGetSchedulerWithFilter  = "GetSchedulerWithFilter"
+	OpGetSchedulerVersions    = "GetSchedulerVersions"
+	OpGetSchedulers           = "GetSchedulers"
+	OpGetSchedulersWithFilter = "GetSchedulersWithFilter"
+	OpGetAllSchedulers        = "GetAllSchedulers"
+	OpCreateScheduler         = "CreateScheduler"
+	OpUpdateScheduler         = "UpdateScheduler"
+	OpDeleteScheduler         = "DeleteScheduler"
+	OpCreateSchedulerVersion  = "CreateSchedulerVersion"
+)
+
+func reportSchedulerStorageFailsCounterMetric(operation string) {
+	metrics.PostgresFailsCounterMetric.WithLabelValues(SchedulerStorageMetricLabel, operation).Inc()
 }
 
 func runSchedulerStorageFunctionCollectingLatency(operation string, executionFunction func()) {


### PR DESCRIPTION
 ## Summary
  Reverts PostgreSQL scheduler storage metrics from 3 labels to 2 labels and enhances error messages with operation constants for better debugging.

  ## Changes
  - **Revert metrics to 2 labels**: Remove scheduler label from `PostgresFailsCounterMetric` (now uses only `storage`, `operation`)
  - **Fix all call sites**: Update all 10 storage methods to use 2-label metric calls instead of 3
  - **Add operation constants**: Define constants (OpGetScheduler, OpCreateScheduler, etc.) to replace hardcoded strings
  - **Enhance error messages**: Include operation context in all error messages: `"error getting scheduler X (operation: GetScheduler)"`
  - **Update latency metrics**: Use constants for consistency across metrics and latency collection

  ## Rationale
  The 3-label approach had inconsistent usage (7 methods passed scheduler name, 3 didn't) and caused label count mismatches. The 2-label approach is cleaner and more consistent, while operation-enhanced error
  messages provide the debugging context we need since all storage errors are logged by higher-level components.