### PR TITLE
reduce log level to debug for most recurrent logs

### DIFF
--- a/internal/core/services/rooms/room_manager.go
+++ b/internal/core/services/rooms/room_manager.go
@@ -166,7 +166,7 @@ func (m *RoomManager) UpdateRoomInstance(ctx context.Context, gameRoomInstance *
 	if gameRoomInstance == nil {
 		return fmt.Errorf("cannot update room instance since it is nil")
 	}
-	m.Logger.Sugar().Infof("Updating room instance. ID: %v", gameRoomInstance.ID)
+	m.Logger.Sugar().Debugf("Updating room instance. ID: %v", gameRoomInstance.ID)
 	err := m.InstanceStorage.UpsertInstance(ctx, gameRoomInstance)
 	if err != nil {
 		return fmt.Errorf("failed when updating the game room instance on storage: %w", err)
@@ -177,7 +177,7 @@ func (m *RoomManager) UpdateRoomInstance(ctx context.Context, gameRoomInstance *
 		return fmt.Errorf("failed to update game room status: %w", err)
 	}
 
-	m.Logger.Info("Updating room instance success")
+	m.Logger.Debug("Updating room instance success")
 
 	return nil
 }


### PR DESCRIPTION
The most frequent INFO logs in Maestro are related to room instance updates, with over 18 million log entries over the. The two main patterns are:

"Updating room instance success" - Confirms successful room updates
"Updating room instance. ID: [room-id]" - Indicates the start of a room update process
These logs come from the runtime-watcher component and room_manager service, which are responsible for managing game room instances. The logs show regular health checks and updates of game rooms for various games (particularly sniper3d).

We are in an effort to reduce unnecessary logs to reduce costs from LogZ.