### PR TITLE
Add the ability to setup psql pool size and min idle connections

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,8 @@ adapters:
   schedulerStorage:
     postgres:
       url: "postgres://maestro:maestro@localhost:5432/maestro?sslmode=disable"
+      pooSize: 20
+      minIdleConns: 10
   schedulerCache:
     redis:
       url: "redis://localhost:6379/0"

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -245,6 +245,8 @@ func TestSchedulerStoragePostgres(t *testing.T) {
 		config := configmock.NewMockConfig(mockCtrl)
 
 		config.EXPECT().GetString(schedulerStoragePostgresURLPath).Return("postgres://somewhere:5432/db")
+		config.EXPECT().GetInt(schedulerStoragePostgresPoolSize).Return(50)
+		config.EXPECT().GetInt(schedulerStoragePostgresMinIdleConnections).Return(10)
 		config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
 		_, err := NewSchedulerStoragePg(config)
 		require.NoError(t, err)


### PR DESCRIPTION
Since default for pool size is based on GOMAXPROCS, it's possible for maestro deployments to have a significant higher connection pool than needed. This change can help reduce that DB connection load, especially during rollouts.