### PR TITLE
Fix error omission while creating room in runtime

### DIFF
--- a/internal/core/services/rooms/room_manager.go
+++ b/internal/core/services/rooms/room_manager.go
@@ -445,7 +445,7 @@ func (m *RoomManager) createRoomOnStorageAndRuntime(ctx context.Context, schedul
 	if err != nil {
 		deleteRoomErr := m.RoomStorage.DeleteRoom(ctx, scheduler.Name, room.ID)
 		if deleteRoomErr != nil {
-			return nil, nil, fmt.Errorf("error deleting room during create game room instance error: %w", deleteRoomErr)
+			return nil, nil, errors.Join(fmt.Errorf("error creating room instance and cleaning up room on storage"), err, deleteRoomErr)
 		}
 		return nil, nil, err
 	}

--- a/internal/core/services/rooms/room_manager.go
+++ b/internal/core/services/rooms/room_manager.go
@@ -445,7 +445,7 @@ func (m *RoomManager) createRoomOnStorageAndRuntime(ctx context.Context, schedul
 	if err != nil {
 		deleteRoomErr := m.RoomStorage.DeleteRoom(ctx, scheduler.Name, room.ID)
 		if deleteRoomErr != nil {
-			return nil, nil, errors.Join(fmt.Errorf("error creating room instance and cleaning up room on storage"), err, deleteRoomErr)
+			return nil, nil, errors.Join(fmt.Errorf("error creating game room and cleaning up room on storage"), err, deleteRoomErr)
 		}
 		return nil, nil, err
 	}

--- a/internal/core/services/rooms/room_manager_test.go
+++ b/internal/core/services/rooms/room_manager_test.go
@@ -195,7 +195,9 @@ func TestRoomManager_CreateRoom(t *testing.T) {
 		roomStorage.EXPECT().DeleteRoom(context.Background(), scheduler.Name, gameRoom.ID).Return(fmt.Errorf("error deleting room"))
 
 		room, instance, err := roomManager.CreateRoom(context.Background(), scheduler, false)
-		assert.EqualError(t, err, "error deleting room during create game room instance error: error deleting room")
+		assert.ErrorContains(t, err, "error creating game room and cleaning up room on storage")
+		assert.ErrorContains(t, err, "error creating game room on runtime")
+		assert.ErrorContains(t, err, "error deleting room")
 		assert.Nil(t, room)
 		assert.Nil(t, instance)
 	})


### PR DESCRIPTION
**Summary**
This PR addresses a bug where the original error from `m.Runtime.CreateGameRoomInstance` was being swallowed if the subsequent `m.RoomStorage.DeleteRoom` call also failed.

**What is changing?**
This update modifies the error handling logic to use `errors.Join`. This function allows us to combine both the original error from `CreateGameRoomInstance` and the new error from `DeleteRoom` into a single, comprehensive error.