### PR TITLE
Add scheduler cache to UpdateRoomWithPing flow

### DIFF
--- a/cmd/roomsapi/wire_gen.go
+++ b/cmd/roomsapi/wire_gen.go
@@ -32,6 +32,10 @@ func initializeRoomsMux(ctx context.Context, conf config.Config) (*runtime.Serve
 	if err != nil {
 		return nil, err
 	}
+	schedulerCache, err := service.NewSchedulerCacheRedis(conf)
+	if err != nil {
+		return nil, err
+	}
 	gameRoomInstanceStorage, err := service.NewGameRoomInstanceStorageRedis(conf)
 	if err != nil {
 		return nil, err
@@ -44,10 +48,6 @@ func initializeRoomsMux(ctx context.Context, conf config.Config) (*runtime.Serve
 	if err != nil {
 		return nil, err
 	}
-	schedulerCache, err := service.NewSchedulerCacheRedis(conf)
-	if err != nil {
-		return nil, err
-	}
 	eventsForwarderConfig, err := service.NewEventsForwarderServiceConfig(conf)
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func initializeRoomsMux(ctx context.Context, conf config.Config) (*runtime.Serve
 	if err != nil {
 		return nil, err
 	}
-	roomManager := service.NewRoomManager(clock, portAllocator, roomStorage, schedulerStorage, gameRoomInstanceStorage, portsRuntime, eventsService, roomManagerConfig)
+	roomManager := service.NewRoomManager(clock, portAllocator, roomStorage, schedulerStorage, schedulerCache, gameRoomInstanceStorage, portsRuntime, eventsService, roomManagerConfig)
 	roomsHandler := handlers.ProvideRoomsHandler(roomManager, eventsService)
 	serveMux := provideRoomsMux(ctx, roomsHandler)
 	return serveMux, nil

--- a/cmd/runtimewatcher/wire_gen.go
+++ b/cmd/runtimewatcher/wire_gen.go
@@ -38,15 +38,15 @@ func initializeRuntimeWatcher(c config.Config) (*workers.WorkersManager, error) 
 	if err != nil {
 		return nil, err
 	}
+	schedulerCache, err := service.NewSchedulerCacheRedis(c)
+	if err != nil {
+		return nil, err
+	}
 	gameRoomInstanceStorage, err := service.NewGameRoomInstanceStorageRedis(c)
 	if err != nil {
 		return nil, err
 	}
 	eventsForwarder, err := service.NewEventsForwarder(c)
-	if err != nil {
-		return nil, err
-	}
-	schedulerCache, err := service.NewSchedulerCacheRedis(c)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/runtimewatcher/wire_gen.go
+++ b/cmd/runtimewatcher/wire_gen.go
@@ -59,7 +59,7 @@ func initializeRuntimeWatcher(c config.Config) (*workers.WorkersManager, error) 
 	if err != nil {
 		return nil, err
 	}
-	roomManager := service.NewRoomManager(clock, portAllocator, roomStorage, schedulerStorage, gameRoomInstanceStorage, runtime, eventsService, roomManagerConfig)
+	roomManager := service.NewRoomManager(clock, portAllocator, roomStorage, schedulerStorage, schedulerCache, gameRoomInstanceStorage, runtime, eventsService, roomManagerConfig)
 	runtimeWatcherConfig := provideRuntimeWatcherConfig(c)
 	workerOptions := &worker.WorkerOptions{
 		Runtime:              runtime,

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -53,15 +53,15 @@ func initializeWorker(c config.Config, builder *worker.WorkerBuilder) (*workers.
 	if err != nil {
 		return nil, err
 	}
+	schedulerCache, err := service.NewSchedulerCacheRedis(c)
+	if err != nil {
+		return nil, err
+	}
 	gameRoomInstanceStorage, err := service.NewGameRoomInstanceStorageRedis(c)
 	if err != nil {
 		return nil, err
 	}
 	eventsForwarder, err := service.NewEventsForwarder(c)
-	if err != nil {
-		return nil, err
-	}
-	schedulerCache, err := service.NewSchedulerCacheRedis(c)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/worker/wire_gen.go
+++ b/cmd/worker/wire_gen.go
@@ -74,7 +74,7 @@ func initializeWorker(c config.Config, builder *worker.WorkerBuilder) (*workers.
 	if err != nil {
 		return nil, err
 	}
-	roomManager := service.NewRoomManager(clock, portAllocator, roomStorage, schedulerStorage, gameRoomInstanceStorage, runtime, eventsService, roomManagerConfig)
+	roomManager := service.NewRoomManager(clock, portAllocator, roomStorage, schedulerStorage, schedulerCache, gameRoomInstanceStorage, runtime, eventsService, roomManagerConfig)
 	schedulerManager := service.NewSchedulerManager(schedulerStorage, schedulerCache, operationManager, roomStorage)
 	policyMap := service.NewPolicyMap(roomStorage)
 	autoscaler := service.NewAutoscaler(policyMap)

--- a/internal/core/services/rooms/room_manager.go
+++ b/internal/core/services/rooms/room_manager.go
@@ -538,7 +538,7 @@ func contains[T comparable](s []T, e T) bool {
 func (m *RoomManager) getScheduler(ctx context.Context, schedulerName string) (*entities.Scheduler, error) {
 	scheduler, err := m.SchedulerCache.GetScheduler(ctx, schedulerName)
 	if err != nil {
-		m.Logger.Error(fmt.Sprintf("Failed to get scheduler \"%v\" from cache", schedulerName), zap.Error(err))
+		m.Logger.Warn(fmt.Sprintf("Failed to get scheduler \"%v\" from cache", schedulerName), zap.Error(err))
 	}
 	if scheduler == nil {
 		scheduler, err = m.SchedulerStorage.GetScheduler(ctx, schedulerName)
@@ -547,7 +547,7 @@ func (m *RoomManager) getScheduler(ctx context.Context, schedulerName string) (*
 			return nil, err
 		}
 		if err = m.SchedulerCache.SetScheduler(ctx, scheduler, m.Config.SchedulerCacheTtl); err != nil {
-			m.Logger.Error(fmt.Sprintf("Failed to set scheduler \"%v\" in cache", schedulerName), zap.Error(err))
+			m.Logger.Warn(fmt.Sprintf("Failed to set scheduler \"%v\" in cache", schedulerName), zap.Error(err))
 		}
 	}
 	return scheduler, nil

--- a/internal/core/services/rooms/room_manager_config.go
+++ b/internal/core/services/rooms/room_manager_config.go
@@ -27,4 +27,5 @@ import "time"
 type RoomManagerConfig struct {
 	RoomPingTimeout     time.Duration
 	RoomDeletionTimeout time.Duration
+	SchedulerCacheTtl   time.Duration
 }

--- a/internal/core/services/rooms/room_manager_test.go
+++ b/internal/core/services/rooms/room_manager_test.go
@@ -429,8 +429,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 		newGameRoomInvalidState := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusTerminating, PingStatus: game_room.GameRoomPingStatusReady}
 		currentInstance := &game_room.Instance{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.InstanceStatus{Type: game_room.InstancePending}}
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoomInvalidState).Return(nil)
-		scheduler := &entities.Scheduler{Name: newGameRoomInvalidState.SchedulerID}
-		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoomInvalidState.SchedulerID).Return(scheduler, nil)
+		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoomInvalidState.SchedulerID).Return(&entities.Scheduler{Name: newGameRoomInvalidState.SchedulerID}, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoomInvalidState.SchedulerID, newGameRoomInvalidState.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoomInvalidState.SchedulerID, newGameRoomInvalidState.ID).Return(newGameRoomInvalidState, nil)
 
@@ -719,10 +718,10 @@ func TestRoomManager_UpdateRoomInstance(t *testing.T) {
 
 	t.Run("updates rooms with success", func(t *testing.T) {
 		instanceStorage.EXPECT().UpsertInstance(context.Background(), newGameRoomInstance).Return(nil)
-		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoomInstance.SchedulerID).Return(&entities.Scheduler{Name: newGameRoomInstance.SchedulerID}, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID).Return(newGameRoomInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID).Return(currentGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID, game_room.GameStatusError).Return(nil)
+		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoomInstance.SchedulerID).Return(&entities.Scheduler{Name: newGameRoomInstance.SchedulerID}, nil)
 
 		err := roomManager.UpdateRoomInstance(context.Background(), newGameRoomInstance)
 		require.NoError(t, err)

--- a/internal/core/services/rooms/room_manager_test.go
+++ b/internal/core/services/rooms/room_manager_test.go
@@ -65,8 +65,9 @@ func TestRoomManager_CreateRoom(t *testing.T) {
 	instanceStorage := mockports.NewMockGameRoomInstanceStorage(mockCtrl)
 	fakeClock := clockmock.NewFakeClock(now)
 	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+	schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
 	config := RoomManagerConfig{}
-	roomManager := New(fakeClock, portAllocator, roomStorage, schedulerStorage, instanceStorage, runtime, eventsService, config)
+	roomManager := New(fakeClock, portAllocator, roomStorage, schedulerStorage, schedulerCache, instanceStorage, runtime, eventsService, config)
 
 	container1 := game_room.Container{
 		Name: "container1",
@@ -384,6 +385,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 		mockports.NewMockPortAllocator(mockCtrl),
 		roomStorage,
 		schedulerStorage,
+		mockports.NewMockSchedulerCache(mockCtrl),
 		instanceStorage,
 		runtime,
 		eventsService,
@@ -467,6 +469,7 @@ func TestRoomManager_ListRoomsWithDeletionPriority(t *testing.T) {
 		nil,
 		roomStorage,
 		schedulerStorage,
+		mockports.NewMockSchedulerCache(mockCtrl),
 		nil,
 		runtime,
 		eventsService,
@@ -693,6 +696,7 @@ func TestRoomManager_UpdateRoomInstance(t *testing.T) {
 		mockports.NewMockPortAllocator(mockCtrl),
 		roomStorage,
 		schedulerStorage,
+		mockports.NewMockSchedulerCache(mockCtrl),
 		instanceStorage,
 		runtime,
 		eventsService,
@@ -740,6 +744,7 @@ func TestRoomManager_CleanRoomState(t *testing.T) {
 		mockports.NewMockPortAllocator(mockCtrl),
 		roomStorage,
 		schedulerStorage,
+		mockports.NewMockSchedulerCache(mockCtrl),
 		instanceStorage,
 		runtime,
 		eventsService,
@@ -1354,6 +1359,7 @@ func testSetup(t *testing.T) (
 
 	roomStorage := mockports.NewMockRoomStorage(mockCtrl)
 	schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+	schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
 	instanceStorage := mockports.NewMockGameRoomInstanceStorage(mockCtrl)
 	runtime := mockports.NewMockRuntime(mockCtrl)
 	eventsService := mockports.NewMockEventsService(mockCtrl)
@@ -1365,6 +1371,7 @@ func testSetup(t *testing.T) (
 		mockports.NewMockPortAllocator(mockCtrl),
 		roomStorage,
 		schedulerStorage,
+		schedulerCache,
 		instanceStorage,
 		runtime,
 		eventsService,

--- a/internal/core/services/rooms/room_manager_test.go
+++ b/internal/core/services/rooms/room_manager_test.go
@@ -400,8 +400,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 	newGameRoom := &game_room.GameRoom{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.GameStatusReady, PingStatus: game_room.GameRoomPingStatusOccupied, LastPingAt: clock.Now(), Metadata: map[string]interface{}{}}
 
 	t.Run("when the current game room exists then it execute without returning error", func(t *testing.T) {
-		scheduler := &entities.Scheduler{Name: newGameRoom.SchedulerID}
-		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(scheduler, nil)
+		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(&entities.Scheduler{Name: newGameRoom.SchedulerID}, nil)
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
@@ -441,8 +440,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 
 	t.Run("when update status fails then it returns error", func(t *testing.T) {
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(nil)
-		scheduler := &entities.Scheduler{Name: newGameRoom.SchedulerID}
-		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(scheduler, nil)
+		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(&entities.Scheduler{Name: newGameRoom.SchedulerID}, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(porterrors.ErrUnexpected)
@@ -453,8 +451,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 
 	t.Run("when some error occurs on events forwarding then it does not return with error", func(t *testing.T) {
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(nil)
-		scheduler := &entities.Scheduler{Name: newGameRoom.SchedulerID}
-		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(scheduler, nil)
+		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(&entities.Scheduler{Name: newGameRoom.SchedulerID}, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(nil)
@@ -722,8 +719,7 @@ func TestRoomManager_UpdateRoomInstance(t *testing.T) {
 
 	t.Run("updates rooms with success", func(t *testing.T) {
 		instanceStorage.EXPECT().UpsertInstance(context.Background(), newGameRoomInstance).Return(nil)
-		scheduler := &entities.Scheduler{Name: newGameRoomInstance.SchedulerID}
-		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoomInstance.SchedulerID).Return(scheduler, nil)
+		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoomInstance.SchedulerID).Return(&entities.Scheduler{Name: newGameRoomInstance.SchedulerID}, nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID).Return(newGameRoomInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID).Return(currentGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID, game_room.GameStatusError).Return(nil)

--- a/internal/core/services/rooms/room_manager_test.go
+++ b/internal/core/services/rooms/room_manager_test.go
@@ -381,6 +381,10 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 	clock := clockmock.NewFakeClock(time.Now())
 	config := RoomManagerConfig{}
 
+	// Configure cache to always miss, making tests transparent to caching
+	schedulerCache.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	schedulerCache.EXPECT().SetScheduler(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
 	roomManager := New(
 		clock,
 		mockports.NewMockPortAllocator(mockCtrl),
@@ -397,9 +401,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 
 	t.Run("when the current game room exists then it execute without returning error", func(t *testing.T) {
 		scheduler := &entities.Scheduler{Name: newGameRoom.SchedulerID}
-		schedulerCache.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
@@ -429,9 +431,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 		currentInstance := &game_room.Instance{ID: "test-room", SchedulerID: "test-scheduler", Status: game_room.InstanceStatus{Type: game_room.InstancePending}}
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoomInvalidState).Return(nil)
 		scheduler := &entities.Scheduler{Name: newGameRoomInvalidState.SchedulerID}
-		schedulerCache.EXPECT().GetScheduler(context.Background(), newGameRoomInvalidState.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoomInvalidState.SchedulerID).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoomInvalidState.SchedulerID, newGameRoomInvalidState.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoomInvalidState.SchedulerID, newGameRoomInvalidState.ID).Return(newGameRoomInvalidState, nil)
 
@@ -442,9 +442,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 	t.Run("when update status fails then it returns error", func(t *testing.T) {
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(nil)
 		scheduler := &entities.Scheduler{Name: newGameRoom.SchedulerID}
-		schedulerCache.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(porterrors.ErrUnexpected)
@@ -456,9 +454,7 @@ func TestRoomManager_UpdateRoom(t *testing.T) {
 	t.Run("when some error occurs on events forwarding then it does not return with error", func(t *testing.T) {
 		roomStorage.EXPECT().UpdateRoom(context.Background(), newGameRoom).Return(nil)
 		scheduler := &entities.Scheduler{Name: newGameRoom.SchedulerID}
-		schedulerCache.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoom.SchedulerID).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(currentInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID).Return(newGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoom.SchedulerID, newGameRoom.ID, game_room.GameStatusOccupied).Return(nil)
@@ -705,6 +701,11 @@ func TestRoomManager_UpdateRoomInstance(t *testing.T) {
 	eventsService := mockports.NewMockEventsService(mockCtrl)
 	clock := clockmock.NewFakeClock(time.Now())
 	config := RoomManagerConfig{}
+
+	// Configure cache to always miss, making tests transparent to caching
+	schedulerCache.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	schedulerCache.EXPECT().SetScheduler(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
 	roomManager := New(
 		clock,
 		mockports.NewMockPortAllocator(mockCtrl),
@@ -722,9 +723,7 @@ func TestRoomManager_UpdateRoomInstance(t *testing.T) {
 	t.Run("updates rooms with success", func(t *testing.T) {
 		instanceStorage.EXPECT().UpsertInstance(context.Background(), newGameRoomInstance).Return(nil)
 		scheduler := &entities.Scheduler{Name: newGameRoomInstance.SchedulerID}
-		schedulerCache.EXPECT().GetScheduler(context.Background(), newGameRoomInstance.SchedulerID).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), newGameRoomInstance.SchedulerID).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 		instanceStorage.EXPECT().GetInstance(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID).Return(newGameRoomInstance, nil)
 		roomStorage.EXPECT().GetRoom(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID).Return(currentGameRoom, nil)
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), newGameRoomInstance.SchedulerID, newGameRoomInstance.ID, game_room.GameStatusError).Return(nil)
@@ -1170,6 +1169,11 @@ func TestUpdateGameRoomStatus(t *testing.T) {
 		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
 		instanceStorage := mockports.NewMockGameRoomInstanceStorage(mockCtrl)
 		eventsService := mockports.NewMockEventsService(mockCtrl)
+
+		// Configure cache to always miss, making tests transparent to caching
+		schedulerCache.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		schedulerCache.EXPECT().SetScheduler(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
 		roomManager := New(
 			clockmock.NewFakeClock(time.Now()),
 			mockports.NewMockPortAllocator(mockCtrl),
@@ -1190,7 +1194,7 @@ func TestUpdateGameRoomStatus(t *testing.T) {
 
 		scheduler := newValidScheduler()
 		roomId := "room-id"
-		roomStorage, schedulerStorage, schedulerCache, instanceStorage, roomManager, _ := setup(mockCtrl)
+		roomStorage, schedulerStorage, _, instanceStorage, roomManager, _ := setup(mockCtrl)
 
 		room := &game_room.GameRoom{SchedulerID: scheduler.Name, PingStatus: game_room.GameRoomPingStatusReady, Status: game_room.GameStatusPending, Metadata: map[string]interface{}{}}
 		roomStorage.EXPECT().GetRoom(context.Background(), scheduler.Name, roomId).Return(room, nil)
@@ -1200,9 +1204,7 @@ func TestUpdateGameRoomStatus(t *testing.T) {
 
 		roomStorage.EXPECT().UpdateRoomStatus(context.Background(), scheduler.Name, roomId, game_room.GameStatusReady)
 
-		schedulerCache.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 
 		err := roomManager.UpdateGameRoomStatus(context.Background(), scheduler.Name, roomId)
 		require.NoError(t, err)
@@ -1213,11 +1215,9 @@ func TestUpdateGameRoomStatus(t *testing.T) {
 
 		scheduler := newValidScheduler()
 		roomId := "room-id"
-		roomStorage, schedulerStorage, schedulerCache, instanceStorage, roomManager, _ := setup(mockCtrl)
+		roomStorage, schedulerStorage, _, instanceStorage, roomManager, _ := setup(mockCtrl)
 
-		schedulerCache.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 
 		room := &game_room.GameRoom{SchedulerID: scheduler.Name, PingStatus: game_room.GameRoomPingStatusReady, Status: game_room.GameStatusReady}
 		roomStorage.EXPECT().GetRoom(context.Background(), scheduler.Name, roomId).Return(room, nil)
@@ -1234,11 +1234,9 @@ func TestUpdateGameRoomStatus(t *testing.T) {
 
 		scheduler := newValidScheduler()
 		roomId := "room-id"
-		roomStorage, schedulerStorage, schedulerCache, _, roomManager, _ := setup(mockCtrl)
+		roomStorage, schedulerStorage, _, _, roomManager, _ := setup(mockCtrl)
 
-		schedulerCache.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 
 		roomStorage.EXPECT().GetRoom(context.Background(), scheduler.Name, roomId).Return(nil, porterrors.ErrNotFound)
 
@@ -1251,11 +1249,9 @@ func TestUpdateGameRoomStatus(t *testing.T) {
 
 		scheduler := newValidScheduler()
 		roomId := "room-id"
-		roomStorage, schedulerStorage, schedulerCache, instanceStorage, roomManager, _ := setup(mockCtrl)
+		roomStorage, schedulerStorage, _, instanceStorage, roomManager, _ := setup(mockCtrl)
 
-		schedulerCache.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 
 		room := &game_room.GameRoom{SchedulerID: scheduler.Name, PingStatus: game_room.GameRoomPingStatusReady, Status: game_room.GameStatusPending}
 		roomStorage.EXPECT().GetRoom(context.Background(), scheduler.Name, roomId).Return(room, nil)
@@ -1271,11 +1267,9 @@ func TestUpdateGameRoomStatus(t *testing.T) {
 
 		scheduler := newValidScheduler()
 		roomId := "room-id"
-		roomStorage, schedulerStorage, schedulerCache, instanceStorage, roomManager, _ := setup(mockCtrl)
+		roomStorage, schedulerStorage, _, instanceStorage, roomManager, _ := setup(mockCtrl)
 
-		schedulerCache.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 
 		room := &game_room.GameRoom{SchedulerID: scheduler.Name, PingStatus: game_room.GameRoomPingStatusReady, Status: game_room.GameStatusTerminating}
 		roomStorage.EXPECT().GetRoom(context.Background(), scheduler.Name, roomId).Return(room, nil)
@@ -1292,11 +1286,9 @@ func TestUpdateGameRoomStatus(t *testing.T) {
 
 		scheduler := newValidScheduler()
 		roomId := "room-id"
-		roomStorage, schedulerStorage, schedulerCache, instanceStorage, roomManager, eventsService := setup(mockCtrl)
+		roomStorage, schedulerStorage, _, instanceStorage, roomManager, eventsService := setup(mockCtrl)
 
-		schedulerCache.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 
 		room := &game_room.GameRoom{SchedulerID: scheduler.Name, PingStatus: game_room.GameRoomPingStatusTerminating, Status: game_room.GameStatusReady}
 		roomStorage.EXPECT().GetRoom(context.Background(), scheduler.Name, roomId).Return(room, nil)
@@ -1316,11 +1308,9 @@ func TestUpdateGameRoomStatus(t *testing.T) {
 
 		scheduler := newValidScheduler()
 		roomId := "room-id"
-		roomStorage, schedulerStorage, schedulerCache, instanceStorage, roomManager, eventsService := setup(mockCtrl)
+		roomStorage, schedulerStorage, _, instanceStorage, roomManager, eventsService := setup(mockCtrl)
 
-		schedulerCache.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(nil, nil)
 		schedulerStorage.EXPECT().GetScheduler(context.Background(), scheduler.Name).Return(scheduler, nil)
-		schedulerCache.EXPECT().SetScheduler(context.Background(), scheduler, gomock.Any()).Return(nil)
 
 		room := &game_room.GameRoom{SchedulerID: scheduler.Name, PingStatus: game_room.GameRoomPingStatusTerminating, Status: game_room.GameStatusReady}
 		roomStorage.EXPECT().GetRoom(context.Background(), scheduler.Name, roomId).Return(room, nil)
@@ -1340,14 +1330,20 @@ func TestRoomManager_GetRoomInstance(t *testing.T) {
 	setup := func(mockCtrl *gomock.Controller) (*mockports.MockRoomStorage, *mockports.MockGameRoomInstanceStorage, ports.RoomManager, *mockports.MockEventsService) {
 		roomStorage := mockports.NewMockRoomStorage(mockCtrl)
 		schedulerStorage := mockports.NewMockSchedulerStorage(mockCtrl)
+		schedulerCache := mockports.NewMockSchedulerCache(mockCtrl)
 		instanceStorage := mockports.NewMockGameRoomInstanceStorage(mockCtrl)
 		eventsService := mockports.NewMockEventsService(mockCtrl)
+
+		// Configure cache to always miss, making tests transparent to caching
+		schedulerCache.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		schedulerCache.EXPECT().SetScheduler(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
 		roomManager := New(
 			clockmock.NewFakeClock(time.Now()),
 			mockports.NewMockPortAllocator(mockCtrl),
 			roomStorage,
 			schedulerStorage,
-			mockports.NewMockSchedulerCache(mockCtrl),
+			schedulerCache,
 			instanceStorage,
 			mockports.NewMockRuntime(mockCtrl),
 			eventsService,
@@ -1406,6 +1402,10 @@ func testSetup(t *testing.T) (
 	eventsService := mockports.NewMockEventsService(mockCtrl)
 	config := RoomManagerConfig{}
 	roomStorageStatusWatcher := mockports.NewMockRoomStorageStatusWatcher(mockCtrl)
+
+	// Configure cache to always miss, making tests transparent to caching
+	schedulerCache.EXPECT().GetScheduler(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	schedulerCache.EXPECT().SetScheduler(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	roomManager := New(
 		clockmock.NewFakeClock(time.Now()),

--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -117,8 +117,8 @@ func NewOperationManager(flow ports.OperationFlow, storage ports.OperationStorag
 }
 
 // NewRoomManager instantiates a room manager.
-func NewRoomManager(clock ports.Clock, portAllocator ports.PortAllocator, roomStorage ports.RoomStorage, schedulerStorage ports.SchedulerStorage, instanceStorage ports.GameRoomInstanceStorage, runtime ports.Runtime, eventsService ports.EventsService, config rooms.RoomManagerConfig) ports.RoomManager {
-	return rooms.New(clock, portAllocator, roomStorage, schedulerStorage, instanceStorage, runtime, eventsService, config)
+func NewRoomManager(clock ports.Clock, portAllocator ports.PortAllocator, roomStorage ports.RoomStorage, schedulerStorage ports.SchedulerStorage, schedulerCache ports.SchedulerCache, instanceStorage ports.GameRoomInstanceStorage, runtime ports.Runtime, eventsService ports.EventsService, config rooms.RoomManagerConfig) ports.RoomManager {
+	return rooms.New(clock, portAllocator, roomStorage, schedulerStorage, schedulerCache, instanceStorage, runtime, eventsService, config)
 }
 
 // NewEventsForwarder instantiates GRPC as events forwarder.

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -115,10 +115,12 @@ func NewOperationRoomsRemoveConfig(c config.Config) remove.Config {
 func NewRoomManagerConfig(c config.Config) (roommanager.RoomManagerConfig, error) {
 	pingTimeout := time.Duration(c.GetInt(roomPingTimeoutMillisConfigPath)) * time.Millisecond
 	deletionTimeout := time.Duration(c.GetInt(roomDeletionTimeoutMillisConfigPath)) * time.Millisecond
+	schedulerCacheTTL := getSchedulerCacheTTL(c)
 
 	roomManagerConfig := roommanager.RoomManagerConfig{
 		RoomPingTimeout:     pingTimeout,
 		RoomDeletionTimeout: deletionTimeout,
+		SchedulerCacheTtl:   schedulerCacheTTL,
 	}
 
 	return roomManagerConfig, nil
@@ -151,18 +153,21 @@ func NewOperationManagerConfig(c config.Config) (operationmanager.OperationManag
 
 // NewEventsForwarderServiceConfig instantiate a new EventsForwarderConfig to be used by the EventsForwarder to customize its configuration.
 func NewEventsForwarderServiceConfig(c config.Config) (events.EventsForwarderConfig, error) {
-	var schedulerCacheTTL time.Duration
-	defaultSchedulerCacheTTL := time.Hour * 24
-
-	if configuredSchedulerCacheTTLInt := c.GetInt(schedulerCacheTTLMillisConfigPath); configuredSchedulerCacheTTLInt > 0 {
-		schedulerCacheTTL = time.Duration(configuredSchedulerCacheTTLInt) * time.Millisecond
-	} else {
-		schedulerCacheTTL = defaultSchedulerCacheTTL
-	}
+	schedulerCacheTTL := getSchedulerCacheTTL(c)
 
 	eventsForwarderConfig := events.EventsForwarderConfig{
 		SchedulerCacheTtl: schedulerCacheTTL,
 	}
 
 	return eventsForwarderConfig, nil
+}
+
+// getSchedulerCacheTTL returns the scheduler cache TTL from config or default value
+func getSchedulerCacheTTL(c config.Config) time.Duration {
+	defaultSchedulerCacheTTL := 5 * time.Minute
+
+	if configuredSchedulerCacheTTLInt := c.GetInt(schedulerCacheTTLMillisConfigPath); configuredSchedulerCacheTTLInt > 0 {
+		return time.Duration(configuredSchedulerCacheTTLInt) * time.Millisecond
+	}
+	return defaultSchedulerCacheTTL
 }


### PR DESCRIPTION
Added `SchedulerCache` dependency and caching logic to `updateGameRoomStatus` method. This will allow `UpdateRoomWithPing` handler to work even if it has no access to the database.

The `SchedulerCache` is set by (if absent):

* `EventsForwarderService`
  *  `ForwardRoomEvent` handler
  *  `ForwardPlayerEvent` handler
  *  `UpdateRoomStatus` handler
  *  `UpdateRoomWithPing` (new)
* `RoomManager` (new)
  * `DeleteRoom`
  * `CleanRoomState` 
  * `updateGameRoomStatus` (new)