### PR TITLE
feat: pipelining CleanExpireOperations operations

### DIFF
--- a/internal/adapters/storage/redis/operation/operation_storage_redis.go
+++ b/internal/adapters/storage/redis/operation/operation_storage_redis.go
@@ -321,18 +321,28 @@ func (r *redisOperationStorage) CleanExpiredOperations(ctx context.Context, sche
 	}
 
 	if len(operationsIDs) > 0 {
+		// Pipeline EXISTS calls to check which operations have expired (hash key gone due to TTL).
+		// Previously each EXISTS was a separate round-trip, causing O(N) latency.
+		existsPipe := r.client.Pipeline()
+		existsCmds := make([]*redis.IntCmd, len(operationsIDs))
+		for i, operationID := range operationsIDs {
+			existsCmds[i] = existsPipe.Exists(ctx, r.buildSchedulerOperationKey(schedulerName, operationID))
+		}
+		_, err = existsPipe.Exec(ctx)
+		if err != nil && err != redis.Nil {
+			return fmt.Errorf("failed to check expired operations existence: %w", err)
+		}
 
-		pipe := r.client.Pipeline()
-		for _, operationID := range operationsIDs {
-			operationExists, _ := r.client.Exists(ctx, r.buildSchedulerOperationKey(schedulerName, operationID)).Result()
-			if operationExists == 0 {
-				pipe.ZRem(ctx, r.buildSchedulerHistoryOperationsKey(schedulerName), operationID)
-				pipe.ZRem(ctx, r.buildSchedulerNoActionKey(schedulerName), operationID)
+		remPipe := r.client.Pipeline()
+		for i, operationID := range operationsIDs {
+			if existsCmds[i].Val() == 0 {
+				remPipe.ZRem(ctx, r.buildSchedulerHistoryOperationsKey(schedulerName), operationID)
+				remPipe.ZRem(ctx, r.buildSchedulerNoActionKey(schedulerName), operationID)
 			}
 		}
 
 		metrics.RunWithMetrics(operationStorageMetricLabel, func() error {
-			_, err = pipe.Exec(ctx)
+			_, err = remPipe.Exec(ctx)
 			return err
 		})
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Redis cleanup logic used before listing finished operations; behavior should be equivalent but changes command batching and error handling, which could affect cleanup correctness under Redis errors.
> 
> **Overview**
> `CleanExpiredOperations` now batches per-operation `EXISTS` checks into a single Redis pipeline and then pipelines the resulting `ZREM` removals, reducing round-trips when cleaning up expired operation IDs.
> 
> It also adds explicit error handling for the pipelined existence check (instead of ignoring `EXISTS` call errors) before proceeding with removals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ef25a13ed67f9d060c2a63994eb6ff2fe6a5bc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->