### PR TITLE
fix(SUP-7456): fix grpc code logging causing mapper_parsing_exception…

### DIFF
--- a/internal/core/services/events/events_forwarder_service.go
+++ b/internal/core/services/events/events_forwarder_service.go
@@ -185,7 +185,8 @@ func (es *EventsForwarderService) forwardRoomEvent(
 		reportRoomEventForwardingFailed(scheduler.Game, event.SchedulerID, code.String())
 		es.logger.Error(fmt.Sprintf("Failed to forward room events for room %s and scheduler %s", event.RoomID, event.SchedulerID),
 			zap.Error(err),
-			zap.Any("code", code))
+			zap.Uint32("code", uint32(code)),
+			zap.String("grpc_code", code.String()))
 
 		return err
 	}


### PR DESCRIPTION
… in logzio

zap.Any on codes.Code (a named uint32 type) falls through to the fmt.Stringer case and logs the value as a string (e.g. "Unavailable"), conflicting with the existing long mapping for json.code in Logz.io.

Replace with zap.Uint32 to preserve the numeric value for the existing mapping, and add grpc_code as a human-readable string field.