### PR TITLE
fix(events): split forwarder code log into numeric + name (SUP-7456)

### DIFF
--- a/internal/core/services/events/events_forwarder_service.go
+++ b/internal/core/services/events/events_forwarder_service.go
@@ -185,7 +185,8 @@ func (es *EventsForwarderService) forwardRoomEvent(
 		reportRoomEventForwardingFailed(scheduler.Game, event.SchedulerID, code.String())
 		es.logger.Error(fmt.Sprintf("Failed to forward room events for room %s and scheduler %s", event.RoomID, event.SchedulerID),
 			zap.Error(err),
-			zap.Any("code", code))
+			zap.Uint32("grpc_code", uint32(code)),
+			zap.String("grpc_code_name", code.String()))
 
 		return err
 	}


### PR DESCRIPTION
The error log emitted by forwardRoomEvent wrote the gRPC status as `zap.Any("code", code)`. Because `codes.Code` ships a `MarshalJSON` that returns the status name, zap serialized that field as a string ("Unavailable", "DeadlineExceeded", ...). When the destination Elasticsearch index has `json.code` mapped as `long` (pinned by another producer in the same index that writes a numeric `code`), every failed forward triggers a mapper_parsing_exception and the document is dropped:

  failed to parse field [json.code] of type [long]
  Preview of field's value: 'Unavailable'

This change splits the log into two type-stable fields:

  grpc_code       uint32  — numeric value (e.g. 14), index-friendly
  grpc_code_name  string  — human-readable name (e.g. "Unavailable")

The original `code` field is removed; queries that referenced `code:"Unavailable"` need to move to `grpc_code_name:"Unavailable"` (or `grpc_code:14`).