### PR TITLE
feat(redis): add configurable MaxConnAge to bound failover error window

### DIFF
--- a/internal/service/adapters.go
+++ b/internal/service/adapters.go
@@ -93,6 +93,12 @@ const (
 	operationFlowRedisURLPath = "adapters.operationFlow.redis.url"
 	// Redis configs
 	redisPoolSizePath = "adapters.redis.poolSize"
+	// Connection age at which the go-redis client retires (closes) a conn.
+	// Unset/0 keeps the go-redis default (no limit). Set a finite value to
+	// bound the post-failover window in which pooled conns can keep talking
+	// to a node that has been demoted from primary (ElastiCache Redis->Valkey
+	// engine swaps, scaling, unplanned failover).
+	redisMaxConnAgePath = "adapters.redis.maxConnAge"
 	// Random port allocator
 	portAllocatorRandomRangePath = "adapters.portAllocator.random.range"
 	// Postgres scheduler storage
@@ -282,6 +288,9 @@ func createRedisClient(c config.Config, url string, customizers ...func(*redis.O
 		return nil, fmt.Errorf("invalid redis URL: %w", err)
 	}
 	opts.PoolSize = c.GetInt(redisPoolSizePath)
+	if maxConnAge := c.GetDuration(redisMaxConnAgePath); maxConnAge > 0 {
+		opts.MaxConnAge = maxConnAge
+	}
 	if opts.TLSConfig != nil {
 		opts.TLSConfig.InsecureSkipVerify = true
 	}

--- a/internal/service/adapters_maxconnage_test.go
+++ b/internal/service/adapters_maxconnage_test.go
@@ -1,0 +1,61 @@
+// MIT License
+//
+// Copyright (c) 2021 TFG Co
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build unit
+// +build unit
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	configmock "github.com/topfreegames/maestro/internal/config/mock"
+)
+
+func TestCreateRedisClient_MaxConnAge_AppliesWhenSet(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	config := configmock.NewMockConfig(mockCtrl)
+
+	config.EXPECT().GetInt(redisPoolSizePath).Return(500)
+	config.EXPECT().GetDuration(redisMaxConnAgePath).Return(5 * time.Minute)
+	config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
+
+	client, err := createRedisClient(config, "redis://localhost:6379/0")
+	require.NoError(t, err)
+	require.Equal(t, 5*time.Minute, client.Options().MaxConnAge)
+}
+
+func TestCreateRedisClient_MaxConnAge_UnsetKeepsDefault(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	config := configmock.NewMockConfig(mockCtrl)
+
+	config.EXPECT().GetInt(redisPoolSizePath).Return(500)
+	config.EXPECT().GetDuration(redisMaxConnAgePath).Return(time.Duration(0))
+	config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
+
+	client, err := createRedisClient(config, "redis://localhost:6379/0")
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(0), client.Options().MaxConnAge)
+}

--- a/internal/service/adapters_test.go
+++ b/internal/service/adapters_test.go
@@ -68,6 +68,7 @@ func TestOperationStorageRedis(t *testing.T) {
 
 		config.EXPECT().GetString(operationStorageRedisURLPath).Return(getRedisURL(t))
 		config.EXPECT().GetInt(redisPoolSizePath).Return(500)
+		config.EXPECT().GetDuration(redisMaxConnAgePath).Return(time.Duration(0))
 		config.EXPECT().GetDuration(operationsTTLPath).Return(time.Minute).Times(4)
 		config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
 		opStorage, err := NewOperationStorageRedis(clock, definitionsProviders, config)
@@ -87,6 +88,7 @@ func TestOperationStorageRedis(t *testing.T) {
 		config.EXPECT().GetString(operationStorageRedisURLPath).Return("redis://somewhere-in-the-world:6379")
 		config.EXPECT().GetDuration(operationsTTLPath).Return(time.Minute).Times(4)
 		config.EXPECT().GetInt(redisPoolSizePath).Return(500)
+		config.EXPECT().GetDuration(redisMaxConnAgePath).Return(time.Duration(0))
 		config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
 		opStorage, err := NewOperationStorageRedis(clock, definitionsProviders, config)
 		require.NoError(t, err)
@@ -119,6 +121,7 @@ func TestRoomStorageRedis(t *testing.T) {
 
 		config.EXPECT().GetString(roomStorageRedisURLPath).Return(getRedisURL(t))
 		config.EXPECT().GetInt(redisPoolSizePath).Return(500)
+		config.EXPECT().GetDuration(redisMaxConnAgePath).Return(time.Duration(0))
 		config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
 
 		roomStorage, err := NewRoomStorageRedis(config)
@@ -136,6 +139,7 @@ func TestRoomStorageRedis(t *testing.T) {
 
 		config.EXPECT().GetString(roomStorageRedisURLPath).Return("redis://somewhere-in-the-world:6379")
 		config.EXPECT().GetInt(redisPoolSizePath).Return(500)
+		config.EXPECT().GetDuration(redisMaxConnAgePath).Return(time.Duration(0))
 		config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
 		roomStorage, err := NewRoomStorageRedis(config)
 		require.NoError(t, err)
@@ -168,6 +172,7 @@ func TestInstanceStorageRedis(t *testing.T) {
 		config.EXPECT().GetString(instanceStorageRedisURLPath).Return(getRedisURL(t))
 		config.EXPECT().GetInt(instanceStorageRedisScanSizePath).Return(10)
 		config.EXPECT().GetInt(redisPoolSizePath).Return(500)
+		config.EXPECT().GetDuration(redisMaxConnAgePath).Return(time.Duration(0))
 		config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
 		instanceStorage, err := NewGameRoomInstanceStorageRedis(config)
 		require.NoError(t, err)
@@ -185,6 +190,7 @@ func TestInstanceStorageRedis(t *testing.T) {
 		config.EXPECT().GetString(instanceStorageRedisURLPath).Return("redis://somewhere-in-the-world:6379")
 		config.EXPECT().GetInt(instanceStorageRedisScanSizePath).Return(10)
 		config.EXPECT().GetInt(redisPoolSizePath).Return(500)
+		config.EXPECT().GetDuration(redisMaxConnAgePath).Return(time.Duration(0))
 		config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
 		instanceStorage, err := NewGameRoomInstanceStorageRedis(config)
 		require.NoError(t, err)
@@ -275,6 +281,7 @@ func TestOperationFlowRedis(t *testing.T) {
 
 		config.EXPECT().GetString(operationFlowRedisURLPath).Return(getRedisURL(t))
 		config.EXPECT().GetInt(redisPoolSizePath).Return(500)
+		config.EXPECT().GetDuration(redisMaxConnAgePath).Return(time.Duration(0))
 		config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
 		operationFlow, err := NewOperationFlowRedis(config)
 		require.NoError(t, err)
@@ -291,6 +298,7 @@ func TestOperationFlowRedis(t *testing.T) {
 
 		config.EXPECT().GetString(operationFlowRedisURLPath).Return("redis://somewhere-in-the-world:6379")
 		config.EXPECT().GetInt(redisPoolSizePath).Return(500)
+		config.EXPECT().GetDuration(redisMaxConnAgePath).Return(time.Duration(0))
 		config.EXPECT().GetBool("api.tracing.jaeger.disabled").Return(true)
 		operationFlow, err := NewOperationFlowRedis(config)
 		require.NoError(t, err)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Adds a configurable `MaxConnAge` to the go-redis client used by every maestro Redis adapter, to bound the error window during an ElastiCache failover/switchover.

**Why.** During a switchover (failover, Redis→Valkey engine upgrade, scaling), AWS swaps the primary/replica role of the cluster's nodes. Pooled TCP conns stay attached to the node they originally dialed, which is now a replica, and any subsequent write returns:

```
READONLY You can't write against a read only replica.
```

go-redis does not treat `READONLY` as a bad-conn signal, so the offending conn is returned to the pool and reused, perpetuating the failure until it's recycled by some other means. `IdleTimeout` doesn't help on a hot pool (conns never sit idle long enough for the reaper). `MaxConnAge` is checked at every conn checkout, so it guarantees turnover regardless of traffic; after the bound elapses the next dial re-resolves DNS and lands on the new primary.

**What.**
- `createRedisClient` now reads `adapters.redis.maxConnAge` and sets `opt.MaxConnAge` when > 0. Unset/0 keeps the go-redis default (no limit), so behavior is unchanged unless configured.
- Shared knob across all six Redis adapters, mirroring the existing `adapters.redis.poolSize`. Env var: `MAESTRO_ADAPTERS_REDIS_MAXCONNAGE` (Go duration, e.g. `5m`).

**Operational note.** Set `MAESTRO_ADAPTERS_REDIS_MAXCONNAGE=5m` (or shorter) on the deployment before the planned Redis→Valkey maintenance window. Safe to leave on permanently; overhead is negligible on production-sized pools and it future-proofs against unplanned failovers.

**What this does *not* do.** This bounds the post-failover error window; it does not eliminate it. A request landing on a stale conn during the swap still sees one `READONLY` before that conn is recycled. A retry-on-READONLY wrapper around the room-allocation Lua script would be a complementary follow-up, out of scope here.

This mirrors the matchmaker change in MR !137 (matchmaker is on go-redis v6; maestro stays on v8, where the field is still named `MaxConnAge` — it becomes `ConnMaxLifetime` in v9).

## Any other comments?

- New `//go:build unit` test covers both the set case (`5m` reaches `client.Options().MaxConnAge`) and the unset-keeps-default case.
- Existing integration tests updated with the new `GetDuration` expectation.
- `go build`, `go vet -tags=integration`, `goimports`, license check, and the new unit tests all pass locally. Integration suite (k3d) not run locally.
