### PR TITLE
fix(redis): occupancy leak — stop GetRoom resurrecting rooms, and make running-matches orphan-immune

### DIFF
--- a/internal/adapters/storage/redis/room/redis.go
+++ b/internal/adapters/storage/redis/room/redis.go
@@ -88,13 +88,16 @@ end
 // Ignoring them keeps GetRunningMatchesCount — and therefore the roomOccupancy autoscaler and the
 // running_matches metric — correct even if the occupancy set has stale members. Read-only.
 var runningMatchesScript = redis.NewScript(`
-local occupancy_key = KEYS[1]
-local status_key = KEYS[2]
+local occupancy = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', '+inf', 'WITHSCORES')
+local status = redis.call('ZRANGE', KEYS[2], 0, -1)
+local in_status = {}
+for i = 1, #status do
+    in_status[status[i]] = true
+end
 local sum = 0
-local entries = redis.call('ZRANGEBYSCORE', occupancy_key, '-inf', '+inf', 'WITHSCORES')
-for i = 1, #entries, 2 do
-    if redis.call('ZSCORE', status_key, entries[i]) then
-        sum = sum + tonumber(entries[i + 1])
+for i = 1, #occupancy, 2 do
+    if in_status[occupancy[i]] then
+        sum = sum + tonumber(occupancy[i + 1])
     end
 end
 return sum

--- a/internal/adapters/storage/redis/room/redis.go
+++ b/internal/adapters/storage/redis/room/redis.go
@@ -88,7 +88,10 @@ end
 // Ignoring them keeps GetRunningMatchesCount — and therefore the roomOccupancy autoscaler and the
 // running_matches metric — correct even if the occupancy set has stale members. Read-only.
 var runningMatchesScript = redis.NewScript(`
-local occupancy = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', '+inf', 'WITHSCORES')
+-- Only members with score > 0 can contribute to the sum, so skip the (typically large) set of
+-- zero-score members (ready rooms + any zero-score orphans). This keeps the walk proportional to
+-- the number of rooms actually running matches, not the size of the occupancy set.
+local occupancy = redis.call('ZRANGEBYSCORE', KEYS[1], '(0', '+inf', 'WITHSCORES')
 local status = redis.call('ZRANGE', KEYS[2], 0, -1)
 local in_status = {}
 for i = 1, #status do

--- a/internal/adapters/storage/redis/room/redis.go
+++ b/internal/adapters/storage/redis/room/redis.go
@@ -103,7 +103,13 @@ func (r redisStateStorage) GetRoom(ctx context.Context, scheduler, roomID string
 	roomHashCmd := r.client.HGetAll(ctx, getRoomRedisKey(room.SchedulerID, room.ID))
 
 	p := r.client.Pipeline()
-	_ = p.ZAddNX(ctx, getRoomOccupancyRedisKey(room.SchedulerID), &redis.Z{Member: room.ID, Score: float64(room.RunningMatches)})
+	// GetRoom must be side-effect free. It previously ZAddNX'd the room into the occupancy
+	// sorted set to backfill rooms created before the occupancy feature (#659), but GetRoom is
+	// also called for rooms that are being/already deleted (late pings, in-flight operations),
+	// which re-created an occupancy-only entry (score 0) that no path removes — GetAllRoomIDs
+	// only iterates :status. Those orphans inflate GetRunningMatchesCount forever, which gates
+	// the roomOccupancy autoscaler. CreateRoom already establishes the occupancy entry, and
+	// UpdateRoom uses ZAddXXCh precisely to avoid resurrecting deleted rooms; reads must do the same.
 	statusCmd := p.ZScore(ctx, getRoomStatusSetRedisKey(room.SchedulerID), room.ID)
 	pingCmd := p.ZScore(ctx, getRoomPingRedisKey(room.SchedulerID), room.ID)
 	occupancyCmd := p.ZScore(ctx, getRoomOccupancyRedisKey(room.SchedulerID), room.ID)

--- a/internal/adapters/storage/redis/room/redis.go
+++ b/internal/adapters/storage/redis/room/redis.go
@@ -82,6 +82,24 @@ else
 end
 `)
 
+// runningMatchesScript sums the occupancy scores of rooms that still exist in the status set.
+// Entries present in :occupancy but absent from :status are orphans (e.g. left behind by older
+// versions) and must not count: a running match only exists in a room maestro still tracks.
+// Ignoring them keeps GetRunningMatchesCount — and therefore the roomOccupancy autoscaler and the
+// running_matches metric — correct even if the occupancy set has stale members. Read-only.
+var runningMatchesScript = redis.NewScript(`
+local occupancy_key = KEYS[1]
+local status_key = KEYS[2]
+local sum = 0
+local entries = redis.call('ZRANGEBYSCORE', occupancy_key, '-inf', '+inf', 'WITHSCORES')
+for i = 1, #entries, 2 do
+    if redis.call('ZSCORE', status_key, entries[i]) then
+        sum = sum + tonumber(entries[i + 1])
+    end
+end
+return sum
+`)
+
 type redisStateStorage struct {
 	client *redis.Client
 }
@@ -377,25 +395,17 @@ func (r *redisStateStorage) UpdateRoomStatus(ctx context.Context, scheduler, roo
 }
 
 func (r *redisStateStorage) GetRunningMatchesCount(ctx context.Context, scheduler string) (count int, err error) {
-	client := r.client
-	var rooms []redis.Z
 	metrics.RunWithMetrics(roomStorageMetricLabel, func() error {
-		rooms, err = client.ZRangeByScoreWithScores(ctx, getRoomOccupancyRedisKey(scheduler), &redis.ZRangeBy{
-			Min: "-inf",
-			Max: "+inf",
-		}).Result()
+		count, err = runningMatchesScript.Run(ctx, r.client,
+			[]string{getRoomOccupancyRedisKey(scheduler), getRoomStatusSetRedisKey(scheduler)},
+		).Int()
 		return err
 	})
 	if err != nil {
 		return 0, errors.NewErrUnexpected("error getting running matches scores from redis").WithError(err)
 	}
 
-	sum := 0
-	for _, room := range rooms {
-		sum += int(room.Score)
-	}
-
-	return sum, nil
+	return count, nil
 }
 
 func (r *redisStateStorage) WatchRoomStatus(ctx context.Context, room *game_room.GameRoom) (ports.RoomStorageStatusWatcher, error) {

--- a/internal/adapters/storage/redis/room/redis_test.go
+++ b/internal/adapters/storage/redis/room/redis_test.go
@@ -369,6 +369,17 @@ func TestRedisStateStorage_GetRoom(t *testing.T) {
 		_, err := storage.GetRoom(ctx, "game", "room-3")
 		requireErrorKind(t, errors.ErrNotFound, err)
 	})
+
+	t.Run("getting a non existent room does not create an occupancy entry", func(t *testing.T) {
+		// Regression: GetRoom must be side-effect free. It used to ZAddNX the room into the
+		// occupancy sorted set, resurrecting deleted/never-created rooms as orphans that inflate
+		// GetRunningMatchesCount forever and gate the roomOccupancy autoscaler.
+		_, err := storage.GetRoom(ctx, "game", "ghost-room")
+		requireErrorKind(t, errors.ErrNotFound, err)
+
+		occupancyCmd := client.ZScore(ctx, getRoomOccupancyRedisKey("game"), "ghost-room")
+		require.ErrorIs(t, occupancyCmd.Err(), redis.Nil, "GetRoom must not add a missing room to the occupancy set")
+	})
 }
 
 func TestRedisStateStorage_GetAllRoomIDs(t *testing.T) {

--- a/internal/adapters/storage/redis/room/redis_test.go
+++ b/internal/adapters/storage/redis/room/redis_test.go
@@ -758,39 +758,42 @@ func TestRedisStateStorage_GetRunningMatchesCount(t *testing.T) {
 		require.Equal(t, 0, count)
 	})
 
-	t.Run("single running match", func(t *testing.T) {
-		room := &game_room.GameRoom{
-			ID:             "room-1",
-			SchedulerID:    "game",
-			RunningMatches: 1,
-		}
-		client.ZAdd(ctx, getRoomOccupancyRedisKey(room.SchedulerID), &redis.Z{
-			Member: room.ID,
-			Score:  float64(room.RunningMatches),
-		})
+	// addRoom registers a room in both the status and occupancy sets, like CreateRoom does.
+	addRoom := func(scheduler, id string, runningMatches int) {
+		client.ZAdd(ctx, getRoomStatusSetRedisKey(scheduler), &redis.Z{Member: id, Score: float64(game_room.GameStatusOccupied)})
+		client.ZAdd(ctx, getRoomOccupancyRedisKey(scheduler), &redis.Z{Member: id, Score: float64(runningMatches)})
+	}
 
-		count, err := storage.GetRunningMatchesCount(ctx, room.SchedulerID)
+	t.Run("single running match", func(t *testing.T) {
+		addRoom("game", "room-1", 1)
+
+		count, err := storage.GetRunningMatchesCount(ctx, "game")
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 	})
 
 	t.Run("multiple running matches", func(t *testing.T) {
-		rooms := []*game_room.GameRoom{
-			{ID: "room-1", SchedulerID: "game", RunningMatches: 1},
-			{ID: "room-2", SchedulerID: "game", RunningMatches: 2},
-			{ID: "room-3", SchedulerID: "game", RunningMatches: 3},
-		}
-
-		for _, room := range rooms {
-			client.ZAdd(ctx, getRoomOccupancyRedisKey(room.SchedulerID), &redis.Z{
-				Member: room.ID,
-				Score:  float64(room.RunningMatches),
-			})
-		}
+		addRoom("game", "room-1", 1)
+		addRoom("game", "room-2", 2)
+		addRoom("game", "room-3", 3)
 
 		count, err := storage.GetRunningMatchesCount(ctx, "game")
 		require.NoError(t, err)
 		require.Equal(t, 6, count)
+	})
+
+	t.Run("ignores orphan occupancy entries not present in status", func(t *testing.T) {
+		// Regression: occupancy entries with no matching status member (e.g. left over from older
+		// versions) must not inflate the count, or they pin the roomOccupancy autoscaler's downscale
+		// gate. Use a dedicated scheduler to isolate from the shared "game" state above.
+		const sch = "game-orphan-count"
+		addRoom(sch, "real-room", 5)
+		// orphan: present only in :occupancy, score 99
+		client.ZAdd(ctx, getRoomOccupancyRedisKey(sch), &redis.Z{Member: "orphan-room", Score: 99})
+
+		count, err := storage.GetRunningMatchesCount(ctx, sch)
+		require.NoError(t, err)
+		require.Equal(t, 5, count, "orphan occupancy entry must be ignored")
 	})
 }
 


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

The `roomOccupancy` autoscaler input `running_matches` is the score-sum of `scheduler:<name>:occupancy`. That set accumulates orphan members that are never removed, so `running_matches` drifts upward and never returns to reality. Once it sits above the downscale threshold, `CanDownscale` is permanently false: the scheduler stops downscaling and rolling updates can't drain old-version rooms. Observed in prod: `:occupancy` had ~2.3k members vs ~5 in `:status`, `running_matches` pinned at 410 while the API reported 0 occupied; killing pods and switching versions didn't move it (the state is in Redis, not the pods).

Two commits, prevention + immunity:

**1. Stop `GetRoom` from resurrecting deleted rooms into `:occupancy`.**
`GetRoom` (a read) did an unconditional `ZAddNX` into `:occupancy` (added in #659 to backfill rooms predating the occupancy feature). But `GetRoom` is also called for rooms being/already deleted (late pings, in-flight operations), so it re-created an occupancy-only entry (score 0) that no path removes — `GetAllRoomIDs` only iterates `:status`, and ping-expiry/pod-gone cleanup only act on status-tracked rooms. Removed the write: a read must be side-effect free. `CreateRoom` already establishes the occupancy entry, and `UpdateRoom` uses `ZAddXXCh` precisely to avoid resurrecting deleted rooms; reads now match. After this, the only occupancy writers are `CreateRoom` (adds all three sets together) and `UpdateRoom` (`XXCh`, update-only) — neither can create an occupancy-only orphan.

**2. Make `GetRunningMatchesCount` immune to any orphan that already exists.**
Prevention alone doesn't help schedulers that already leaked, and operators shouldn't have to `ZREM` orphans by hand. `GetRunningMatchesCount` now sums occupancy scores only for rooms still present in `:status` (a running match only lives in a tracked room), via a read-only Lua script. This is self-correcting: stale occupancy members are ignored automatically, so the autoscaler and the `running_matches` metric stay correct even before/without any cleanup.

Net: #1 stops the leak at the source; #2 makes the autoscaler correct regardless of existing orphans — no manual reconciliation required.

Tests: added a regression test that `GetRoom` on a missing room creates no occupancy entry; updated the running-matches storage tests to register rooms in `:status` and added a case asserting an orphan occupancy entry is not counted. All `internal/adapters/storage/redis/room` (integration) and `internal/core/services/autoscaler/...` (unit) tests pass.

## Does this close any currently open issues?

No tracked issue; full root-cause analysis with `file:line` references is in the description and commits.

## Any relevant logs, error output, etc?

While stuck: `scheduler <x> can't downscale, occupation is above the threshold` (emitted every cycle with 0 occupied rooms).

## Any other comments?

The `GetRoom` `ZAddNX` regression was introduced in #659 (commit `7590c7fa`, first released v10.11.4, 2025-02-28); present through current `main`. With #2 in place, the historical orphan entries become harmless on deploy; cleaning them from Redis is optional hygiene, no longer required for correctness.